### PR TITLE
Fix repo and homepage in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "files": [
     "dist/src/**"
   ],
-  "repository": "zeit/@zeit/swr",
+  "repository": "zeit/swr",
+  "homepage": "https://swr.now.sh",
   "license": "MIT",
   "scripts": {
     "dev": "now dev",


### PR DESCRIPTION
This will allow links to show up from https://npmjs.com to the github repo and homepage.