### PR TITLE
Clear page cache on resetPages and page key changes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -109,6 +109,7 @@ export type pagesResponseInterface<Data, Error> = {
   isReachingEnd: boolean
   isEmpty: boolean
   loadMore: () => void
+  resetPages: () => void
 }
 
 export type actionType<Data, Error> = {


### PR DESCRIPTION
Adding a Reset for pages

based on the work of [patrickus](https://github.com/patrickus) and [gabrielperales@8ba8379](https://github.com/gabrielperales/swr/commit/8ba8379d2e6c580ded234385d34ea829be996788)

This is a copy of the [Pull Request from patrickus](https://github.com/zeit/swr/pull/243)
with the following changes:

- reset pageCacheMap to ensure offset is computed after a reset is performed
- restore types
- restore JSX for page components (we need better eslint config to avoid warnings, pr coming)
- remove unneeded useMemo call on pageCountKey and pageOffsetKey (strings are primitive values)

resolving: #189

Sorry for the duplicated PR, I needed those fixes for today so I created a fix on my repo. Disregard this PR if patrickus want to improve the work done on his PR.

thanks to https://github.com/patrickus and https://github.com/gabrielperales
