### PR TITLE
Add overload to improve type inference

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -117,9 +117,24 @@ const mutate: mutateInterface = async (
   return data
 }
 
-function useSWR<K extends any[], Data = any, Error = any>(
-  key: K,
-  fn: (...args: K) => Promise<Data>,
+function useSWR<K1, Data = any, Error = any>(
+  key: [K1],
+  fn: (k1: K1) => Data | Promise<Data>,
+  config?: ConfigInterface<Data, Error>
+): responseInterface<Data, Error>
+function useSWR<K1, K2, Data = any, Error = any>(
+  key: [K1, K2],
+  fn: (k1: K1, k2: K2) => Data | Promise<Data>,
+  config?: ConfigInterface<Data, Error>
+): responseInterface<Data, Error>
+function useSWR<K1, K2, K3, Data = any, Error = any>(
+  key: [K1, K2, K3],
+  fn: (k1: K1, k2: K2, k3: K3) => Data | Promise<Data>,
+  config?: ConfigInterface<Data, Error>
+): responseInterface<Data, Error>
+function useSWR<K1, K2, K3, K4, Data = any, Error = any>(
+  key: [K1, K2, K3, K4],
+  fn: (k1: K1, k2: K2, k3: K3, k4: K4) => Data | Promise<Data>,
   config?: ConfigInterface<Data, Error>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -117,6 +117,11 @@ const mutate: mutateInterface = async (
   return data
 }
 
+function useSWR<K extends any[], Data = any, Error = any>(
+  key: K,
+  fn: (...args: K) => Promise<Data>,
+  config?: ConfigInterface<Data, Error>
+): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: keyInterface
 ): responseInterface<Data, Error>


### PR DESCRIPTION
Add a function overload for `useSWR` that improves [type inferencing for array keys](https://github.com/Janpot/next-rpc/blob/f677daa0db8903d2e80a2edebb445e1c6ff4a45a/examples/with-swr/pages/index.js#L8).

Unfortunately a workaround for up to 4 parameters had to be made to get around missing [variadic generics](https://github.com/microsoft/TypeScript/issues/5453)