### PR TITLE
fix: suspense when key is falsy

### DIFF
--- a/src/libs/is-falsy.ts
+++ b/src/libs/is-falsy.ts
@@ -1,0 +1,3 @@
+export default function isFalsy(value: any): boolean {
+  return value == null || value === false
+}

--- a/src/libs/is-falsy.ts
+++ b/src/libs/is-falsy.ts
@@ -1,3 +1,0 @@
-export default function isFalsy(value: any): boolean {
-  return value == null || value === false
-}

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -18,7 +18,6 @@ import defaultConfig, {
 } from './config'
 import isDocumentVisible from './libs/is-document-visible'
 import isOnline from './libs/is-online'
-import isFalsy from './libs/is-falsy'
 import throttle from './libs/throttle'
 import SWRConfigContext from './swr-config-context'
 import {
@@ -373,7 +372,7 @@ function useSWR<Data = any, Error = any>(
 
     // update the state if the key changed (not the inital render) or cache updated
     if (
-      (keyRef.current !== key && (!isFalsy(keyRef.current) && !isFalsy(key))) ||
+      (keyRef.current !== key && (!keyRef.current && !key)) ||
       !config.compare(currentHookData, latestKeyedData)
     ) {
       dispatch({ data: latestKeyedData })

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -372,7 +372,7 @@ function useSWR<Data = any, Error = any>(
 
     // update the state if the key changed (not the inital render) or cache updated
     if (
-      (keyRef.current !== key && (!keyRef.current && !key)) ||
+      keyRef.current !== key ||
       !config.compare(currentHookData, latestKeyedData)
     ) {
       dispatch({ data: latestKeyedData })
@@ -543,10 +543,15 @@ function useSWR<Data = any, Error = any>(
       typeof latestError === 'undefined'
     ) {
       // need to start the request if it hasn't
+
       if (!CONCURRENT_PROMISES[key]) {
-        // trigger revalidate immediately
-        // to get the promise
-        revalidate()
+        if (key) {
+          // trigger revalidate immediately
+          // to get the promise
+          revalidate()
+        } else {
+          throw Promise.reject()
+        }
       }
 
       if (

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -543,15 +543,10 @@ function useSWR<Data = any, Error = any>(
       typeof latestError === 'undefined'
     ) {
       // need to start the request if it hasn't
-
       if (!CONCURRENT_PROMISES[key]) {
-        if (key) {
-          // trigger revalidate immediately
-          // to get the promise
-          revalidate()
-        } else {
-          throw Promise.reject()
-        }
+        // trigger revalidate immediately
+        // to get the promise
+        revalidate()
       }
 
       if (
@@ -569,6 +564,10 @@ function useSWR<Data = any, Error = any>(
     if (typeof latestData === 'undefined' && latestError) {
       // in suspense mode, throw error if there's no content
       throw latestError
+    }
+
+    if (!key) {
+      throw new Promise(() => {})
     }
 
     // return the latest data / error from cache

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -18,6 +18,7 @@ import defaultConfig, {
 } from './config'
 import isDocumentVisible from './libs/is-document-visible'
 import isOnline from './libs/is-online'
+import isFalsy from './libs/is-falsy'
 import throttle from './libs/throttle'
 import SWRConfigContext from './swr-config-context'
 import {
@@ -372,7 +373,7 @@ function useSWR<Data = any, Error = any>(
 
     // update the state if the key changed (not the inital render) or cache updated
     if (
-      keyRef.current !== key ||
+      (keyRef.current !== key && (!isFalsy(keyRef.current) && !isFalsy(key))) ||
       !config.compare(currentHookData, latestKeyedData)
     ) {
       dispatch({ data: latestKeyedData })

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1281,7 +1281,6 @@ describe('useSWR - suspense', () => {
           suspense: true
         }
       )
-
       return <div>{data}</div>
     }
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1267,6 +1267,40 @@ describe('useSWR - suspense', () => {
     // 'suspense-7' -> undefined -> 'suspense-8'
     expect(renderedResults).toEqual(['suspense-7', 'suspense-8'])
   })
+
+  // hold render when suspense
+  it('should pause when key is falsy', async () => {
+    const renderedResults = []
+
+    function Section() {
+      const [key, setKey] = useState(null)
+      const { data } = useSWR(
+        key,
+        k => new Promise(res => setTimeout(() => res(k), 50)),
+        {
+          suspense: true
+        }
+      )
+
+      useEffect(() => {
+        setKey('suspense-9')
+      }, [])
+
+      if (data !== renderedResults[renderedResults.length - 1]) {
+        renderedResults.push(data)
+      }
+
+      return <div>{data}</div>
+    }
+    render(
+      <Suspense fallback={<div>fallback</div>}>
+        <Section />
+      </Suspense>
+    )
+    await act(() => new Promise(res => setTimeout(res, 210)))
+
+    expect(renderedResults).toEqual(['suspense-9'])
+  })
 })
 
 describe('useSWR - cache', () => {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1270,30 +1270,31 @@ describe('useSWR - suspense', () => {
 
   // hold render when suspense
   it('should pause when key is falsy', async () => {
-    function SectionContent({ swrKey, onClick }) {
+    function SectionContent({ swrKey }) {
       const { data } = useSWR(
-        () => (swrKey % 2 === 0 ? null : swrKey),
-        k => new Promise(res => setTimeout(() => res(k), 30)),
+        () => (swrKey % 2 ? null : 'suspense-' + swrKey),
+        key =>
+          new Promise(res =>
+            setTimeout(() => res(key.replace('suspense-', '')), 100)
+          ),
         {
           suspense: true
         }
       )
 
-      return (
-        <div onClick={onClick}>
-          {swrKey && data ? 'suspense-' + (9 + Number(data)) : undefined}
-        </div>
-      )
+      return <div>{data}</div>
     }
 
     const Section = () => {
-      const [key, setKey] = useState(0)
+      const [key, setKey] = useState(9)
       const handleClick = () => setKey(key + 1)
 
       return (
-        <Suspense fallback={<div onClick={handleClick}>fallback</div>}>
-          <SectionContent onClick={handleClick} swrKey={key} />
-        </Suspense>
+        <div onClick={handleClick}>
+          <Suspense fallback={<div>fallback</div>}>
+            <SectionContent swrKey={key} />
+          </Suspense>
+        </div>
       )
     }
 
@@ -1306,13 +1307,21 @@ describe('useSWR - suspense', () => {
       )
     }
 
-    expect(container.textContent).toMatchInlineSnapshot(`"fallback"`)
-    await clickAndWait(100)
-    expect(container.textContent).toMatchInlineSnapshot(`"suspense-10"`)
-    await clickAndWait(100)
-    expect(container.textContent).toMatchInlineSnapshot(`"fallback"`)
-    await clickAndWait(100)
-    expect(container.textContent).toMatchInlineSnapshot(`"suspense-10"`)
+    expect(
+      container.firstElementChild.lastElementChild.textContent
+    ).toMatchInlineSnapshot(`"fallback"`)
+    await clickAndWait(150)
+    expect(
+      container.firstElementChild.lastElementChild.textContent
+    ).toMatchInlineSnapshot(`"10"`)
+    await clickAndWait(150)
+    expect(
+      container.firstElementChild.lastElementChild.textContent
+    ).toMatchInlineSnapshot(`"fallback"`)
+    await clickAndWait(150)
+    expect(
+      container.firstElementChild.lastElementChild.textContent
+    ).toMatchInlineSnapshot(`"12"`)
   })
 })
 


### PR DESCRIPTION
Bugfix
* try to solve issue https://github.com/zeit/swr/issues/339

When previous and current key are both not falsy while detecting the key change, schedule a rerender