### PR TITLE
enhance: clone object when retrieve data from cache

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -20,12 +20,12 @@ export default class Cache implements CacheInterface {
 
   get(key: keyInterface): any {
     const [_key] = this.serializeKey(key)
-    return clone(this.__cache.get(_key))
+    return this.__cache.get(_key)
   }
 
   set(key: keyInterface, value: any, shouldNotify = true): any {
     const [_key] = this.serializeKey(key)
-    this.__cache.set(_key, value)
+    this.__cache.set(_key, clone(value))
     if (shouldNotify) mutate(key, value, false)
     this.notify()
   }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,6 +2,13 @@ import { CacheInterface, keyInterface, cacheListener } from './types'
 import { mutate } from './use-swr'
 import hash from './libs/hash'
 
+const clone = (ref: any): any => {
+  if (ref !== null && typeof ref === 'object') {
+    return Object.assign(Object.create(Object.getPrototypeOf(ref)), ref)
+  }
+  return ref
+}
+
 export default class Cache implements CacheInterface {
   private __cache: Map<string, any>
   private __listeners: cacheListener[]
@@ -13,7 +20,7 @@ export default class Cache implements CacheInterface {
 
   get(key: keyInterface): any {
     const [_key] = this.serializeKey(key)
-    return this.__cache.get(_key)
+    return clone(this.__cache.get(_key))
   }
 
   set(key: keyInterface, value: any, shouldNotify = true): any {


### PR DESCRIPTION
Try to fix https://github.com/zeit/swr/issues/313

## How
Not sure if this is what you want. To make sure the data manipulation in `boundMutate((data) => { data.xxx = ... })` won't effect the data in cache, `cache.set` will always receive a clone mirror of origin data.

This is just a workaround, welcome more discussions here

## Defects
Shapes of data could be changed. like `{get val() { return 1}}` will become `{val: 1}` in the cache

