### PR TITLE
fix: cache initial data

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -167,6 +167,10 @@ function useSWR<Data = any, Error = any>(
     fn = config.fetcher
   }
 
+  if (config.initialData && !cache.has(key) && !IS_SERVER) {
+    cache.set(key, config.initialData, false)
+  }
+
   const initialData = cache.get(key) || config.initialData
   const initialError = cache.get(keyErr)
 
@@ -366,7 +370,7 @@ function useSWR<Data = any, Error = any>(
     // and trigger a revalidation
 
     const currentHookData = stateRef.current.data
-    const latestKeyedData = cache.get(key) || config.initialData
+    const latestKeyedData = cache.get(key)
 
     // update the state if the key changed (not the inital render) or cache updated
     if (


### PR DESCRIPTION
It appears some time ago the `initialData` configuration was used as a fallback.  When #211 was merged, this behavior changed to be used with SSR like in the next.js example in the README.  Issue #230 explains this was the expectation. I'm using SSR, so im fine with the new behavior.

Since `initialData` is now not quickly revalidated, another issue (#308) has been raised.  Since `initialData` is not cached, and the mutate w/ callback grabs the curerent data from the cache, when `initialData` is used, `undefined` is returned.

fixes #308