### PR TITLE
Make trigger return a promise resolved to the new cache value

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -58,7 +58,7 @@ export type updaterInterface<Data = any, Error = any> = (
 export type triggerInterface = (
   key: keyInterface,
   shouldRevalidate?: boolean
-) => void
+) => Promise<any>
 type mutateCallback<Data = any> = (currentValue: Data) => Promise<Data>
 export type mutateInterface<Data = any> = (
   key: keyInterface,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -59,9 +59,8 @@ const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
     }
     // return new updated value
     return Promise.all(promises).then(() => cache.get(key))
-  } else {
-    return Promise.resolve(cache.get(key))
   }
+  return Promise.resolve(cache.get(key))
 }
 
 const broadcastState: broadcastStateInterface = (key, data, error) => {
@@ -115,9 +114,12 @@ const mutate: mutateInterface = async (
   // update existing SWR Hooks' state
   const updaters = CACHE_REVALIDATORS[key]
   if (updaters) {
+    const promises = []
     for (let i = 0; i < updaters.length; ++i) {
-      updaters[i](!!shouldRevalidate, data, error, i > 0)
+      promises.push(updaters[i](!!shouldRevalidate, data, error, i > 0))
     }
+    // return new updated value
+    return Promise.all(promises).then(() => cache.get(key))
   }
 
   // throw error or return data to be used by caller of mutate

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1089,6 +1089,28 @@ describe('useSWR - local mutation', () => {
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 1"`)
   })
+
+  it('should return promise from mutate without data', async () => {
+    let value = 0
+    function Page() {
+      const { data } = useSWR('dynamic-18', () => value++, {
+        dedupingInterval: 0
+      })
+      return <div>data: {data}</div>
+    }
+    const { container } = render(<Page />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
+    await waitForDomChange({ container }) // mount
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 0"`)
+    let promise
+    await act(() => {
+      promise = mutate('dynamic-18')
+      return promise
+    })
+    expect(promise).toBeInstanceOf(Promise) // mutate returns a promise
+    expect(promise).resolves.toBe(1) // the return value should be the new cache
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 1"`)
+  })
 })
 
 describe('useSWR - context configs', () => {


### PR DESCRIPTION
Right now `mutate` is typed to return a Promise with the updated value, but if you don't pass a second argument `mutate` calls `trigger` that was not retuning anything.

This PR changes `trigger` to return a promise always, if it didn't received a key it's an immediately resolved promise, if it has key and there are updaters for that key, it uses Promise.all to await for all of them to be resolved and then returns the new cached value, lastly If there are no updated it will return an immediately resolved promise with the current cached value.

This should allow us to do:

```ts
import { mutate } from 'swr'

// do something
await mutate(key)
// do more things after the cache key was revalidated
```

This fix https://github.com/zeit/swr/issues/355