### PR TITLE
build: use es5 syntax for esm build (#443)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "now dev",
     "build": "npm run build:esm && npm run build:cjs",
     "build:cjs": "ncc build src/index.ts -o dist -m -e react",
-    "build:esm": "tsc --target ESNext --module ES6 --outDir esm",
+    "build:esm": "tsc --module ES6 --outDir esm",
     "watch": "tsc --watch",
     "types:check": "tsc --noEmit",
     "format": "prettier --write \"{src,test,examples}/**/*.{ts,tsx}\"",


### PR DESCRIPTION
output es5 synatx (configured in tsconfig.json) for both esm and cjs build