### PR TITLE
Use initialData in suspense mode if provided

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -555,8 +555,8 @@ function useSWR<Data = any, Error = any>(
     // (it should be suspended)
 
     // try to get data and error from cache
-    let latestData = cache.get(key)
-    let latestError = cache.get(keyErr)
+    let latestData = cache.get(key) || initialData
+    let latestError = cache.get(keyErr) || initialError
 
     if (
       typeof latestData === 'undefined' &&

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1409,6 +1409,29 @@ describe('useSWR - suspense', () => {
     expect(container.textContent).toMatchInlineSnapshot(`"hello, error"`) // get error with cache
   })
 
+  it('should render initial data if set', async () => {
+    const fetcher = jest.fn(() => 'SWR')
+
+    function Page() {
+      const { data } = useSWR('initial-data-1', fetcher, {
+        initialData: 'Initial',
+        suspense: true
+      })
+      return <div>hello, {data}</div>
+    }
+
+    const { container } = render(
+      <Suspense fallback={<div>fallback</div>}>
+        <Page />
+      </Suspense>
+    )
+
+    expect(fetcher).not.toBeCalled()
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, Initial"`
+    )
+  })
+
   it('should pause when key changes', async () => {
     const renderedResults = []
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1409,29 +1409,6 @@ describe('useSWR - suspense', () => {
     expect(container.textContent).toMatchInlineSnapshot(`"hello, error"`) // get error with cache
   })
 
-  it('should render initial data if set', async () => {
-    const fetcher = jest.fn(() => 'SWR')
-
-    function Page() {
-      const { data } = useSWR('initial-data-1', fetcher, {
-        initialData: 'Initial',
-        suspense: true
-      })
-      return <div>hello, {data}</div>
-    }
-
-    const { container } = render(
-      <Suspense fallback={<div>fallback</div>}>
-        <Page />
-      </Suspense>
-    )
-
-    expect(fetcher).not.toBeCalled()
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"hello, Initial"`
-    )
-  })
-
   it('should pause when key changes', async () => {
     const renderedResults = []
 
@@ -1469,6 +1446,29 @@ describe('useSWR - suspense', () => {
     // fixes https://github.com/zeit/swr/issues/57
     // 'suspense-7' -> undefined -> 'suspense-8'
     expect(renderedResults).toEqual(['suspense-7', 'suspense-8'])
+  })
+
+  it('should render initial data if set', async () => {
+    const fetcher = jest.fn(() => 'SWR')
+
+    function Page() {
+      const { data } = useSWR('suspense-9', fetcher, {
+        initialData: 'Initial',
+        suspense: true
+      })
+      return <div>hello, {data}</div>
+    }
+
+    const { container } = render(
+      <Suspense fallback={<div>fallback</div>}>
+        <Page />
+      </Suspense>
+    )
+
+    expect(fetcher).not.toBeCalled()
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, Initial"`
+    )
   })
 })
 


### PR DESCRIPTION
- [x] Resolves #429 

Took me a while to figure out how the testing works. I hope the test is okay for this now. I locally tried it with `revalidateOnMount: true` as well, so `fetcher` gets called and will change the data to `SWR` later, but I was unsure if that extra test isn't already done through the revalidation tests.