### PR TITLE
Remove extraneous IS_SERVER from useIsomorphicLayoutEffect

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -435,7 +435,6 @@ function useSWR<Data = any, Error = any>(
     ) {
       if (
         typeof latestKeyedData !== 'undefined' &&
-        !IS_SERVER &&
         window['requestIdleCallback']
       ) {
         // delay revalidate if there's cache


### PR DESCRIPTION
We know we're not on the server in `useIsomorphicLayoutEffect` right?
https://github.com/vercel/swr/blob/new-pagination-api/src/use-swr.ts#L40