### PR TITLE
Do not rerender if key changes but not data

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -482,12 +482,11 @@ function useSWR<Data = any, Error = any>(
     const latestKeyedData = cache.get(key) || config.initialData
 
     // update the state if the key changed (not the inital render) or cache updated
-    if (
-      keyRef.current !== key ||
-      !config.compare(currentHookData, latestKeyedData)
-    ) {
-      dispatch({ data: latestKeyedData })
+    if (keyRef.current !== key) {
       keyRef.current = key
+    }
+    if (!config.compare(currentHookData, latestKeyedData)) {
+      dispatch({ data: latestKeyedData })
     }
 
     // revalidate with deduping


### PR DESCRIPTION
This is so that you do not get an unnecessary rerender when the key has changed but the cached data is the same. In my case I'm conditionally fetching and when the key becomes valid I get an extra render while data is still `undefined`.

A few changes are from a linter that I assume ran on commit? Let me know if it's uncouth to have left them there.