### PR TITLE
Change name to ▲Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "dist/**",
     "esm/**"
   ],
-  "repository": "zeit/swr",
+  "repository": "vercel/swr",
   "homepage": "https://swr.now.sh",
   "license": "MIT",
   "scripts": {
-    "dev": "now dev",
+    "dev": "vercel dev",
     "build": "npm run build:esm && npm run build:cjs",
     "build:cjs": "ncc build src/index.ts -o dist -m -e react",
     "build:esm": "tsc --module ES6 --outDir esm",


### PR DESCRIPTION
This PR focuses on changing the value of the `repository` property to `vercel/swr`. This renaming is also being applied for the `dev` command found in scripts.

<img width="458" alt="Screen Shot 2020-06-15 at 16 15 04" src="https://user-images.githubusercontent.com/16585386/84712348-efd00d00-af2d-11ea-88cc-bf8624d311f0.png">
