### PR TITLE
enhance: move online listeners to config (#474)

### DIFF
--- a/examples/focus-revalidate/pages/api/user.js
+++ b/examples/focus-revalidate/pages/api/user.js
@@ -5,7 +5,7 @@ export default (req, res) => {
     res.json({
       loggedIn: true,
       name: 'Shu',
-      avatar: 'https://github.com/quietshu.png'
+      avatar: 'https://github.com/shuding.png'
     })
     return
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import deepEqual from 'fast-deep-equal'
 import isDocumentVisible from './libs/is-document-visible'
-import isOnline from './libs/is-online'
 import {
   ConfigInterface,
   RevalidateOptionInterface,
@@ -74,31 +73,6 @@ const defaultConfig: ConfigInterface = {
   shouldRetryOnError: true,
   suspense: false,
   compare: deepEqual
-}
-
-// setup DOM events listeners for `focus` and `reconnect` actions
-if (typeof window !== 'undefined' && window.addEventListener) {
-  const revalidate = revalidators => {
-    if (!isDocumentVisible() || !isOnline()) return
-
-    for (const key in revalidators) {
-      if (revalidators[key][0]) revalidators[key][0]()
-    }
-  }
-
-  // focus revalidate
-  window.addEventListener(
-    'visibilitychange',
-    () => revalidate(FOCUS_REVALIDATORS),
-    false
-  )
-  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
-  // reconnect revalidate
-  window.addEventListener(
-    'online',
-    () => revalidate(RECONNECT_REVALIDATORS),
-    false
-  )
 }
 
 export {

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,15 +10,6 @@ import Cache from './cache'
 // cache
 const cache = new Cache()
 
-// state managers
-const CONCURRENT_PROMISES = {}
-const CONCURRENT_PROMISES_TS = {}
-const FOCUS_REVALIDATORS = {}
-const RECONNECT_REVALIDATORS = {}
-const CACHE_REVALIDATORS = {}
-const MUTATION_TS = {}
-const MUTATION_END_TS = {}
-
 // error retry
 function onErrorRetry(
   _,
@@ -75,14 +66,5 @@ const defaultConfig: ConfigInterface = {
   compare: deepEqual
 }
 
-export {
-  CONCURRENT_PROMISES,
-  CONCURRENT_PROMISES_TS,
-  FOCUS_REVALIDATORS,
-  RECONNECT_REVALIDATORS,
-  CACHE_REVALIDATORS,
-  MUTATION_TS,
-  MUTATION_END_TS,
-  cache
-}
+export { cache }
 export default defaultConfig

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ const cache = new Cache()
 const CONCURRENT_PROMISES = {}
 const CONCURRENT_PROMISES_TS = {}
 const FOCUS_REVALIDATORS = {}
+const RECONNECT_REVALIDATORS = {}
 const CACHE_REVALIDATORS = {}
 const MUTATION_TS = {}
 const MUTATION_END_TS = {}
@@ -77,30 +78,34 @@ const defaultConfig: ConfigInterface = {
 
 // setup DOM events listeners for `focus` and `reconnect` actions
 if (typeof window !== 'undefined' && window.addEventListener) {
-  const revalidate = () => {
+  const revalidate = revalidators => {
     if (!isDocumentVisible() || !isOnline()) return
 
-    for (const key in FOCUS_REVALIDATORS) {
-      if (FOCUS_REVALIDATORS[key][0]) FOCUS_REVALIDATORS[key][0]()
+    for (const key in revalidators) {
+      if (revalidators[key][0]) revalidators[key][0]()
     }
   }
 
   // focus revalidate
-  if (defaultConfig.revalidateOnFocus) {
-    window.addEventListener('visibilitychange', revalidate, false)
-    window.addEventListener('focus', revalidate, false)
-  }
-
+  window.addEventListener(
+    'visibilitychange',
+    () => revalidate(FOCUS_REVALIDATORS),
+    false
+  )
+  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
   // reconnect revalidate
-  if (defaultConfig.revalidateOnReconnect) {
-    window.addEventListener('online', revalidate, false)
-  }
+  window.addEventListener(
+    'online',
+    () => revalidate(RECONNECT_REVALIDATORS),
+    false
+  )
 }
 
 export {
   CONCURRENT_PROMISES,
   CONCURRENT_PROMISES_TS,
   FOCUS_REVALIDATORS,
+  RECONNECT_REVALIDATORS,
   CACHE_REVALIDATORS,
   MUTATION_TS,
   MUTATION_END_TS,

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,6 @@ const cache = new Cache()
 const CONCURRENT_PROMISES = {}
 const CONCURRENT_PROMISES_TS = {}
 const FOCUS_REVALIDATORS = {}
-const RECONNECT_REVALIDATORS = {}
 const CACHE_REVALIDATORS = {}
 const MUTATION_TS = {}
 const MUTATION_END_TS = {}
@@ -76,37 +75,25 @@ const defaultConfig: ConfigInterface = {
   compare: deepEqual
 }
 
-// Focus revalidate
+// setup DOM events listeners for `focus` and `reconnect` actions
 if (typeof window !== 'undefined' && window.addEventListener) {
-  // only bind the events once
-  let focusEventsBinded = false
-  let onlineEventsBinded = false
-  if (!focusEventsBinded) {
-    const revalidate = () => {
-      if (!isDocumentVisible() || !isOnline()) return
+  const revalidate = () => {
+    if (!isDocumentVisible() || !isOnline()) return
 
-      for (const key in FOCUS_REVALIDATORS) {
-        if (FOCUS_REVALIDATORS[key][0]) FOCUS_REVALIDATORS[key][0]()
-      }
+    for (const key in FOCUS_REVALIDATORS) {
+      if (FOCUS_REVALIDATORS[key][0]) FOCUS_REVALIDATORS[key][0]()
     }
-    window.addEventListener('visibilitychange', revalidate, false)
-    window.addEventListener('focus', revalidate, false)
-
-    focusEventsBinded = true
   }
 
-  // set up reconnecting when the browser regains network connection
-  if (defaultConfig.revalidateOnReconnect && !onlineEventsBinded) {
-    const revalidate = () => {
-      if (!isOnline()) return
+  // focus revalidate
+  if (defaultConfig.revalidateOnFocus) {
+    window.addEventListener('visibilitychange', revalidate, false)
+    window.addEventListener('focus', revalidate, false)
+  }
 
-      for (const key in RECONNECT_REVALIDATORS) {
-        if (RECONNECT_REVALIDATORS[key][0]) RECONNECT_REVALIDATORS[key][0]()
-      }
-    }
+  // reconnect revalidate
+  if (defaultConfig.revalidateOnReconnect) {
     window.addEventListener('online', revalidate, false)
-
-    onlineEventsBinded = true
   }
 }
 
@@ -114,7 +101,6 @@ export {
   CONCURRENT_PROMISES,
   CONCURRENT_PROMISES_TS,
   FOCUS_REVALIDATORS,
-  RECONNECT_REVALIDATORS,
   CACHE_REVALIDATORS,
   MUTATION_TS,
   MUTATION_END_TS,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -8,16 +8,7 @@ import {
   useMemo
 } from 'react'
 
-import defaultConfig, {
-  CACHE_REVALIDATORS,
-  CONCURRENT_PROMISES,
-  CONCURRENT_PROMISES_TS,
-  FOCUS_REVALIDATORS,
-  RECONNECT_REVALIDATORS,
-  MUTATION_TS,
-  MUTATION_END_TS,
-  cache
-} from './config'
+import defaultConfig, { cache } from './config'
 import isDocumentVisible from './libs/is-document-visible'
 import isOnline from './libs/is-online'
 import throttle from './libs/throttle'
@@ -41,6 +32,15 @@ const IS_SERVER = typeof window === 'undefined'
 // To get around it, we can conditionally useEffect on the server (no-op) and
 // useLayoutEffect in the browser.
 const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
+
+// global state managers
+const CONCURRENT_PROMISES = {}
+const CONCURRENT_PROMISES_TS = {}
+const FOCUS_REVALIDATORS = {}
+const RECONNECT_REVALIDATORS = {}
+const CACHE_REVALIDATORS = {}
+const MUTATION_TS = {}
+const MUTATION_END_TS = {}
 
 // setup DOM events listeners for `focus` and `reconnect` actions
 if (!IS_SERVER && window.addEventListener) {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -42,6 +42,31 @@ const IS_SERVER = typeof window === 'undefined'
 // useLayoutEffect in the browser.
 const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
 
+// setup DOM events listeners for `focus` and `reconnect` actions
+if (!IS_SERVER && window.addEventListener) {
+  const revalidate = revalidators => {
+    if (!isDocumentVisible() || !isOnline()) return
+
+    for (const key in revalidators) {
+      if (revalidators[key][0]) revalidators[key][0]()
+    }
+  }
+
+  // focus revalidate
+  window.addEventListener(
+    'visibilitychange',
+    () => revalidate(FOCUS_REVALIDATORS),
+    false
+  )
+  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
+  // reconnect revalidate
+  window.addEventListener(
+    'online',
+    () => revalidate(RECONNECT_REVALIDATORS),
+    false
+  )
+}
+
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
   // we are ignoring the second argument which correspond to the arguments
   // the fetcher will receive when key is an array

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -509,9 +509,6 @@ function useSWR<Data = any, Error = any>(
       onReconnect = softRevalidate
     }
 
-    addRevalidator(FOCUS_REVALIDATORS, onFocus)
-    addRevalidator(RECONNECT_REVALIDATORS, onReconnect)
-
     // register global cache update listener
     const onUpdate: updaterInterface<Data, Error> = (
       shouldRevalidate = true,
@@ -552,12 +549,9 @@ function useSWR<Data = any, Error = any>(
       return false
     }
 
-    // add updater to listeners
-    if (!CACHE_REVALIDATORS[key]) {
-      CACHE_REVALIDATORS[key] = [onUpdate]
-    } else {
-      CACHE_REVALIDATORS[key].push(onUpdate)
-    }
+    addRevalidator(FOCUS_REVALIDATORS, onFocus)
+    addRevalidator(RECONNECT_REVALIDATORS, onReconnect)
+    addRevalidator(CACHE_REVALIDATORS, onUpdate)
 
     return () => {
       // cleanup

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -13,6 +13,7 @@ import defaultConfig, {
   CONCURRENT_PROMISES,
   CONCURRENT_PROMISES_TS,
   FOCUS_REVALIDATORS,
+  RECONNECT_REVALIDATORS,
   MUTATION_TS,
   MUTATION_END_TS,
   cache
@@ -247,19 +248,19 @@ function useSWR<Data = any, Error = any>(
     [key]
   )
 
-  const addRevalidator = (revalidators, revalidator) => {
-    if (!revalidator) return
+  const addRevalidator = (revalidators, callback) => {
+    if (!callback) return
     if (!revalidators[key]) {
-      revalidators[key] = [revalidator]
+      revalidators[key] = [callback]
     } else {
-      revalidators[key].push(revalidator)
+      revalidators[key].push(callback)
     }
   }
 
-  const removeRevalidator = (revlidators, revalidator) => {
+  const removeRevalidator = (revlidators, callback) => {
     if (revlidators[key]) {
       const revalidators = revlidators[key]
-      const index = revalidators.indexOf(revalidator)
+      const index = revalidators.indexOf(callback)
       if (index >= 0) {
         // 10x faster than splice
         // https://jsperf.com/array-remove-by-index
@@ -484,7 +485,7 @@ function useSWR<Data = any, Error = any>(
     }
 
     addRevalidator(FOCUS_REVALIDATORS, onFocus)
-    addRevalidator(FOCUS_REVALIDATORS, onReconnect)
+    addRevalidator(RECONNECT_REVALIDATORS, onReconnect)
 
     // register global cache update listener
     const onUpdate: updaterInterface<Data, Error> = (
@@ -541,7 +542,7 @@ function useSWR<Data = any, Error = any>(
       unmountedRef.current = true
 
       removeRevalidator(FOCUS_REVALIDATORS, onFocus)
-      removeRevalidator(FOCUS_REVALIDATORS, onReconnect)
+      removeRevalidator(RECONNECT_REVALIDATORS, onReconnect)
       removeRevalidator(CACHE_REVALIDATORS, onUpdate)
     }
   }, [key, revalidate])


### PR DESCRIPTION
## Changes

Resolves #474 , attach online event listeners in config 


## Test Plan

* build swr locally and yarn link to the examples/focus-revalidate 
* add one more swr hook there
* disconnect and reconnect the network in devtools
* expected: the requests get re-fetched