### PR TITLE
enhance: remove mutate calls from cache

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,5 +1,4 @@
 import { CacheInterface, keyInterface, cacheListener } from './types'
-import { mutate } from './use-swr'
 import hash from './libs/hash'
 
 export default class Cache implements CacheInterface {
@@ -16,10 +15,9 @@ export default class Cache implements CacheInterface {
     return this.__cache.get(_key)
   }
 
-  set(key: keyInterface, value: any, shouldNotify = true): any {
+  set(key: keyInterface, value: any): any {
     const [_key] = this.serializeKey(key)
     this.__cache.set(_key, value)
-    if (shouldNotify) mutate(key, value, false)
     this.notify()
   }
 
@@ -32,15 +30,13 @@ export default class Cache implements CacheInterface {
     return this.__cache.has(_key)
   }
 
-  clear(shouldNotify = true) {
-    if (shouldNotify) this.__cache.forEach(key => mutate(key, null, false))
+  clear() {
     this.__cache.clear()
     this.notify()
   }
 
-  delete(key: keyInterface, shouldNotify = true) {
+  delete(key: keyInterface) {
     const [_key] = this.serializeKey(key)
-    if (shouldNotify) mutate(key, null, false)
     this.__cache.delete(_key)
     this.notify()
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,11 +122,11 @@ export type actionType<Data, Error> = {
 
 export interface CacheInterface {
   get(key: keyInterface): any
-  set(key: keyInterface, value: any, shouldNotify?: boolean): any
+  set(key: keyInterface, value: any): any
   keys(): string[]
   has(key: keyInterface): boolean
-  delete(key: keyInterface, shouldNotify?: boolean): void
-  clear(shouldNotify?: boolean): void
+  delete(key: keyInterface): void
+  clear(): void
   serializeKey(key: keyInterface): [string, any, string]
   subscribe(listener: cacheListener): () => void
 }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -156,7 +156,7 @@ function useSWRInfinite<Data = any, Error = any>(
           } else {
             pageData = await fn(pageKey)
           }
-          cache.set(pageKey, pageData, false)
+          cache.set(pageKey, pageData)
         }
 
         data.push(pageData)
@@ -180,10 +180,10 @@ function useSWRInfinite<Data = any, Error = any>(
       if (shouldRevalidate && typeof data !== 'undefined') {
         // we only revalidate the pages that are changed
         const originalData = swr.data
-        cache.set(contextCacheKey, { originalData, force: false }, false)
+        cache.set(contextCacheKey, { originalData, force: false })
       } else if (shouldRevalidate) {
         // calling `mutate()`, we revalidate all pages
-        cache.set(contextCacheKey, { force: true }, false)
+        cache.set(contextCacheKey, { force: true })
       }
 
       return mutate(data, shouldRevalidate)
@@ -197,7 +197,7 @@ function useSWRInfinite<Data = any, Error = any>(
       } else if (typeof arg === 'number') {
         pageCountRef.current = arg
       }
-      cache.set(pageCountCacheKey, pageCountRef.current, false)
+      cache.set(pageCountCacheKey, pageCountRef.current)
       rerender(v => !v)
       return swr.mutate(v => v)
     },

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -123,9 +123,9 @@ const mutate: mutateInterface = async (
 
   if (typeof data !== 'undefined') {
     // update cached data, avoid notifying from the cache
-    cache.set(key, data, false)
+    cache.set(key, data)
   }
-  cache.set(keyErr, error, false)
+  cache.set(keyErr, error)
 
   // reset the timestamp to mark the mutation has ended
   MUTATION_END_TS[key] = Date.now() - 1
@@ -335,8 +335,8 @@ function useSWR<Data = any, Error = any>(
           return false
         }
 
-        cache.set(key, newData, false)
-        cache.set(keyErr, undefined, false)
+        cache.set(key, newData)
+        cache.set(keyErr, undefined)
 
         // new state for the reducer
         const newState: actionType<Data, Error> = {
@@ -364,7 +364,7 @@ function useSWR<Data = any, Error = any>(
         delete CONCURRENT_PROMISES[key]
         delete CONCURRENT_PROMISES_TS[key]
 
-        cache.set(keyErr, err, false)
+        cache.set(keyErr, err)
 
         // get a new error
         // don't use deep equal for errors

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1524,7 +1524,7 @@ describe('useSWR - suspense', () => {
 })
 
 describe('useSWR - cache', () => {
-  it('should react to direct cache updates', async () => {
+  it('should not react to direct cache updates but mutate', async () => {
     cache.set('cache-1', 'custom cache message')
 
     function Page() {
@@ -1555,16 +1555,23 @@ describe('useSWR - cache', () => {
       </div>
     `)
 
-    act(() => cache.set('cache-1', 'a different message'))
+    act(async () => {
+      const value = 'a different message'
+      cache.set('cache-1', value)
+      await mutate('cache-1', value, false)
+    })
 
-    // content should be updated from new cache value
+    // content should be updated from new cache value, after mutate without revalidate
     expect(await findByText('a different message')).toMatchInlineSnapshot(`
       <div>
         a different message
       </div>
     `)
 
-    act(() => cache.delete('cache-1'))
+    act(async () => {
+      cache.delete('cache-1')
+      mutate('cache-1')
+    })
 
     // content should go back to be the fetched value
     expect(await findByText('random message')).toMatchInlineSnapshot(`


### PR DESCRIPTION
## Purpose

* try to make cache pure. currently swr had 2 standalone paths to trigger revalidation of data: one is `mutate(key, value, true)` another is `cache.set(key, value, true)`. the way cache to revalidate data is leveraging mutate api, which means `mutate` is the out path to trigger revalidation.

* this can also resolve circular dependency issue of swr itself (mentioned in https://github.com/vercel/swr/pull/487#issuecomment-650562001). now we had clear deps path like the following:

![image](https://user-images.githubusercontent.com/4800338/86136930-3bcea480-bb1f-11ea-866b-1c595ecce4b8.png)

