### PR TITLE
Fix page size persistence when remounting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "0.2.3",
+  "version": "0.3.0-beta.9",
   "description": "React Hooks library for remote data fetching",
   "main": "./dist/index.js",
   "module": "./esm/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "0.3.0-beta.9",
+  "version": "0.2.3",
   "description": "React Hooks library for remote data fetching",
   "main": "./dist/index.js",
   "module": "./esm/index.js",

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -106,11 +106,16 @@ function useSWRInfinite<Data = any, Error = any>(
     cachedPageSize = cache.get(pageCountCacheKey)
   }
   const pageCountRef = useRef<number>(cachedPageSize || initialSize)
+  const didMountRef = useRef<boolean>(false)
 
   // every time the key changes, we reset the page size if it's not persisted
   useEffect(() => {
-    if (!persistSize) {
-      pageCountRef.current = initialSize
+    if (didMountRef.current) {
+      if (!persistSize) {
+        pageCountRef.current = initialSize
+      }
+    } else {
+      didMountRef.current = true
     }
   }, [firstPageKey])
 


### PR DESCRIPTION
Page size should only be reset on **re-render** (not first render). That ensures scroll position restoration to work correctly.