### PR TITLE
build: use tsc for cjs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "dev": "vercel dev",
     "build": "npm run build:esm && npm run build:cjs",
-    "build:cjs": "ncc build src/index.ts -o dist -m -e react",
+    "build:cjs": "tsc --outDir dist",
     "build:esm": "tsc --module ES6 --outDir esm",
     "watch": "tsc --watch",
     "types:check": "tsc --noEmit",
@@ -44,7 +44,6 @@
     "@types/react": "16.9.11",
     "@typescript-eslint/eslint-plugin": "2.5.0",
     "@typescript-eslint/parser": "2.5.0",
-    "@zeit/ncc": "0.20.5",
     "eslint": "6.6.0",
     "eslint-config-prettier": "6.5.0",
     "husky": "2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -506,11 +506,6 @@
     lodash.unescape "4.0.1"
     semver "^6.3.0"
 
-"@zeit/ncc@0.20.5":
-  version "0.20.5"
-  resolved "https://registry.yarnpkg.com/@zeit/ncc/-/ncc-0.20.5.tgz#a41af6e6bcab4a58f4612bae6137f70bce0192e3"
-  integrity sha512-XU6uzwvv95DqxciQx+aOLhbyBx/13ky+RK1y88Age9Du3BlA4mMPCy13BGjayOrrumOzlq1XV3SD/BWiZENXlw==
-
 abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"


### PR DESCRIPTION
## Changes

Simplify cjs build process, use tsc to compile without bundling the assets, aligning with esm build process.

## Purpose

* for library, bundling and code minification can be left to application side, let its bundler and minifier to consume the library code.
* we tried to leverage microbundle for assets generation. but unfortunately commonjs assets generated by microbundle doesn't work since it disabled rollup `output.esModule`, then the output cjs code won't work with interpolate import since it doesn't have `__esModule` property. (import deafult will not work when consum cjs bundle)
