### PR TITLE
don't retry on error if errorRetryCount is set to 0

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ function onErrorRetry(
   }
 
   if (
-    config.errorRetryCount != null &&
+    typeof config.errorRetryCount === 'number' &&
     opts.retryCount > config.errorRetryCount
   ) {
     return

--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,10 @@ function onErrorRetry(
     return
   }
 
-  if (config.errorRetryCount && opts.retryCount > config.errorRetryCount) {
+  if (
+    config.errorRetryCount != null &&
+    opts.retryCount > config.errorRetryCount
+  ) {
     return
   }
 


### PR DESCRIPTION
thanks @whj1995 for spotting out the bug. This should handle the edge case where user decides to set errorRetryCount to 0 instead of using the shouldRetryOnError boolean flag.