### PR TITLE
fix: check if mounted when trigger rerender

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -224,6 +224,7 @@ function useSWR<Data = any, Error = any>(
       }
     }
     if (shouldUpdateState || config.suspense) {
+      if (unmountedRef.current) return
       rerender({})
     }
   }, [])


### PR DESCRIPTION
### fix

Resolve #494 

react exp version will warn setState calls when component is not mounted. on suspense mode, swr trigger revalidate and lead to call `rerender` when the component is not mounted yet. 

![image](https://user-images.githubusercontent.com/4800338/86995181-e3f90300-c1da-11ea-8cd6-1cd0794bec34.png)
