### PR TITLE
Export interfaces used by useSWRInfinite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 export * from './use-swr'
 import { default as useSWR } from './use-swr'
-export { useSWRInfinite } from './use-swr-infinite'
+export {
+  useSWRInfinite,
+  ExtendedConfigInterface,
+  ExtendedResponseInterface
+} from './use-swr-infinite'
 export { cache } from './config'
 export {
   ConfigInterface,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ export * from './use-swr'
 import { default as useSWR } from './use-swr'
 export {
   useSWRInfinite,
-  ExtendedConfigInterface,
-  ExtendedResponseInterface
+  SWRInfiniteConfigInterface,
+  SWRInfiniteResponseInterface
 } from './use-swr-infinite'
 export { cache } from './config'
 export {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -212,4 +212,4 @@ function useSWRInfinite<Data = any, Error = any>(
   return swr
 }
 
-export { useSWRInfinite }
+export { useSWRInfinite, ExtendedConfigInterface, ExtendedResponseInterface }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -9,7 +9,7 @@ type KeyLoader<Data = any> = (
   index: number,
   previousPageData: Data | null
 ) => keyType
-type ExtendedConfigInterface<Data = any, Error = any> = ConfigInterface<
+type SWRInfiniteConfigInterface<Data = any, Error = any> = ConfigInterface<
   Data[],
   Error,
   fetcherFn<Data[]>
@@ -18,7 +18,7 @@ type ExtendedConfigInterface<Data = any, Error = any> = ConfigInterface<
   revalidateAll?: boolean
   persistSize?: boolean
 }
-type ExtendedResponseInterface<Data = any, Error = any> = responseInterface<
+type SWRInfiniteResponseInterface<Data = any, Error = any> = responseInterface<
   Data[],
   Error
 > & {
@@ -30,22 +30,22 @@ type ExtendedResponseInterface<Data = any, Error = any> = responseInterface<
 
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>
-): ExtendedResponseInterface<Data, Error>
+): SWRInfiniteResponseInterface<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
-  config?: ExtendedConfigInterface<Data, Error>
-): ExtendedResponseInterface<Data, Error>
+  config?: SWRInfiniteConfigInterface<Data, Error>
+): SWRInfiniteResponseInterface<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
   fn?: fetcherFn<Data>,
-  config?: ExtendedConfigInterface<Data, Error>
-): ExtendedResponseInterface<Data, Error>
+  config?: SWRInfiniteConfigInterface<Data, Error>
+): SWRInfiniteResponseInterface<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   ...args
-): ExtendedResponseInterface<Data, Error> {
+): SWRInfiniteResponseInterface<Data, Error> {
   let getKey: KeyLoader<Data>,
     fn: fetcherFn<Data> | undefined,
-    config: ExtendedConfigInterface<Data, Error> = {}
+    config: SWRInfiniteConfigInterface<Data, Error> = {}
 
   if (args.length >= 1) {
     getKey = args[0]
@@ -120,7 +120,7 @@ function useSWRInfinite<Data = any, Error = any>(
   }, [firstPageKey])
 
   // actual swr of all pages
-  const swr: ExtendedResponseInterface<Data, Error> = useSWR<Data[], Error>(
+  const swr: SWRInfiniteResponseInterface<Data, Error> = useSWR<Data[], Error>(
     firstPageKey ? ['many', firstPageKey] : null,
     async () => {
       // get the revalidate context
@@ -212,4 +212,8 @@ function useSWRInfinite<Data = any, Error = any>(
   return swr
 }
 
-export { useSWRInfinite, ExtendedConfigInterface, ExtendedResponseInterface }
+export {
+  useSWRInfinite,
+  SWRInfiniteConfigInterface,
+  SWRInfiniteResponseInterface
+}


### PR DESCRIPTION
Rationale: Extending these interfaces in a TypeScript project when composing your own hooks using SWR.
You can already do this with config/response interfaces used by `useSWR` as these are already exposed.