### PR TITLE
fix bug of fetcher falsy return

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -591,7 +591,7 @@ function useSWR<Data = any, Error = any>(
       typeof latestError === 'undefined'
     ) {
       // need to start the request if it hasn't
-      if (!CONCURRENT_PROMISES[key]) {
+      if (!(key in CONCURRENT_PROMISES)) {
         // trigger revalidate immediately
         // to get the promise
         revalidate()


### PR DESCRIPTION
should check if is there any value (even falsy value) is ready in CONCURRENT_PROMISES for key or not

close #517 issue

(I don't know codebase very well but I think this change condition will fix the bug, am I right?)