### PR TITLE
fix: `eventsRef` should trigger the lastest version of config callbacks

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -193,7 +193,9 @@ function useSWR<Data = any, Error = any>(
   )
 
   const configRef = useRef(config)
-  configRef.current = config
+  useIsomorphicLayoutEffect(() => {
+    configRef.current = config
+  })
 
   if (typeof fn === 'undefined') {
     // use the global fetcher

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -192,10 +192,8 @@ function useSWR<Data = any, Error = any>(
     config
   )
 
-  const lastestConfig = useRef(config)
-  useIsomorphicLayoutEffect(() => {
-    lastestConfig.current = config
-  })
+  const configRef = useRef(config)
+  configRef.current = config
 
   if (typeof fn === 'undefined') {
     // use the global fetcher
@@ -242,7 +240,7 @@ function useSWR<Data = any, Error = any>(
   const eventsRef = useRef({
     emit: (event, ...params) => {
       if (unmountedRef.current) return
-      lastestConfig.current[event](...params)
+      configRef.current[event](...params)
     }
   })
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -192,6 +192,11 @@ function useSWR<Data = any, Error = any>(
     config
   )
 
+  const lastestConfig = useRef(config)
+  useIsomorphicLayoutEffect(() => {
+    lastestConfig.current = config
+  })
+
   if (typeof fn === 'undefined') {
     // use the global fetcher
     fn = config.fetcher
@@ -237,7 +242,7 @@ function useSWR<Data = any, Error = any>(
   const eventsRef = useRef({
     emit: (event, ...params) => {
       if (unmountedRef.current) return
-      config[event](...params)
+      lastestConfig.current[event](...params)
     }
   })
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1903,7 +1903,7 @@ describe('useSWR - config callbacks', () => {
 
     function Page(props) {
       const { data } = useSWR(
-        'config callbacks - onErrorRetry',
+        'config callbacks - onLoadingSlow',
         () => new Promise(res => setTimeout(() => res(count++), 200)),
         {
           onLoadingSlow: () => {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1741,3 +1741,211 @@ describe('useSWR - key', () => {
     )
   })
 })
+
+describe('useSWR - config callbacks', () => {
+  it('should trigger the onSuccess event with the latest version of the onSuccess callback', async () => {
+    let state = null
+    let count = 0
+
+    function Page(props) {
+      const { data, revalidate } = useSWR(
+        'config callbacks - onSuccess',
+        () => new Promise(res => setTimeout(() => res(count++), 200)),
+        { onSuccess: () => (state = props.text) }
+      )
+      return (
+        <div onClick={revalidate}>
+          hello, {data}, {props.text}
+        </div>
+      )
+    }
+    const { container, rerender } = render(<Page text={'a'} />)
+    // the onSuccess callback does not trigger yet, the state still null.
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, , a"`
+    )
+    expect(state).toEqual(null)
+
+    await waitForDomChange({ container })
+    // since the promise resolved, the onSuccess callback assign `props.text` to `state`
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, 0, a"`
+    )
+    expect(state).toEqual('a')
+
+    // props changed, but the onSuccess callback does not trigger yet, `state` is same as before
+    rerender(<Page text={'b'} />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, 0, b"`
+    )
+    expect(state).toEqual('a')
+
+    await act(() => {
+      // trigger revalidation, this would re-trigger the onSuccess callback
+      fireEvent.click(container.firstElementChild)
+      return new Promise(res => setTimeout(res, 201))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, 1, b"`
+    )
+    // the onSuccess callback should capture the latest `props.text`
+    expect(state).toEqual('b')
+  })
+
+  it('should trigger the onError event with the latest version of the onError callback', async () => {
+    let state = null
+    let count = 0
+
+    function Page(props) {
+      const { data, revalidate, error } = useSWR(
+        'config callbacks - onError',
+        () =>
+          new Promise((_, rej) =>
+            setTimeout(() => rej(new Error(`Error: ${count++}`)), 200)
+          ),
+        { onError: () => (state = props.text) }
+      )
+      if (error)
+        return (
+          <div title={props.text} onClick={revalidate}>
+            {error.message}
+          </div>
+        )
+      return (
+        <div onClick={revalidate}>
+          hello, {data}, {props.text}
+        </div>
+      )
+    }
+
+    const { container, rerender } = render(<Page text="a" />)
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, , a"`
+    )
+    expect(state).toEqual(null)
+
+    await waitForDomChange({ container })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"Error: 0"`)
+    expect(state).toEqual('a')
+
+    // props changed, but the onError callback doese not trigger yet.
+    rerender(<Page text="b" />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"Error: 0"`)
+    expect(container.firstElementChild.getAttribute('title')).toEqual('b')
+    expect(state).toEqual('a')
+
+    await act(() => {
+      fireEvent.click(container.firstElementChild)
+      return new Promise(res => setTimeout(res, 201))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"Error: 1"`)
+    expect(container.firstElementChild.getAttribute('title')).toEqual('b')
+    expect(state).toEqual('b')
+  })
+
+  it('should trigger the onErrorRetry event with the latest version of the onErrorRetry callback', async () => {
+    let state = null
+    let count = 0
+    function Page(props) {
+      const { data, error } = useSWR(
+        'config callbacks - onErrorRetry',
+        () =>
+          new Promise((_, rej) =>
+            setTimeout(() => rej(new Error(`Error: ${count++}`)), 200)
+          ),
+        {
+          onErrorRetry: (_, __, ___, revalidate, revalidateOpts) => {
+            state = props.text
+            setTimeout(() => revalidate(revalidateOpts), 100)
+          }
+        }
+      )
+      if (error) return <div title={props.text}>{error.message}</div>
+      return (
+        <div>
+          hello, {data}, {props.text}
+        </div>
+      )
+    }
+
+    const { container, rerender } = render(<Page text="a" />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, , a"`
+    )
+    expect(state).toEqual(null)
+
+    await waitForDomChange({ container })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"Error: 0"`)
+    expect(container.firstElementChild.getAttribute('title')).toEqual('a')
+    expect(state).toEqual('a')
+
+    // since the onErrorRetry schedule a timer to trigger revalidation, update props.text now
+    rerender(<Page text="b" />)
+    // not revalidate yet.
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"Error: 0"`)
+    expect(container.firstElementChild.getAttribute('title')).toEqual('b')
+    expect(state).toEqual('a')
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 301))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"Error: 1"`)
+    expect(container.firstElementChild.getAttribute('title')).toEqual('b')
+    expect(state).toEqual('b')
+  })
+
+  it('should trigger the onLoadingSlow and onSuccess event with the lastest version of the callbacks', async () => {
+    let state = null
+    let count = 0
+
+    function Page(props) {
+      const { data } = useSWR(
+        'config callbacks - onErrorRetry',
+        () => new Promise(res => setTimeout(() => res(count++), 200)),
+        {
+          onLoadingSlow: () => {
+            state = props.text
+          },
+          onSuccess: () => {
+            state = props.text
+          },
+          loadingTimeout: 100
+        }
+      )
+      return (
+        <div>
+          hello, {data}, {props.text}
+        </div>
+      )
+    }
+
+    const { container, rerender } = render(<Page text="a" />)
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, , a"`
+    )
+    expect(state).toEqual(null)
+
+    await act(() => {
+      // wait 100ms to trigger onLoadingSlow event, but not success yet.
+      return new Promise(res => setTimeout(res, 101))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, , a"`
+    )
+    expect(state).toEqual('a')
+    rerender(<Page text="b" />)
+
+    await act(() => {
+      // now trigger onSuccess event
+      return new Promise(res => setTimeout(res, 100))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, 0, b"`
+    )
+    expect(state).toEqual('b')
+  })
+})


### PR DESCRIPTION
 # fix

Resolve: #508 #515 
 
Now the `eventsRef` read the config via the `ref`,which always capture the lastest version of the config callbacks.

This fix the problem of the stale closure related to the config callbacks.