### PR TITLE
fix: should throw when mutate failed

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -139,9 +139,11 @@ const mutate: mutateInterface = async (
       promises.push(updaters[i](!!shouldRevalidate, data, error, i > 0))
     }
     // return new updated value
-    return Promise.all(promises).then(() => cache.get(key))
+    return Promise.all(promises).then(() => {
+      if (error) throw error
+      return cache.get(key)
+    })
   }
-
   // throw error or return data to be used by caller of mutate
   if (error) throw error
   return data


### PR DESCRIPTION
Fix #556

mutate failure should throw the error out. error is hidden when use `mutate` and `useSWR` hook at the same time.

* in `mutate`: throw error after onUpdate callback executed
* update test: add try catch on top of `mutate` call when it might throw