### PR TITLE
Promote isValidating to the global level of data and error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ esm
 .next
 .DS_Store
 .idea
+.vscode
 examples/**/yarn.lock
 package-lock.json

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -42,7 +42,7 @@ export default class Cache implements CacheInterface {
   }
 
   // TODO: introduce namespace for the cache
-  serializeKey(key: keyInterface): [string, any, string] {
+  serializeKey(key: keyInterface): [string, any, string, string] {
     let args = null
     if (typeof key === 'function') {
       try {
@@ -63,8 +63,9 @@ export default class Cache implements CacheInterface {
     }
 
     const errorKey = key ? 'err@' + key : ''
+    const isValidatingKey = key ? 'validating@' + key : ''
 
-    return [key, args, errorKey]
+    return [key, args, errorKey, isValidatingKey]
   }
 
   subscribe(listener: cacheListener) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,8 @@ export type mutateInterface<Data = any> = (
 export type broadcastStateInterface<Data = any, Error = any> = (
   key: string,
   data: Data,
-  error?: Error
+  error?: Error,
+  isValidating?: boolean
 ) => void
 export type responseInterface<Data, Error> = {
   data?: Data
@@ -127,7 +128,7 @@ export interface CacheInterface {
   has(key: keyInterface): boolean
   delete(key: keyInterface): void
   clear(): void
-  serializeKey(key: keyInterface): [string, any, string]
+  serializeKey(key: keyInterface): [string, any, string, string]
   subscribe(listener: cacheListener): () => void
 }
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -75,7 +75,7 @@ if (!IS_SERVER && window.addEventListener) {
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
   // we are ignoring the second argument which correspond to the arguments
   // the fetcher will receive when key is an array
-  const [key, , keyErr] = cache.serializeKey(_key)
+  const [key, , keyErr, keyValidating] = cache.serializeKey(_key)
   if (!key) return Promise.resolve()
 
   const updaters = CACHE_REVALIDATORS[key]
@@ -83,10 +83,17 @@ const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
   if (key && updaters) {
     const currentData = cache.get(key)
     const currentError = cache.get(keyErr)
+    const currentIsValidating = cache.get(keyValidating)
     const promises = []
     for (let i = 0; i < updaters.length; ++i) {
       promises.push(
-        updaters[i](shouldRevalidate, currentData, currentError, i > 0)
+        updaters[i](
+          shouldRevalidate,
+          currentData,
+          currentError,
+          currentIsValidating,
+          i > 0
+        )
       )
     }
     // return new updated value
@@ -95,11 +102,16 @@ const trigger: triggerInterface = (_key, shouldRevalidate = true) => {
   return Promise.resolve(cache.get(key))
 }
 
-const broadcastState: broadcastStateInterface = (key, data, error) => {
+const broadcastState: broadcastStateInterface = (
+  key,
+  data,
+  error,
+  isValidating
+) => {
   const updaters = CACHE_REVALIDATORS[key]
   if (key && updaters) {
     for (let i = 0; i < updaters.length; ++i) {
-      updaters[i](false, data, error)
+      updaters[i](false, data, error, isValidating)
     }
   }
 }
@@ -167,7 +179,9 @@ const mutate: mutateInterface = async (
   if (updaters) {
     const promises = []
     for (let i = 0; i < updaters.length; ++i) {
-      promises.push(updaters[i](!!shouldRevalidate, data, error, i > 0))
+      promises.push(
+        updaters[i](!!shouldRevalidate, data, error, undefined, i > 0)
+      )
     }
     // return new updated value
     return Promise.all(promises).then(() => {
@@ -216,7 +230,7 @@ function useSWR<Data = any, Error = any>(
   // `key` can change but `fn` shouldn't
   // (because `revalidate` only depends on `key`)
   // `keyErr` is the cache key for error objects
-  const [key, fnArgs, keyErr] = cache.serializeKey(_key)
+  const [key, fnArgs, keyErr, keyValidating] = cache.serializeKey(_key)
 
   config = Object.assign(
     {},
@@ -232,6 +246,7 @@ function useSWR<Data = any, Error = any>(
 
   const initialData = cache.get(key) || config.initialData
   const initialError = cache.get(keyErr)
+  const initialIsValidating = cache.get(keyValidating)
 
   // if a state is accessed (data, error or isValidating),
   // we add the state to dependencies so if the state is
@@ -244,7 +259,7 @@ function useSWR<Data = any, Error = any>(
   const stateRef = useRef({
     data: initialData,
     error: initialError,
-    isValidating: false
+    isValidating: initialIsValidating
   })
 
   const rerender = useState(null)[1]
@@ -321,6 +336,11 @@ function useSWR<Data = any, Error = any>(
         dispatch({
           isValidating: true
         })
+        cache.set(keyValidating, true)
+        if (!shouldDeduping) {
+          // also update other hooks
+          broadcastState(key, undefined, undefined, true)
+        }
 
         let newData
         let startAt
@@ -393,6 +413,7 @@ function useSWR<Data = any, Error = any>(
 
         cache.set(key, newData)
         cache.set(keyErr, undefined)
+        cache.set(keyValidating, false)
 
         // new state for the reducer
         const newState: actionType<Data, Error> = {
@@ -414,7 +435,7 @@ function useSWR<Data = any, Error = any>(
 
         if (!shouldDeduping) {
           // also update other hooks
-          broadcastState(key, newData, undefined)
+          broadcastState(key, newData, undefined, false)
         }
       } catch (err) {
         delete CONCURRENT_PROMISES[key]
@@ -433,7 +454,7 @@ function useSWR<Data = any, Error = any>(
 
           if (!shouldDeduping) {
             // also broadcast to update other hooks
-            broadcastState(key, undefined, err)
+            broadcastState(key, undefined, err, false)
           }
         }
 
@@ -518,6 +539,7 @@ function useSWR<Data = any, Error = any>(
       shouldRevalidate = true,
       updatedData,
       updatedError,
+      updatedIsValidating,
       dedupe = true
     ) => {
       // update hook state
@@ -536,6 +558,14 @@ function useSWR<Data = any, Error = any>(
       // because it can be `undefined`
       if (stateRef.current.error !== updatedError) {
         newState.error = updatedError
+        needUpdate = true
+      }
+
+      if (
+        typeof updatedIsValidating !== 'undefined' &&
+        stateRef.current.isValidating !== updatedIsValidating
+      ) {
+        newState.isValidating = updatedIsValidating
         needUpdate = true
       }
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -246,7 +246,7 @@ function useSWR<Data = any, Error = any>(
 
   const initialData = cache.get(key) || config.initialData
   const initialError = cache.get(keyErr)
-  const initialIsValidating = cache.get(keyValidating)
+  const initialIsValidating = !!cache.get(keyValidating)
 
   // if a state is accessed (data, error or isValidating),
   // we add the state to dependencies so if the state is


### PR DESCRIPTION
This fixes https://github.com/vercel/swr/issues/549 by caching and broadcasting `isValidating` in the same way that `data` and `error` are cached and broadcasted.

**Before**

![before](https://user-images.githubusercontent.com/10765285/88843984-d3fb9000-d196-11ea-95ab-561280c5af81.gif)

**After**

![after](https://user-images.githubusercontent.com/10765285/88843992-d6f68080-d196-11ea-9695-8979558ae56c.gif)