### PR TITLE
Type fetcher function arguments based on array key (#331)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react": "16.11.0",
     "react-dom": "16.11.0",
     "ts-jest": "24.1.0",
-    "typescript": "3.6.4"
+    "typescript": "3.9.7"
   },
   "dependencies": {
     "fast-deep-equal": "2.0.1"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,6 @@
-export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
+export type fetcherFn<Data, TKey extends readonly any[] = any[]> = (
+  ...args: TKey
+) => Data | Promise<Data>
 export interface ConfigInterface<
   Data = any,
   Error = any,
@@ -47,9 +49,11 @@ export interface RevalidateOptionInterface {
   dedupe?: boolean
 }
 
-export type keyType = string | any[] | null
-type keyFunction = () => keyType
-export type keyInterface = keyFunction | keyType
+export type keyType<TKey extends readonly any[] = any[]> = string | TKey | null
+type keyFunction<TKey extends readonly any[] = any[]> = () => keyType<TKey>
+export type keyInterface<TKey extends readonly any[] = any[]> =
+  | keyFunction<TKey>
+  | keyType<TKey>
 export type updaterInterface<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,11 +49,9 @@ export interface RevalidateOptionInterface {
   dedupe?: boolean
 }
 
-export type keyType<TKey extends readonly any[] = any[]> = string | TKey | null
-type keyFunction<TKey extends readonly any[] = any[]> = () => keyType<TKey>
-export type keyInterface<TKey extends readonly any[] = any[]> =
-  | keyFunction<TKey>
-  | keyType<TKey>
+export type keyType<TKey = any> = string | TKey | null
+type keyFunction<TKey> = () => keyType<TKey>
+export type keyInterface<TKey = any> = keyFunction<TKey> | keyType<TKey>
 export type updaterInterface<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -187,9 +187,9 @@ function useSWR<Data = any, Error = any>(
   key: keyInterface,
   config?: ConfigInterface<Data, Error>
 ): responseInterface<Data, Error>
-function useSWR<Data = any, Error = any>(
-  key: keyInterface,
-  fn?: fetcherFn<Data>,
+function useSWR<Data = any, Error = any, TKey extends readonly any[] = any[]>(
+  key: keyInterface<TKey>,
+  fn?: fetcherFn<Data, TKey>,
   config?: ConfigInterface<Data, Error>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -180,6 +180,24 @@ const mutate: mutateInterface = async (
   return data
 }
 
+type DefinedQueryKeyPart =
+  | string
+  | object
+  | boolean
+  | number
+  | readonly QueryKeyPart[]
+
+type QueryKeyPart =
+  | string
+  | object
+  | boolean
+  | number
+  | readonly QueryKeyPart[]
+  | null
+  | undefined
+
+type AnyQueryKey = readonly [DefinedQueryKeyPart, ...QueryKeyPart[]] // this forces the key to be inferred as a tuple
+
 function useSWR<Data = any, Error = any>(
   key: keyInterface
 ): responseInterface<Data, Error>
@@ -187,7 +205,16 @@ function useSWR<Data = any, Error = any>(
   key: keyInterface,
   config?: ConfigInterface<Data, Error>
 ): responseInterface<Data, Error>
-function useSWR<Data = any, Error = any, TKey extends readonly any[] = any[]>(
+function useSWR<Data = any, Error = any, TKey extends string = string>(
+  key: keyInterface<TKey>,
+  fn?: fetcherFn<Data, [TKey]>,
+  config?: ConfigInterface<Data, Error>
+): responseInterface<Data, Error>
+function useSWR<
+  Data = any,
+  Error = any,
+  TKey extends AnyQueryKey = [any, ...any[]]
+>(
   key: keyInterface<TKey>,
   fn?: fetcherFn<Data, TKey>,
   config?: ConfigInterface<Data, Error>

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -226,7 +226,7 @@ describe('useSWR', () => {
 
     function Page() {
       const { data: v1 } = useSWR(
-        ['args-1', obj, arr],
+        ['args-1', obj, arr] as const,
         (a, b, c) => a + b.v + c[0]
       )
 
@@ -235,7 +235,7 @@ describe('useSWR', () => {
 
       // different object
       const { data: v3 } = useSWR(
-        ['args-2', obj, 'world'],
+        ['args-2', obj, 'world'] as const,
         (a, b, c) => a + b.v + c
       )
 
@@ -260,7 +260,7 @@ describe('useSWR', () => {
 
     function Page() {
       const { data } = useSWR(
-        () => ['args-3', obj, arr],
+        () => ['args-3', obj, arr] as const,
         (a, b, c) => a + b.v + c[0]
       )
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -226,7 +226,7 @@ describe('useSWR', () => {
 
     function Page() {
       const { data: v1 } = useSWR(
-        ['args-1', obj, arr] as const,
+        ['args-1', obj, arr],
         (a, b, c) => a + b.v + c[0]
       )
 
@@ -235,7 +235,7 @@ describe('useSWR', () => {
 
       // different object
       const { data: v3 } = useSWR(
-        ['args-2', obj, 'world'] as const,
+        ['args-2', obj, 'world'],
         (a, b, c) => a + b.v + c
       )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4543,10 +4543,10 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uglify-js@^3.1.4:
   version "3.6.9"


### PR DESCRIPTION
Changes in tests provide and example of what this looks like:

```
const { data: v1 } = useSWR(
  ['args-1', obj, arr] as const,
  (a, b, c) => a + b.v + c[0]
)
```

Need to do `as const` so Typescript infers the tuple type instead of something like `(string | object | string[])[]` (in this case). Now, a, b, and c have the proper types and there are type errors if I misuse one of the variables or have the incorrect number of arguments.