### PR TITLE
Add useDebugValue to show the data label in the React DevTools

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "homepage": "https://swr.now.sh",
   "license": "MIT",
   "scripts": {
-    "dev": "vercel dev",
     "build": "npm run build:esm && npm run build:cjs",
     "build:cjs": "ncc build src/index.ts -o dist -m -e react",
     "build:esm": "tsc --module ES6 --outDir esm",

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -5,7 +5,8 @@ import {
   useLayoutEffect,
   useState,
   useRef,
-  useMemo
+  useMemo,
+  useDebugValue
 } from 'react'
 
 import defaultConfig, {
@@ -213,6 +214,9 @@ function useSWR<Data = any, Error = any>(
     error: initialError,
     isValidating: false
   })
+
+  // display the data label in the React DevTools next to SWR hooks
+  useDebugValue(stateRef.current.data)
 
   const rerender = useState(null)[1]
   let dispatch = useCallback(payload => {


### PR DESCRIPTION
close #574 

With this PR, it will look like this in the React DevTools:

![image](https://user-images.githubusercontent.com/21211353/89097088-475b0700-d40e-11ea-90d9-15b8397e510b.png)

I'm not sure if we need to show `undefined` when the data is not returned as expected? like this:

![image](https://user-images.githubusercontent.com/21211353/89097078-1e3a7680-d40e-11ea-933f-69a41222a038.png)
