### PR TITLE
add function key arguments to WeakMap so they trigger revalidation on identity change

### DIFF
--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -13,7 +13,7 @@ export default function hash(args: any[]): string {
   let key = 'arg'
   for (let i = 0; i < args.length; ++i) {
     let _hash
-    if (args[i] === null || typeof args[i] !== 'object') {
+    if (args[i] === null || (typeof args[i] !== 'object' && typeof args[i] !== 'function')) {
       // need to consider the case that args[i] is a string:
       // args[i]        _hash
       // "undefined" -> '"undefined"'


### PR DESCRIPTION
This is a proposed fix for the issue I raised in https://github.com/vercel/swr/issues/611 .

See the original issue for more details on the issue I'm facing.