### PR TITLE
Add passKeyToFetcher option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -66,6 +66,7 @@ const defaultConfig: ConfigInterface = {
   refreshWhenOffline: false,
   shouldRetryOnError: true,
   suspense: false,
+  passKeyToFetcher: true,
   compare: deepEqual
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface ConfigInterface<
   revalidateOnMount?: boolean
   revalidateOnReconnect?: boolean
   shouldRetryOnError?: boolean
+  passKeyToFetcher?: boolean
   fetcher?: Fn
   suspense?: boolean
   initialData?: Data

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -260,7 +260,7 @@ function useSWR<Data = any, Error = any>(
     let shouldUpdateState = false
     for (let k in payload) {
       if (stateRef.current[k] === payload[k]) {
-        continue;
+        continue
       }
 
       stateRef.current[k] = payload[k]
@@ -352,7 +352,10 @@ function useSWR<Data = any, Error = any>(
           }
 
           if (fnArgs !== null) {
-            CONCURRENT_PROMISES[key] = fn(...fnArgs)
+            const [, ...fnArgsWithoutKey] = fnArgs
+            CONCURRENT_PROMISES[key] = config.passKeyToFetcher
+              ? fn(...fnArgs)
+              : fn(...fnArgsWithoutKey)
           } else {
             CONCURRENT_PROMISES[key] = fn(key)
           }

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -273,6 +273,26 @@ describe('useSWR', () => {
     expect(container.textContent).toMatchInlineSnapshot(`"args-3helloworld"`)
   })
 
+  it('should not pass the key to the fetcher when passKeyToFetcher is set to false', async () => {
+    const obj = { v: 'hello' }
+    const arr = ['world']
+
+    function Page() {
+      const { data } = useSWR(
+        () => ['args-without-key', obj, arr],
+        (a, b) => a.v + b[0],
+        { passKeyToFetcher: false }
+      )
+
+      return <div>{data}</div>
+    }
+
+    const { container } = render(<Page />)
+
+    await waitForDomChange({ container })
+    expect(container.textContent).toMatchInlineSnapshot(`"helloworld"`)
+  })
+
   it('should accept initial data', async () => {
     const fetcher = jest.fn(() => 'SWR')
 


### PR DESCRIPTION
This PR adds a new **'passKeyToFetcher'** option (which defaults to true). When set to false, fetcher functions will not receive the key as the first argument. For example:

```javascript
import useSWR from "swr";
import useSesion from "./useSession";

// if passKeyToFetcher was true (which is the default), getUser would receive (key, userId, token).
const getUser = (userId, token) => {
  return fetch(`/api/users/${userId}`, { headers: { authorization: `Bearer ${token}` } })
    .then((response) => response.json());
};

export const UserContext = React.createContext({});
export default function UserProvider({ children }) {
  const { session } = useSession();

  const { data: user } = useSWR(
    () => ["getUser", session.userId, session.token], 
    getUser,  
    { passKeyToFetcher: false }
  );

  const value = { user };

  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
```

Why? If my fetcher function is generic and not dependant of SWR, I don't want to receive (and ignore) a key which is only used by SWR.

I'm obviously open to suggestions, but I hope you find this useful :)

Thanks!