### PR TITLE
try fix cannot stop polling by setting refreshInterval (#632)

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -571,6 +571,7 @@ function useSWR<Data = any, Error = any>(
     addRevalidator(RECONNECT_REVALIDATORS, onReconnect)
     addRevalidator(CACHE_REVALIDATORS, onUpdate)
 
+    let timer = null
     const tick = async () => {
       if (
         !stateRef.current.error &&
@@ -583,11 +584,11 @@ function useSWR<Data = any, Error = any>(
         await revalidate({ dedupe: true })
       }
       if (configRef.current.refreshInterval) {
-        setTimeout(tick, configRef.current.refreshInterval)
+        timer = setTimeout(tick, configRef.current.refreshInterval)
       }
     }
     if (configRef.current.refreshInterval) {
-      setTimeout(tick, configRef.current.refreshInterval)
+      timer = setTimeout(tick, configRef.current.refreshInterval)
     }
 
     return () => {
@@ -600,6 +601,8 @@ function useSWR<Data = any, Error = any>(
       removeRevalidator(FOCUS_REVALIDATORS, onFocus)
       removeRevalidator(RECONNECT_REVALIDATORS, onReconnect)
       removeRevalidator(CACHE_REVALIDATORS, onUpdate)
+
+      if (timer) clearTimeout(timer)
     }
   }, [key, revalidate])
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -598,7 +598,7 @@ function useSWR<Data = any, Error = any>(
         await revalidate({ dedupe: true })
       }
       // Read the latest refreshInterval
-      if (configRef.current.refreshInterval) {
+      if (configRef.current.refreshInterval && !stateRef.current.error) {
         timer = setTimeout(tick, configRef.current.refreshInterval)
       }
     }

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -462,7 +462,7 @@ describe('useSWR - refresh', () => {
     await waitForDomChange({ container }) // mount
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 0"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 210))
+      return new Promise(res => setTimeout(res, 200))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
     await act(() => {
@@ -475,39 +475,111 @@ describe('useSWR - refresh', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
     await act(() => {
       fireEvent.click(container.firstElementChild)
-      // it will clear 200ms timer and setup a new 300ms timer
+      // 200ms timer will be execute and then setup a new 300ms timer
       return new Promise(res => setTimeout(res, 200))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 3"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 110))
+      return new Promise(res => setTimeout(res, 200))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 3"`)
     await act(() => {
       // wait for new 300ms timer
-      return new Promise(res => setTimeout(res, 310))
+      return new Promise(res => setTimeout(res, 100))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
     await act(() => {
       fireEvent.click(container.firstElementChild)
-      // it will clear 300ms timer and setup a new 400ms timer
+      // 300ms timer will be execute and then setup a new 400ms timer
       return new Promise(res => setTimeout(res, 300))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 110))
+      return new Promise(res => setTimeout(res, 300))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
     await act(() => {
       fireEvent.click(container.firstElementChild)
-      // it will clear 400ms timer and stop
-      return new Promise(res => setTimeout(res, 110))
+      // 400ms timer will be execute and then stop
+      return new Promise(res => setTimeout(res, 100))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 110))
+      return new Promise(res => setTimeout(res, 400))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 400))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 400))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
+  })
+
+  it('should update data upon interval changes -- changes happened during revalidate', async () => {
+    let count = 0
+    const STOP_POLLING_THRESHOLD = 2
+    function Page() {
+      const [flag, setFlag] = useState(0)
+      const shouldPoll = flag < STOP_POLLING_THRESHOLD
+      const { data } = useSWR(
+        '/interval-changes-during-revalidate',
+        () => count++,
+        {
+          refreshInterval: shouldPoll ? 200 : 0,
+          dedupingInterval: 100,
+          onSuccess() {
+            setFlag(value => value + 1)
+          }
+        }
+      )
+      return (
+        <div>
+          count: {data} {flag}
+        </div>
+      )
+    }
+    const { container } = render(<Page />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count:  0"`
+    )
+
+    await waitForDomChange({ container }) // mount
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 0 1"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 1 2"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 1 2"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 1 2"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 1 2"`
+    )
   })
 
   it('should allow use custom isEqual method', async () => {
@@ -1920,9 +1992,9 @@ describe('useSWR - key', () => {
   })
 
   it('should revalidate if a function key changes identity', async () => {
-    const closureFunctions: {[key: string]: () => Promise<string>} = {}
+    const closureFunctions: { [key: string]: () => Promise<string> } = {}
 
-    const closureFactory = (id) => {
+    const closureFactory = id => {
       if (closureFunctions[id]) return closureFunctions[id]
       closureFunctions[id] = () => Promise.resolve(`data-${id}`)
       return closureFunctions[id]
@@ -1938,24 +2010,20 @@ describe('useSWR - key', () => {
       const fnWithClosure = closureFactory(id)
       const { data } = useSWR([fnWithClosure], fetcher)
 
-      return (
-        <div>
-          {data}
-        </div>
-      )
+      return <div>{data}</div>
     }
 
-    const { container } = render(<Page />);
+    const { container } = render(<Page />)
     const closureSpy = jest.spyOn(closureFunctions, 'first')
     await waitForDomChange({ container })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"data-first"`
     )
     expect(closureSpy).toHaveBeenCalledTimes(1)
-    
+
     // update, but don't change the id.
     // Function identity should stay the same, and useSWR should not call the function again.
-    await act(() => updateId('first'));
+    await act(() => updateId('first'))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"data-first"`
     )

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -462,7 +462,7 @@ describe('useSWR - refresh', () => {
     await waitForDomChange({ container }) // mount
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 0"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 200))
+      return new Promise(res => setTimeout(res, 210))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
     await act(() => {
@@ -475,49 +475,39 @@ describe('useSWR - refresh', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
     await act(() => {
       fireEvent.click(container.firstElementChild)
-      // 200ms timer will be execute and then setup a new 300ms timer
+      // it will clear 200ms timer and setup a new 300ms timer
       return new Promise(res => setTimeout(res, 200))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 3"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 200))
+      return new Promise(res => setTimeout(res, 110))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 3"`)
     await act(() => {
       // wait for new 300ms timer
-      return new Promise(res => setTimeout(res, 100))
+      return new Promise(res => setTimeout(res, 310))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
     await act(() => {
       fireEvent.click(container.firstElementChild)
-      // 300ms timer will be execute and then setup a new 400ms timer
+      // it will clear 300ms timer and setup a new 400ms timer
       return new Promise(res => setTimeout(res, 300))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 300))
+      return new Promise(res => setTimeout(res, 110))
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
     await act(() => {
       fireEvent.click(container.firstElementChild)
-      // 400ms timer will be execute and then stop
-      return new Promise(res => setTimeout(res, 100))
+      // it will clear 400ms timer and stop
+      return new Promise(res => setTimeout(res, 110))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
     await act(() => {
-      return new Promise(res => setTimeout(res, 400))
+      return new Promise(res => setTimeout(res, 110))
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
-
-    await act(() => {
-      return new Promise(res => setTimeout(res, 400))
-    })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
-
-    await act(() => {
-      return new Promise(res => setTimeout(res, 400))
-    })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 6"`)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
   })
 
   it('should update data upon interval changes -- changes happened during revalidate', async () => {
@@ -538,7 +528,7 @@ describe('useSWR - refresh', () => {
         }
       )
       return (
-        <div>
+        <div onClick={() => setFlag(0)}>
           count: {data} {flag}
         </div>
       )
@@ -579,6 +569,48 @@ describe('useSWR - refresh', () => {
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 1 2"`
+    )
+
+    await act(() => {
+      fireEvent.click(container.firstElementChild)
+      // it will setup a new 200ms timer
+      return new Promise(res => setTimeout(res, 100))
+    })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 1 0"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 100))
+    })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 2 1"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 3 2"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 3 2"`
+    )
+
+    await act(() => {
+      return new Promise(res => setTimeout(res, 200))
+    })
+
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"count: 3 2"`
     )
   })
 


### PR DESCRIPTION
Fix #632 

## Notice
- The old implementation of pooling can't stop timer if refreshInterval changes **during revalidate**. This problem can be solved by using the configRef to get the latest refreshInterval.
- The old implementation of pooling will stop the old timer if refreshInterval changes. ~~But the new implementation of pooling ***will not clear the old timer***~~.