### PR TITLE
chore: use `dequal/lite` for default comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <img src="https://badgen.net/badge/icon/Made%20by%20Vercel?icon=zeit&label&color=black&labelColor=black">
   </a>
   <br/>
-  
+
   <a aria-label="NPM version" href="https://www.npmjs.com/package/swr">
     <img alt="" src="https://badgen.net/npm/v/swr">
   </a>
@@ -24,7 +24,7 @@
 
 SWR is a React Hooks library for remote data fetching.
 
-The name “**SWR**” is derived from `stale-while-revalidate`, a cache invalidation strategy popularized by [HTTP RFC 5861](https://tools.ietf.org/html/rfc5861).  
+The name “**SWR**” is derived from `stale-while-revalidate`, a cache invalidation strategy popularized by [HTTP RFC 5861](https://tools.ietf.org/html/rfc5861).
 **SWR** first returns the data from cache (stale), then sends the fetch request (revalidate), and finally comes with the up-to-date data again.
 
 It features:
@@ -131,7 +131,7 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 - `onSuccess(data, key, config)`: callback function when a request finishes successfully
 - `onError(err, key, config)`: callback function when a request returns an error
 - `onErrorRetry(err, key, config, revalidate, revalidateOps)`: handler for [error retry](#error-retries)
-- `compare(a, b)`: comparison function used to detect when returned data has changed, to avoid spurious rerenders. By default, [fast-deep-equal](https://github.com/epoberezkin/fast-deep-equal) is used.
+- `compare(a, b)`: comparison function used to detect when returned data has changed, to avoid spurious rerenders. By default, [`dequal/lite`](https://github.com/lukeed/dequal) is used.
 
 When under a slow network (2G, <= 70Kbps), `errorRetryInterval` will be 10s, and
 `loadingTimeout` will be 5s by default.
@@ -189,7 +189,7 @@ function App() {
 
 ### Data Fetching
 
-`fetcher` is a function that **accepts the `key`** of SWR, and returns a value or a Promise.  
+`fetcher` is a function that **accepts the `key`** of SWR, and returns a value or a Promise.
 You can use any library to handle data fetching, for example:
 
 ```js
@@ -286,7 +286,7 @@ const { data: orders } = useSWR(user ? ['/api/orders', user] : null, fetchWithUs
 ```
 
 The key of the request is now the combination of both values. SWR **shallowly** compares
-the arguments on every render and triggers revalidation if any of them has changed.  
+the arguments on every render and triggers revalidation if any of them has changed.
 Keep in mind that you should not recreate objects when rendering, as they will be treated as different objects on every render:
 
 ```js
@@ -361,7 +361,7 @@ function Profile() {
 Clicking the button in the example above will send a POST request to modify the remote data, locally update the client data and
 try to fetch the latest one (revalidate).
 
-But many POST APIs will just return the updated data directly, so we don’t need to revalidate again.  
+But many POST APIs will just return the updated data directly, so we don’t need to revalidate again.
 Here’s an example showing the “local mutate - request - update” usage:
 
 ```js
@@ -513,7 +513,7 @@ function prefetch() {
 }
 ```
 
-And use it when you need to preload the **resources** (for example when [hovering](https://github.com/GoogleChromeLabs/quicklink) [a](https://github.com/guess-js/guess) [link](https://instant.page)).  
+And use it when you need to preload the **resources** (for example when [hovering](https://github.com/GoogleChromeLabs/quicklink) [a](https://github.com/guess-js/guess) [link](https://instant.page)).
 Together with techniques like [page prefetching](https://nextjs.org/docs#prefetching-pages) in Next.js, you will be able to load both next page and data instantly.
 
 ### Request Deduplication

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "3.6.4"
   },
   "dependencies": {
-    "fast-deep-equal": "2.0.1"
+    "dequal": "2.0.2"
   },
   "peerDependencies": {
     "react": "^16.11.0"

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import deepEqual from 'fast-deep-equal'
+import { dequal } from 'dequal/lite'
 import isDocumentVisible from './libs/is-document-visible'
 import {
   ConfigInterface,
@@ -66,7 +66,7 @@ const defaultConfig: ConfigInterface = {
   refreshWhenOffline: false,
   shouldRetryOnError: true,
   suspense: false,
-  compare: deepEqual,
+  compare: dequal,
 
   fetcher: url => fetch(url).then(res => res.json())
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,6 +1233,11 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
+dequal@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.2.tgz#85ca22025e3a87e65ef75a7a437b35284a7e319d"
+  integrity sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -1555,7 +1560,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@2.0.1, fast-deep-equal@^2.0.1:
+fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=


### PR DESCRIPTION
Discussion: https://github.com/vercel/swr/discussions/645

> TLDR: `dequal` (especially `dequal/lite`) is smaller and faster. Feature support is identical between FDE and "lite" mode

There are some extra changes in the diff from the pre-commit hook.
FDE is still a part of the lock file through `eslint->ajv` (dev deps).

Build still successful and tests pass locally.