### PR TITLE
Remove unnecessary dependencies from `mutate` and `setSize`

### DIFF
--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -13,7 +13,10 @@ export default function hash(args: any[]): string {
   let key = 'arg'
   for (let i = 0; i < args.length; ++i) {
     let _hash
-    if (args[i] === null || (typeof args[i] !== 'object' && typeof args[i] !== 'function')) {
+    if (
+      args[i] === null ||
+      (typeof args[i] !== 'object' && typeof args[i] !== 'function')
+    ) {
       // need to consider the case that args[i] is a string:
       // args[i]        _hash
       // "undefined" -> '"undefined"'

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -179,6 +179,12 @@ function useSWRInfinite<Data = any, Error = any>(
 
   const swrInfinite = swr as SWRInfiniteResponseInterface<Data, Error>
 
+  // keep the data inside a ref
+  const dataRef = useRef<Data[]>(swrInfinite.data)
+  useEffect(() => {
+    dataRef.current = swrInfinite.data
+  }, [swrInfinite.data])
+
   // extend the SWR API
   const mutate = swrInfinite.mutate
   swrInfinite.size = pageCountRef.current
@@ -186,7 +192,7 @@ function useSWRInfinite<Data = any, Error = any>(
     (data, shouldRevalidate = true) => {
       if (shouldRevalidate && typeof data !== 'undefined') {
         // we only revalidate the pages that are changed
-        const originalData = swrInfinite.data
+        const originalData = dataRef.current
         cache.set(contextCacheKey, { originalData, force: false })
       } else if (shouldRevalidate) {
         // calling `mutate()`, we revalidate all pages
@@ -195,7 +201,7 @@ function useSWRInfinite<Data = any, Error = any>(
 
       return mutate(data, shouldRevalidate)
     },
-    [mutate, swrInfinite.data, contextCacheKey]
+    [mutate, contextCacheKey]
   )
   swrInfinite.setSize = useCallback(
     arg => {


### PR DESCRIPTION
The bound `mutate`/`setSize` from `useSWR` and `useSWRInfinite` should not change over re-renders, so you can include them safely inside hook dependencies (or not include them). It should work just like a `setState` in React.

### Fix 1

This PR removes the `key` dependency from `boundMutate` in `useSWR`, instead we use the ref of the key.

### Fix 2

We used to do this in `useSWRInfinite`:

```js
const swrInfinite = swr
//...
const mutate = swrInfinite.mutate
swrInfinite.mutate = useCallback(..., [mutate])
```

So after one pass, the original object's field `swr.mutate` will be updated to `useCallback(...)`. So upon the next renders, the dependency `[mutate]` will always be considered changed.

Closes #664
