### PR TITLE
Add README to examples

### DIFF
--- a/examples/local-state-sharing/README.md
+++ b/examples/local-state-sharing/README.md
@@ -1,0 +1,36 @@
+# Basic
+
+## One-Click Deploy
+
+Deploy your own SWR project with Vercel.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/project?template=https://github.com/vercel/swr/tree/master/examples/local-state-sharing)
+
+## How to Use
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/vercel/swr/tar.gz/master | tar -xz --strip=2 swr-master/examples/local-state-sharing
+cd local-state-sharing
+```
+
+Install it and run:
+
+```bash
+yarn
+yarn dev
+# or
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://vercel.com/home) ([download](https://vercel.com/download))
+
+```
+now
+```
+
+## The Idea behind the Example
+
+Show how to share local state between React components using SWR.

--- a/examples/suspense/README.md
+++ b/examples/suspense/README.md
@@ -1,0 +1,36 @@
+# Basic
+
+## One-Click Deploy
+
+Deploy your own SWR project with Vercel.
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/project?template=https://github.com/vercel/swr/tree/master/examples/suspense)
+
+## How to Use
+
+Download the example:
+
+```bash
+curl https://codeload.github.com/vercel/swr/tar.gz/master | tar -xz --strip=2 swr-master/examples/suspense
+cd suspense
+```
+
+Install it and run:
+
+```bash
+yarn
+yarn dev
+# or
+npm install
+npm run dev
+```
+
+Deploy it to the cloud with [now](https://vercel.com/home) ([download](https://vercel.com/download))
+
+```
+now
+```
+
+## The Idea behind the Example
+
+Show how to use SWR suspense option with React suspense.


### PR DESCRIPTION
This PR adds README files to examples/suspense and examples/local-state-sharing.

I referred to the readme of other examples.
Please check the section "The Idea behind the Example".