### PR TITLE
Allow passing null as the fetcher function for lazy execution

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type fetcherFn<Data> = (...args: any) => Data | Promise<Data> | null
+export type fetcherFn<Data> = ((...args: any) => Data | Promise<Data>) | null
 export interface ConfigInterface<
   Data = any,
   Error = any,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
+export type fetcherFn<Data> = (...args: any) => Data | Promise<Data> | null
 export interface ConfigInterface<
   Data = any,
   Error = any,


### PR DESCRIPTION
This allows again for lazy execution since passing `undefined` broke with the introduction of a default fetcher in #367