### PR TITLE
Fix race condition when calling mutate synchronously

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -186,6 +186,7 @@ const mutate: mutateInterface = async (
   if (!isMutationAsync) {
     // let's always broadcast in the next tick
     // to dedupe synchronous mutation calls
+    // check out https://github.com/vercel/swr/pull/735 for more details
     await 0
 
     // we skip broadcasting if there's another mutation

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -45,6 +45,12 @@ const CACHE_REVALIDATORS = {}
 const MUTATION_TS = {}
 const MUTATION_END_TS = {}
 
+// generate strictly increasing timestamps
+let now = (() => {
+  let ts = 0
+  return () => ts++
+})()
+
 // setup DOM events listeners for `focus` and `reconnect` actions
 if (!IS_SERVER && window.addEventListener) {
   const revalidate = revalidators => {
@@ -122,28 +128,32 @@ const mutate: mutateInterface = async (
   const [key, , keyErr] = cache.serializeKey(_key)
   if (!key) return
 
-  // if there is no new data, call revalidate against the key
+  // if there is no new data to update, let's just revalidate the key
   if (typeof _data === 'undefined') return trigger(_key, shouldRevalidate)
 
-  // update timestamps
-  MUTATION_TS[key] = Date.now() - 1
+  // update global timestamps
+  MUTATION_TS[key] = now() - 1
   MUTATION_END_TS[key] = 0
 
-  // keep track of timestamps before await asynchronously
+  // track timestamps before await asynchronously
   const beforeMutationTs = MUTATION_TS[key]
   const beforeConcurrentPromisesTs = CONCURRENT_PROMISES_TS[key]
 
   let data, error
+  let isMutationAsync = false
 
   if (_data && typeof _data === 'function') {
     // `_data` is a function, call it passing current cache value
     try {
-      data = await _data(cache.get(key))
+      _data = _data(cache.get(key))
     } catch (err) {
       error = err
     }
-  } else if (_data && typeof _data.then === 'function') {
+  }
+
+  if (_data && typeof _data.then === 'function') {
     // `_data` is a promise
+    isMutationAsync = true
     try {
       data = await _data
     } catch (err) {
@@ -153,7 +163,8 @@ const mutate: mutateInterface = async (
     data = _data
   }
 
-  // check if other mutations have occurred since we've started awaiting, if so then do not persist this change
+  // check if other mutations have occurred since we've started this mutation
+  // if so we don't update cache or broadcast change, just return the data
   if (
     beforeMutationTs !== MUTATION_TS[key] ||
     beforeConcurrentPromisesTs !== CONCURRENT_PROMISES_TS[key]
@@ -163,13 +174,30 @@ const mutate: mutateInterface = async (
   }
 
   if (typeof data !== 'undefined') {
-    // update cached data, avoid notifying from the cache
+    // update cached data
     cache.set(key, data)
   }
+  // always update or reset the error
   cache.set(keyErr, error)
 
   // reset the timestamp to mark the mutation has ended
-  MUTATION_END_TS[key] = Date.now() - 1
+  MUTATION_END_TS[key] = now() - 1
+
+  if (!isMutationAsync) {
+    // let's always broadcast in the next tick
+    // to dedupe synchronous mutation calls
+    await 0
+
+    // we skip broadcasting if there's another mutation
+    // happened synchronously
+    if (
+      beforeMutationTs !== MUTATION_TS[key] ||
+      beforeConcurrentPromisesTs !== CONCURRENT_PROMISES_TS[key]
+    ) {
+      if (error) throw error
+      return data
+    }
+  }
 
   // enter the revalidation stage
   // update existing SWR Hooks' state
@@ -385,7 +413,7 @@ function useSWR<Data = any, Error = any>(
             CONCURRENT_PROMISES[key] = fn(key)
           }
 
-          CONCURRENT_PROMISES_TS[key] = startAt = Date.now()
+          CONCURRENT_PROMISES_TS[key] = startAt = now()
 
           newData = await CONCURRENT_PROMISES[key]
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1523,6 +1523,7 @@ describe('useSWR - local mutation', () => {
     expect(container.textContent).toMatchInlineSnapshot(`"1"`) // directly from cache
     await act(() => new Promise(res => setTimeout(res, 150))) // still suspending
     mutate('mutate-2', 3) // set it to 3. this will drop the ongoing request
+    await 0
     expect(container.textContent).toMatchInlineSnapshot(`"3"`)
     await act(() => new Promise(res => setTimeout(res, 100)))
     expect(container.textContent).toMatchInlineSnapshot(`"3"`)

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1499,7 +1499,8 @@ describe('useSWR - local mutation', () => {
     )
     // call bound mutate
     fireEvent.click(container.firstElementChild)
-    // expect new updated value
+    // expect new updated value (after a tick)
+    await 0
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"data: mutated"`
     )
@@ -1543,9 +1544,14 @@ describe('useSWR - local mutation', () => {
     await act(() => new Promise(res => setTimeout(res, 250)))
     expect(container.textContent).toMatchInlineSnapshot(`"off"`) // Initial state
 
+    mutate('mutate-3', 'on', false)
+
+    // Validate local state is now "on"
+    await 0
+    expect(container.textContent).toMatchInlineSnapshot(`"on"`)
+
     // Simulate toggling "on"
     await act(async () => {
-      mutate('mutate-3', 'on', false)
       expect(
         mutate(
           'mutate-3',
@@ -1560,12 +1566,14 @@ describe('useSWR - local mutation', () => {
       ).resolves.toBe('on')
     })
 
-    // Validate local state is now "on"
-    expect(container.textContent).toMatchInlineSnapshot(`"on"`)
+    mutate('mutate-3', 'off', false)
+
+    // Validate local state is now "off"
+    await 0
+    expect(container.textContent).toMatchInlineSnapshot(`"off"`)
 
     // Simulate toggling "off"
     await act(async () => {
-      mutate('mutate-3', 'off', false)
       expect(
         mutate(
           'mutate-3',
@@ -1580,15 +1588,12 @@ describe('useSWR - local mutation', () => {
       ).resolves.toBe('off')
     })
 
-    // Validate local state is now "off"
-    expect(container.textContent).toMatchInlineSnapshot(`"off"`)
-
     // Wait for toggling "on" promise to resolve, but the "on" mutation is cancelled
-    await act(() => new Promise(res => setTimeout(res, 200)))
+    await act(() => new Promise(res => setTimeout(res, 210)))
     expect(container.textContent).toMatchInlineSnapshot(`"off"`)
 
     // Wait for toggling "off" promise to resolve
-    await act(() => new Promise(res => setTimeout(res, 200)))
+    await act(() => new Promise(res => setTimeout(res, 210)))
     expect(container.textContent).toMatchInlineSnapshot(`"off"`)
   })
 
@@ -1705,6 +1710,39 @@ describe('useSWR - local mutation', () => {
     for (let ref of refs) {
       expect(ref).toEqual(refs[0])
     }
+  })
+
+  it('should dedupe synchronous mutations', async () => {
+    const mutationRecivedValues = []
+    const renderRecivedValues = []
+
+    function Component() {
+      const { data, mutate: boundMutate } = useSWR('mutate-6', () => 0)
+
+      useEffect(() => {
+        setTimeout(() => {
+          // let's mutate twice, synchronously
+          boundMutate(v => {
+            mutationRecivedValues.push(v) // should be 0
+            return 1
+          }, false)
+          boundMutate(v => {
+            mutationRecivedValues.push(v) // should be 1
+            return 2
+          }, false)
+        }, 1)
+      }, [])
+
+      renderRecivedValues.push(data) // should be 0 -> 2, never render 1 in between
+      return null
+    }
+
+    render(<Component />)
+
+    await act(() => new Promise(res => setTimeout(res, 50)))
+
+    expect(mutationRecivedValues).toEqual([0, 1])
+    expect(renderRecivedValues).toEqual([undefined, 0, 2])
   })
 })
 


### PR DESCRIPTION
### Bug

We have this inconsistency issue in current version:

```js
// we call `mutate` twice, synchronously, with a callback that reads the latest value
// let's assume the initial data is `0`

mutate('key', v => v + 1, false)
mutate('key', v => v + 1, false)
```

The data should be `2` after these 2 synchronous mutation calls. However if you test, it is actually `1` (here's a great [bug reproduction](https://codesandbox.io/s/swr-mutate-race-condition-gnrs3) from @derindutz).

The cause is that we are always updating the cache in async (as #619 tries to fix), so the argument `v` passed to the second mutation callback is still `0`. To make it clear, here's a diagram addressing this bug:

![image](https://user-images.githubusercontent.com/3676859/97712707-c76e3700-1af9-11eb-9577-45f3e8c47ba2.png)

### Solution

We at first [tried](https://github.com/vercel/swr/pull/619/files#diff-755ef1ecc6f2f4c1cc601c6091dfcba5f674c653863b70913a115c0856a7b632R141) to make the mutate process synchronous (if the callback is not a promise or async function), but that brings another issue which is intermediate state:

```js
mutate('key', v => v + 1, false)
mutate('key', v => v + 1, false)
```

Now it correctly renders `2` at the end, but there's a moment that `1` was rendered before that. Instead we should "batch" 
synchronous mutations. It is because that the first mutation can't get deduplicated by the second one anymore. They both render the data.

![image](https://user-images.githubusercontent.com/3676859/97713467-d7d2e180-1afa-11eb-8c2c-e70185550add.png)

To ensure the **correctness** of `mutate`, we need to make state broadcasting always asynchronous (kinda like React), but cache needs to be updated ASAP. So the latter mutations will always have the result from the former, but only the last mutation will get rendered:

![image](https://user-images.githubusercontent.com/3676859/97713886-60518200-1afb-11eb-9c45-959f349ee679.png)

The consequence of this fix is, if you mutate something and immediately check the result, it won't be updated. So in our test I added `await 0` to delay the check in the next tick:

```js
mutate('mutate-3', 'off', false)
await 0 // if no `await` here, it's gonna be wrong
expect(container.textContent).toMatchInlineSnapshot(`"off"`)
```

Fixes #566. Related to #619.