### PR TITLE
feat: customizable listener

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,9 @@ const defaultConfig: ConfigInterface = {
 
   fetcher: webPreset.fetcher,
   isOnline: webPreset.isOnline,
-  isDocumentVisible: webPreset.isDocumentVisible
+  isDocumentVisible: webPreset.isDocumentVisible,
+  setOnFocus: webPreset.setOnFocus,
+  setOnConnect: webPreset.setOnConnect
 }
 
 export { cache }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -1,3 +1,6 @@
+const isWindowEventTarget =
+  typeof window !== 'undefined' && window.addEventListener
+
 function isOnline(): boolean {
   if (typeof navigator.onLine !== 'undefined') {
     return navigator.onLine
@@ -17,10 +20,23 @@ function isDocumentVisible(): boolean {
   return true
 }
 
+function setOnFocus(callback) {
+  if (!isWindowEventTarget) return
+  window.addEventListener('focus', callback, false)
+  window.addEventListener('visibilitychange', callback, false)
+}
+
+function setOnConnect(callback) {
+  if (!isWindowEventTarget) return
+  window.addEventListener('online', callback, false)
+}
+
 const fetcher = url => fetch(url).then(res => res.json())
 
 export default {
   isOnline,
   isDocumentVisible,
-  fetcher
+  fetcher,
+  setOnFocus,
+  setOnConnect
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,8 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     revalidateOpts: RevalidateOptionInterface
   ) => void
+  setOnFocus?(callback?): void
+  setOnConnect?(callback?): void
 
   compare?: (a: Data | undefined, b: Data | undefined) => boolean
 }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -46,7 +46,12 @@ const MUTATION_TS = {}
 const MUTATION_END_TS = {}
 
 // setup DOM events listeners for `focus` and `reconnect` actions
-if (!IS_SERVER && window.addEventListener) {
+setup({
+  setOnFocus: defaultConfig.setOnFocus,
+  setOnConnect: defaultConfig.setOnConnect
+})
+
+function setup(preset) {
   const revalidate = revalidators => {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
@@ -56,18 +61,14 @@ if (!IS_SERVER && window.addEventListener) {
   }
 
   // focus revalidate
-  window.addEventListener(
-    'visibilitychange',
-    () => revalidate(FOCUS_REVALIDATORS),
-    false
-  )
-  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
+  if (preset.setOnFocus) {
+    preset.setOnFocus(() => revalidate(FOCUS_REVALIDATORS))
+  }
+
   // reconnect revalidate
-  window.addEventListener(
-    'online',
-    () => revalidate(RECONNECT_REVALIDATORS),
-    false
-  )
+  if (preset.setOnConnect) {
+    preset.setOnConnect(() => revalidate(RECONNECT_REVALIDATORS))
+  }
 }
 
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {


### PR DESCRIPTION
### Goal
provide a way to let other js runtime like RN to customize the way of listening events. then the focus/visible/connect are able to be associated with platform behaviors

### Changes

set the listener attaching process to config

add `config.setOnFocus(callback)`
add `config.setOnConnect(callback)`

for web browser, the fallback will be like following, for RN, it could be sth else

```js
setOnConnect(callback) {
   window && window.addEventListener && window.addEventListener('online', callback, false)
}
```

then `config.setOnConnect` becomes a call that can register event listeners, the event listeners are actually executing the revalidators. i.e.

```
// reconnect revalidate
if (preset.setOnConnect) {
  preset.setOnConnect(() => revalidate(RECONNECT_REVALIDATORS))
}
```

### Unsure Items (😭)

in the setup process, we attach the revalidators to window's focus/visible/online events, I try to change these attachings to customized handlers from config, but the default config cannot be changed at the beginning. unless users have a way to feed the preset to when swr code gets executed.



