### PR TITLE
Fix `mutateCallback` types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -64,8 +64,8 @@ export type triggerInterface = (
   shouldRevalidate?: boolean
 ) => Promise<any>
 export type mutateCallback<Data = any> = (
-  currentValue: Data
-) => Promise<Data> | Data
+  currentValue: undefined | Data
+) => Promise<undefined | Data> | undefined | Data
 export type mutateInterface<Data = any> = (
   key: keyInterface,
   data?: Data | Promise<Data> | mutateCallback<Data>,

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1493,6 +1493,26 @@ describe('useSWR - local mutation', () => {
     expect(callback).toHaveBeenCalledWith('cached data')
   })
 
+  it('should call function with undefined if key not cached', async () => {
+    const increment = jest.fn(currentValue =>
+      currentValue == null ? undefined : currentValue + 1
+    )
+
+    await mutate('dynamic-15.1', increment, false)
+
+    expect(increment).toHaveBeenCalledTimes(1)
+    expect(increment).toHaveBeenLastCalledWith(undefined)
+    expect(increment).toHaveLastReturnedWith(undefined)
+
+    cache.set('dynamic-15.1', 42)
+
+    await mutate('dynamic-15.1', increment, false)
+
+    expect(increment).toHaveBeenCalledTimes(2)
+    expect(increment).toHaveBeenLastCalledWith(42)
+    expect(increment).toHaveLastReturnedWith(43)
+  })
+
   it('should return results of the mutation', async () => {
     // returns the data if promise resolved
     expect(mutate('dynamic-16', Promise.resolve('data'))).resolves.toBe('data')


### PR DESCRIPTION
~1. `Promise<Data | undefined>` because `mutate` implementation handles `undefined` values.~

`mutate` implementation can  pass `undefined` values to the `mutateCallback`: https://github.com/vercel/swr/blob/9e734aaff7d3082fc9fd7945f615fb63621b2bc7/src/use-swr.ts#L138-L144