### PR TITLE
feature: setup once with first config and add test for reconnect options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -74,8 +74,8 @@ const defaultConfig = {
   fetcher: webPreset.fetcher,
   isOnline: webPreset.isOnline,
   isDocumentVisible: webPreset.isDocumentVisible,
-  useOnFocus: webPreset.useOnFocus,
-  useOnConnect: webPreset.useOnConnect
+  setOnFocus: webPreset.setOnFocus,
+  setOnConnect: webPreset.setOnConnect
 } as const
 
 export { cache }

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,8 +74,8 @@ const defaultConfig = {
   fetcher: webPreset.fetcher,
   isOnline: webPreset.isOnline,
   isDocumentVisible: webPreset.isDocumentVisible,
-  setOnFocus: webPreset.setOnFocus,
-  setOnConnect: webPreset.setOnConnect
+  useOnFocus: webPreset.useOnFocus,
+  useOnConnect: webPreset.useOnConnect
 } as const
 
 export { cache }

--- a/src/libs/events.ts
+++ b/src/libs/events.ts
@@ -1,0 +1,39 @@
+import { listenerInterface } from '../types'
+
+function addListener(
+  listenerMap: Record<string, listenerInterface[]>,
+  key: string,
+  callback: listenerInterface
+) {
+  if (!callback) return
+  if (listenerMap[key]) {
+    listenerMap[key].push(callback)
+  } else {
+    listenerMap[key] = [callback]
+  }
+}
+
+function removeListener(
+  listenerMap: Record<string, listenerInterface[]>,
+  key: string,
+  callback: listenerInterface
+) {
+  const listeners = listenerMap[key] || []
+  const index = listeners.indexOf(callback)
+  if (index >= 0) {
+    // 10x faster than splice
+    // https://jsperf.com/array-remove-by-index
+    listeners[index] = listeners[listeners.length - 1]
+    listeners.pop()
+  }
+}
+
+function invokeEvent(
+  listenerMap: Record<string, listenerInterface[]>,
+  key: string
+): void {
+  const listeners = listenerMap[key] || []
+  listeners.forEach(listener => listener())
+}
+
+export { addListener, removeListener, invokeEvent }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -32,7 +32,7 @@ const fetcher = (url: any) => fetch(url).then(res => res.json())
 const invokeFocus = () => invokeEvent(domListenersMap, 'focus')
 const invokeOnline = () => invokeEvent(domListenersMap, 'online')
 
-function useOnFocus(callback: listenerInterface): () => void {
+function setOnFocus(callback: listenerInterface): () => void {
   if (!isWindowEventTarget) return () => {}
   // when first listener attach
   if (hasNoListeners('focus')) {
@@ -51,7 +51,7 @@ function useOnFocus(callback: listenerInterface): () => void {
   }
 }
 
-function useOnConnect(callback: listenerInterface): () => void {
+function setOnConnect(callback: listenerInterface): () => void {
   if (!isWindowEventTarget) return () => {}
   // when first listener attach
   if (hasNoListeners('online')) {
@@ -71,6 +71,6 @@ export default {
   isOnline,
   isDocumentVisible,
   fetcher,
-  useOnFocus,
-  useOnConnect
+  setOnFocus,
+  setOnConnect
 }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -30,7 +30,7 @@ function isDocumentVisible(): boolean {
 const fetcher = (url: any) => fetch(url).then(res => res.json())
 
 const invokeFocus = () => invokeEvent(domListenersMap, 'focus')
-const invokeReconnect = () => invokeEvent(domListenersMap, 'reconnect')
+const invokeOnline = () => invokeEvent(domListenersMap, 'online')
 
 function useOnFocus(callback: listenerInterface): () => void {
   if (!isWindowEventTarget) return () => {}
@@ -54,15 +54,15 @@ function useOnFocus(callback: listenerInterface): () => void {
 function useOnConnect(callback: listenerInterface): () => void {
   if (!isWindowEventTarget) return () => {}
   // when first listener attach
-  if (hasNoListeners('reconnect')) {
-    window.addEventListener('online', invokeReconnect, false)
+  if (hasNoListeners('online')) {
+    window.addEventListener('online', invokeOnline, false)
   }
-  addListener(domListenersMap, 'reconnect', callback)
+  addListener(domListenersMap, 'online', callback)
   return () => {
-    removeListener(domListenersMap, 'reconnect', callback)
+    removeListener(domListenersMap, 'online', callback)
     // when last listener dettach
-    if (hasNoListeners('reconnect')) {
-      window.removeEventListener('online', invokeReconnect, false)
+    if (hasNoListeners('online')) {
+      window.removeEventListener('online', invokeOnline, false)
     }
   }
 }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -1,5 +1,12 @@
+import { listenerInterface } from '../types'
+import { addListener, removeListener, invokeEvent } from './events'
+
 const isWindowEventTarget =
   typeof window !== 'undefined' && window.addEventListener
+
+const domListenersMap: Record<string, listenerInterface[]> = {}
+const hasNoListeners = (event: string): boolean =>
+  !domListenersMap[event] || domListenersMap[event].length === 0
 
 function isOnline(): boolean {
   if (typeof navigator.onLine !== 'undefined') {
@@ -22,21 +29,41 @@ function isDocumentVisible(): boolean {
 
 const fetcher = (url: any) => fetch(url).then(res => res.json())
 
-function useOnFocus(callback: (...args: unknown[]) => void): () => void {
+const invokeFocus = () => invokeEvent(domListenersMap, 'focus')
+const invokeReconnect = () => invokeEvent(domListenersMap, 'reconnect')
+
+function useOnFocus(callback: listenerInterface): () => void {
   if (!isWindowEventTarget) return () => {}
-  window.addEventListener('focus', callback, false)
-  window.addEventListener('visibilitychange', callback, false)
+  // when first listener attach
+  if (hasNoListeners('focus')) {
+    window.addEventListener('focus', invokeFocus, false)
+    window.addEventListener('visibilitychange', invokeFocus, false)
+  }
+  addListener(domListenersMap, 'focus', callback)
+
   return () => {
-    window.removeEventListener('focus', callback, false)
-    window.removeEventListener('visibilitychange', callback, false)
+    removeListener(domListenersMap, 'focus', callback)
+    // when last listener dettach
+    if (hasNoListeners('focus')) {
+      window.removeEventListener('focus', invokeFocus, false)
+      window.removeEventListener('visibilitychange', invokeFocus, false)
+    }
   }
 }
 
-function useOnConnect(callback: (...args: unknown[]) => void): () => void {
+function useOnConnect(callback: listenerInterface): () => void {
   if (!isWindowEventTarget) return () => {}
-  window.addEventListener('online', callback, false)
+  // when first listener attach
+  if (hasNoListeners('reconnect')) {
+    window.addEventListener('online', invokeReconnect, false)
+  }
+  addListener(domListenersMap, 'reconnect', callback)
   return () => {
-    window.removeEventListener('online', callback, false)
+    removeListener(domListenersMap, 'reconnect', callback)
+    // when last listener dettach
+    if (hasNoListeners('reconnect')) {
+      window.removeEventListener('online', invokeReconnect, false)
+    }
   }
 }
 

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -22,21 +22,28 @@ function isDocumentVisible(): boolean {
 
 const fetcher = (url: any) => fetch(url).then(res => res.json())
 
-function setOnFocus(callback: (...args: unknown[]) => void) {
-  if (!isWindowEventTarget) return
+function useOnFocus(callback: (...args: unknown[]) => void): () => void {
+  if (!isWindowEventTarget) return () => {}
   window.addEventListener('focus', callback, false)
   window.addEventListener('visibilitychange', callback, false)
+  return () => {
+    window.removeEventListener('focus', callback, false)
+    window.removeEventListener('visibilitychange', callback, false)
+  }
 }
 
-function setOnConnect(callback: (...args: unknown[]) => void) {
-  if (!isWindowEventTarget) return
+function useOnConnect(callback: (...args: unknown[]) => void): () => void {
+  if (!isWindowEventTarget) return () => {}
   window.addEventListener('online', callback, false)
+  return () => {
+    window.removeEventListener('online', callback, false)
+  }
 }
 
 export default {
   isOnline,
   isDocumentVisible,
   fetcher,
-  setOnFocus,
-  setOnConnect
+  useOnFocus,
+  useOnConnect
 }

--- a/src/swr-config-context.ts
+++ b/src/swr-config-context.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 import { ConfigInterface } from './types'
 
-const SWRConfigContext = createContext<ConfigInterface>({})
+const SWRConfigContext = createContext<ConfigInterface | null>(null)
 SWRConfigContext.displayName = 'SWRConfigContext'
 
 export default SWRConfigContext

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,8 @@ export interface ConfigInterface<
 }
 
 export interface ListenerInterface {
-  setOnFocus: (callback: (...args: any[]) => void) => void
-  setOnConnect: (callback: (...args: any[]) => void) => void
+  setOnFocus?: (callback?: (...args: any[]) => void) => void
+  setOnConnect?: (callback?: (...args: any[]) => void) => void
 }
 
 export interface RevalidateOptionInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,16 +42,15 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     opts: Required<RevalidateOptionInterface>
   ) => void
-  setOnFocus?: ListenerInterface['setOnConnect']
-  setOnConnect?: ListenerInterface['setOnFocus']
+  useOnFocus?: ListenerCallbackInterface
+  useOnConnect?: ListenerCallbackInterface
 
   compare?: (a: Data | undefined, b: Data | undefined) => boolean
 }
 
-export interface ListenerInterface {
-  setOnFocus?: (callback?: (...args: any[]) => void) => void
-  setOnConnect?: (callback?: (...args: any[]) => void) => void
-}
+export type ListenerCallbackInterface = (
+  callback?: (...args: any[]) => void
+) => () => void
 
 export interface RevalidateOptionInterface {
   retryCount?: number

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,14 +42,16 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     opts: Required<RevalidateOptionInterface>
   ) => void
-  useOnFocus?: ListenerCallbackInterface
-  useOnConnect?: ListenerCallbackInterface
+  useOnFocus?: listenerCallbackInterface
+  useOnConnect?: listenerCallbackInterface
 
   compare?: (a: Data | undefined, b: Data | undefined) => boolean
 }
 
-export type ListenerCallbackInterface = (
-  callback?: (...args: any[]) => void
+export type listenerInterface = (...args: any[]) => void
+
+export type listenerCallbackInterface = (
+  callback?: listenerInterface
 ) => () => void
 
 export interface RevalidateOptionInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,8 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     opts: Required<RevalidateOptionInterface>
   ) => void
-  useOnFocus?: listenerCallbackInterface
-  useOnConnect?: listenerCallbackInterface
+  setOnFocus?: listenerCallbackInterface
+  setOnConnect?: listenerCallbackInterface
 
   compare?: (a: Data | undefined, b: Data | undefined) => boolean
 }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -657,6 +657,7 @@ function useSWR<Data = any, Error = any>(
 
       // mark it as unmounted
       unmountedRef.current = true
+
       removeRevalidator(FOCUS_REVALIDATORS, onFocus)
       removeRevalidator(RECONNECT_REVALIDATORS, onReconnect)
       removeRevalidator(CACHE_REVALIDATORS, onUpdate)

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -261,13 +261,13 @@ function useSWR<Data = any, Error = any>(
     if (swrContextConfig !== null) return
     let releaseOnFocus = () => {}
     let releaseOnConnect = () => {}
-    if (config.useOnFocus) {
-      releaseOnFocus = config.useOnFocus(() =>
+    if (config.setOnFocus) {
+      releaseOnFocus = config.setOnFocus(() =>
         invokeRevalidators(FOCUS_REVALIDATORS)
       )
     }
-    if (config.useOnConnect) {
-      releaseOnConnect = config.useOnConnect(() =>
+    if (config.setOnConnect) {
+      releaseOnConnect = config.setOnConnect(() =>
         invokeRevalidators(RECONNECT_REVALIDATORS)
       )
     }
@@ -275,7 +275,7 @@ function useSWR<Data = any, Error = any>(
       releaseOnFocus && releaseOnFocus()
       releaseOnConnect && releaseOnConnect()
     }
-  }, [config.useOnFocus, config.useOnConnect])
+  }, [config.setOnFocus, config.setOnConnect])
 
   const resolveData = () => {
     const cachedData = cache.get(key)
@@ -757,21 +757,18 @@ function useSWR<Data = any, Error = any>(
   return memoizedState
 }
 
-function SWRConfig(props: {
-  children: React.ReactElement
-  value: ConfigInterface
-}) {
+function SWRConfig(props: React.PropsWithChildren<{ value: ConfigInterface }>) {
   const { value: config } = props
   useEffect(() => {
     let releaseOnFocus = () => {}
     let releaseOnConnect = () => {}
-    if (config.useOnFocus) {
-      releaseOnFocus = config.useOnFocus(() =>
+    if (config.setOnFocus) {
+      releaseOnFocus = config.setOnFocus(() =>
         invokeRevalidators(FOCUS_REVALIDATORS)
       )
     }
-    if (config.useOnConnect) {
-      releaseOnConnect = config.useOnConnect(() =>
+    if (config.setOnConnect) {
+      releaseOnConnect = config.setOnConnect(() =>
         invokeRevalidators(RECONNECT_REVALIDATORS)
       )
     }
@@ -779,7 +776,7 @@ function SWRConfig(props: {
       releaseOnFocus && releaseOnFocus()
       releaseOnConnect && releaseOnConnect()
     }
-  }, [config.useOnFocus, config.useOnConnect])
+  }, [config.setOnFocus, config.setOnConnect])
   return createElement(SWRConfigContext.Provider, props)
 }
 

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -2473,7 +2473,7 @@ describe('useSWR - events', () => {
     const { container } = render(
       <SWRConfig
         value={{
-          useOnConnect: callback => {
+          setOnConnect: callback => {
             revalidateOnConnect = callback
             return () => {
               revalidateOnConnect = null

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -2488,7 +2488,6 @@ describe('useSWR - events', () => {
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"hello, "`)
     await waitForDomChange({ container })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"hello, 1"`)
     await act(() => {
       setOnline(true)
       return resolveAfter(150)


### PR DESCRIPTION
### Changes

* only setup **once** across all hooks
* do setup in hook to prevent setup on JS parsing phase. then `setOnFocus` and `setOnConnect` will be available to customize

#### example

in useSWR `options` or in value of `SWRConfig`

```js
{
  setOnConnect((callback) => {
     addEventListener(eventName, callback)
     return () => { removeEventListener(eventName, callback) }
  })
}
```

if there's no such `setOnConnect` / `setOnFocus` from context, it will use setup with default preset. if there's one specified in context, the listeners are set up in the context provider

### Tests
* add custom `setOnConnect` config to support online events in jsdom env. since these options are more platform based, so I believe first setup will be enough
