### PR TITLE
refactor: support SSR in Deno

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -24,7 +24,7 @@ import {
   updaterInterface
 } from './types'
 
-const IS_SERVER = typeof window === 'undefined' || (typeof Deno !== 'undefined' && !!Deno?.version?.deno)
+const IS_SERVER = typeof window === 'undefined' || (typeof Deno !== 'undefined' && Deno !== null && !!Deno.version && !!Deno.version.deno)
 
 // polyfill for requestAnimationFrame
 const rAF = IS_SERVER

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -24,7 +24,7 @@ import {
   updaterInterface
 } from './types'
 
-const IS_SERVER = typeof window === 'undefined'
+const IS_SERVER = typeof window === 'undefined' || (typeof Deno !== 'undefined' && !!Deno?.version?.deno)
 
 // polyfill for requestAnimationFrame
 const rAF = IS_SERVER

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -24,7 +24,8 @@ import {
   updaterInterface
 } from './types'
 
-const IS_SERVER = typeof window === 'undefined' || (typeof Deno !== 'undefined' && Deno !== null && !!Deno.version && !!Deno.version.deno)
+// @ts-ignore
+const IS_SERVER = typeof window === 'undefined' || !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
 
 // polyfill for requestAnimationFrame
 const rAF = IS_SERVER


### PR DESCRIPTION
when use SSR with swr  in Deno i got a warning:

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

```jsx
import useSWR from "https://esm.sh/swr"

export default function Home() {
    const { data } = useSWR('/api/hi', fetcher);

    if (!data) {
        return <div>loading...</div>
    }
    return <div>hello {data.name}!</div>
}
```