### PR TITLE
fix: mark isValidating as false when key is falsy

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -537,7 +537,12 @@ function useSWR<Data = any, Error = any>(
 
   // mounted (client side rendering)
   useIsomorphicLayoutEffect(() => {
-    if (!key) return undefined
+    if (!key) {
+      if (keyRef.current !== key) unmountedRef.current = false
+      keyRef.current = key
+      dispatch({ isValidating: false })
+      return undefined
+    }
 
     // after `key` updates, we need to mark it as mounted
     unmountedRef.current = false

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -537,12 +537,7 @@ function useSWR<Data = any, Error = any>(
 
   // mounted (client side rendering)
   useIsomorphicLayoutEffect(() => {
-    if (!key) {
-      if (keyRef.current !== key) unmountedRef.current = false
-      keyRef.current = key
-      dispatch({ isValidating: false })
-      return undefined
-    }
+    if (!key) return undefined
 
     // after `key` updates, we need to mark it as mounted
     unmountedRef.current = false
@@ -724,7 +719,7 @@ function useSWR<Data = any, Error = any>(
       isValidating: {
         get: function() {
           stateDependencies.current.isValidating = true
-          return stateRef.current.isValidating
+          return key ? stateRef.current.isValidating : false
         },
         enumerable: true
       }

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -2255,6 +2255,36 @@ describe('useSWR - key', () => {
       `"data-second"`
     )
   })
+
+  it('should cleanup state when key turns to empty', async () => {
+    function Page() {
+      const [cnt, setCnt] = useState(1)
+      const { isValidating } = useSWR(
+        cnt === -1 ? '' : `key-empty-${cnt}`,
+        () => new Promise(r => setTimeout(r, 1000))
+      )
+
+      return (
+        <div onClick={() => setCnt(cnt == 2 ? -1 : cnt + 1)}>
+          {isValidating ? 'true' : 'false'}
+        </div>
+      )
+    }
+
+    const { container } = render(<Page />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"true"`)
+    await act(() => {
+      fireEvent.click(container.firstElementChild)
+      return new Promise(res => setTimeout(res, 10))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"true"`)
+    await act(() => {
+      fireEvent.click(container.firstElementChild)
+      return new Promise(res => setTimeout(res, 10))
+    })
+    await new Promise(r => setTimeout(r, 10))
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"false"`)
+  })
 })
 
 describe('useSWR - config callbacks', () => {


### PR DESCRIPTION
Fix #199 

~~* tear down work when key turns to empty, unmount state should be false if it's mounted before.~~
~~* dispatch `isValidating` as `false`~~

scenario: key: v1 -> v2 -> ''

~~in this case, when transfer to empty key the unmountedRef will be set to `true`, which lead dispatch take no effect. so I set it to true if it's not really unmounted.~~
~~then dispatch `isValidating` to `false` to ignore the ongoing requests.~~
~~update `keyRef` to match key, then isValidating getter will retrive states from `stateRef`~~

forcedly return false when key is falsy