### PR TITLE
Return '@null' if args is null ASAP

### DIFF
--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -22,7 +22,6 @@ export default function hash(args: any[]): string {
       // "undefined" -> '"undefined"'
       // undefined   -> 'undefined'
       // 123         -> '123'
-      // null        -> 'null'
       // "null"      -> '"null"'
       if (typeof args[i] === 'string') {
         _hash = '"' + args[i] + '"'

--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -13,7 +13,8 @@ export default function hash(args: any[]): string {
   let key = 'arg'
   for (let i = 0; i < args.length; ++i) {
     if (args[i] === null) {
-      return (key += '@null')
+      key += '@null'
+      continue
     }
     let _hash
     if (typeof args[i] !== 'object' && typeof args[i] !== 'function') {

--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -12,11 +12,11 @@ export default function hash(args: any[]): string {
   if (!args.length) return ''
   let key = 'arg'
   for (let i = 0; i < args.length; ++i) {
+    if (args[i] === null) {
+      return (key += '@null')
+    }
     let _hash
-    if (
-      args[i] === null ||
-      (typeof args[i] !== 'object' && typeof args[i] !== 'function')
-    ) {
+    if (typeof args[i] !== 'object' && typeof args[i] !== 'function') {
       // need to consider the case that args[i] is a string:
       // args[i]        _hash
       // "undefined" -> '"undefined"'


### PR DESCRIPTION
If args[i] is null, always return `@null`.

Now, check `typeof args[i] === 'string'` and run `String(args[i])`. This is unnecessary.
This fix should improve readability and speed by a small amount.