### PR TITLE
dispatch's payload type is actionType and run lint

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -24,9 +24,9 @@ import {
   updaterInterface
 } from './types'
 
-// @ts-ignore
 const IS_SERVER =
   typeof window === 'undefined' ||
+  // @ts-ignore
   !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
 
 // polyfill for requestAnimationFrame

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -25,7 +25,9 @@ import {
 } from './types'
 
 // @ts-ignore
-const IS_SERVER = typeof window === 'undefined' || !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
+const IS_SERVER =
+  typeof window === 'undefined' ||
+  !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
 
 // polyfill for requestAnimationFrame
 const rAF = IS_SERVER
@@ -301,7 +303,7 @@ function useSWR<Data = any, Error = any>(
   useDebugValue(stateRef.current.data)
 
   const rerender = useState(null)[1]
-  let dispatch = useCallback(payload => {
+  let dispatch = useCallback((payload: actionType<Data, Error>) => {
     let shouldUpdateState = false
     for (let k in payload) {
       if (stateRef.current[k] === payload[k]) {


### PR DESCRIPTION
close #773

When I started reading `use-swr.ts`, it was hard to imagine what arguments dispatch was receiving at first. I think it will be somewhat more readable.

Also, after `yarn run lint:fix`, a line break occurred around line 30.