### PR TITLE
fix: do mount check in config callback

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -335,6 +335,7 @@ function useSWR<Data = any, Error = any>(
   const eventsRef = useRef({
     emit: (event, ...params) => {
       if (unmountedRef.current) return
+      if (!initialMountedRef.current) return
       configRef.current[event](...params)
     }
   })


### PR DESCRIPTION
## Description / Observed Behavior
config callback may also cause ```Can't perform a React state update on a component that hasn't mounted yet```

## Repro Steps / Code Example
[Repo](https://codesandbox.io/s/long-sun-me0tz?file=/src/App.tsx)