### PR TITLE
read cache during render

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,10 @@
     "jest": "25.5.4",
     "lint-staged": "8.2.1",
     "prettier": "1.18.2",
-    "react": "16.11.0",
-    "react-dom": "16.11.0",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
+    "react-dom-experimental": "npm:react-dom@experimental",
+    "react-experimental": "npm:react@experimental",
     "ts-jest": "25.5.1",
     "typescript": "3.6.4"
   },

--- a/src/libs/deep-equal.ts
+++ b/src/libs/deep-equal.ts
@@ -15,9 +15,7 @@ export default function deepEqual(foo: any, bar: any) {
 
     if (ctor === Array) {
       if ((len = foo.length) === bar.length) {
-        while (len && deepEqual(foo[len], bar[len])) {
-          len--
-        }
+        while (len-- && deepEqual(foo[len], bar[len]));
       }
       return len === -1
     }

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,87 @@
+import { useRef, useCallback, useState, MutableRefObject } from 'react'
+
+import { useIsomorphicLayoutEffect } from './env'
+import { State } from './types'
+
+type StateKeys = keyof State<any, any>
+type StateDeps = Record<StateKeys, boolean>
+
+/**
+ * An implementation of state with dependency-tracking.
+ */
+export default function useStateWithDeps<Data, Error, S = State<Data, Error>>(
+  state: S,
+  safeCallback: (callback: () => void) => void
+): [
+  MutableRefObject<S>,
+  MutableRefObject<Record<StateKeys, boolean>>,
+  (payload: S) => void
+] {
+  const rerender = useState<object>({})[1]
+
+  const stateRef = useRef(state)
+  useIsomorphicLayoutEffect(() => {
+    stateRef.current = state
+  })
+
+  // If a state property (data, error or isValidating) is accessed by the render
+  // function, we mark the property as a dependency so if it is updated again
+  // in the future, we trigger a rerender.
+  // This is also known as dependency-tracking.
+  const stateDependenciesRef = useRef<StateDeps>({
+    data: false,
+    error: false,
+    isValidating: false
+  })
+
+  /**
+   * @param payload when you want to change stateRef, you should pass value explicitly
+   * @example
+   * ```js
+   * dispatchState({
+   *   isValidating: false
+   *   data: newData // set data to newData
+   *   error: undefined // set error to undefined
+   * })
+   *
+   * dispatchState({
+   *   isValidating: false
+   *   data: undefined // set data to undefined
+   *   error: err // set error to err
+   * })
+   * ```
+   */
+  const setState = useCallback(
+    (payload: S) => {
+      let shouldRerender = false
+
+      for (const _ of Object.keys(payload)) {
+        // Type casting to work around the `for...in` loop
+        // https://github.com/Microsoft/TypeScript/issues/3500
+        const k = _ as keyof S & StateKeys
+
+        // If the property hasn't changed, skip
+        if (stateRef.current[k] === payload[k]) {
+          continue
+        }
+
+        stateRef.current[k] = payload[k]
+
+        // If the property is accessed by the component, a rerender should be
+        // triggered.
+        if (stateDependenciesRef.current[k]) {
+          shouldRerender = true
+        }
+      }
+
+      if (shouldRerender) {
+        safeCallback(() => rerender({}))
+      }
+    },
+    // config.suspense isn't allowed to change during the lifecycle
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  return [stateRef, stateDependenciesRef, setState]
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -11,7 +11,7 @@ type StateDeps = Record<StateKeys, boolean>
  */
 export default function useStateWithDeps<Data, Error, S = State<Data, Error>>(
   state: S,
-  safeCallback: (callback: () => void) => void
+  unmountedRef: MutableRefObject<boolean>
 ): [
   MutableRefObject<S>,
   MutableRefObject<Record<StateKeys, boolean>>,
@@ -35,16 +35,16 @@ export default function useStateWithDeps<Data, Error, S = State<Data, Error>>(
   })
 
   /**
-   * @param payload when you want to change stateRef, you should pass value explicitly
+   * @param payload To change stateRef, pass the values explicitly to setState:
    * @example
    * ```js
-   * dispatchState({
+   * setState({
    *   isValidating: false
    *   data: newData // set data to newData
    *   error: undefined // set error to undefined
    * })
    *
-   * dispatchState({
+   * setState({
    *   isValidating: false
    *   data: undefined // set data to undefined
    *   error: err // set error to err
@@ -74,8 +74,8 @@ export default function useStateWithDeps<Data, Error, S = State<Data, Error>>(
         }
       }
 
-      if (shouldRerender) {
-        safeCallback(() => rerender({}))
+      if (shouldRerender && !unmountedRef.current) {
+        rerender({})
       }
     },
     // config.suspense isn't allowed to change during the lifecycle

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ export type Broadcaster<Data = any, Error = any> = (
   isValidating?: boolean
 ) => void
 
-export type Action<Data, Error> = {
+export type State<Data, Error> = {
   data?: Data
   error?: Error
   isValidating?: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,9 @@ export type responseInterface<Data, Error> = {
 export interface SWRResponse<Data, Error> {
   data?: Data
   error?: Error
+  /**
+   * @deprecated `revalidate` is deprecated, please use `mutate()` for the same purpose.
+   */
   revalidate: () => Promise<boolean>
   mutate: (
     data?: Data | Promise<Data> | MutatorCallback<Data>,

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,22 +25,22 @@ export interface Configuration<
   isPaused: () => boolean
   onLoadingSlow: (
     key: string,
-    config: Readonly<Required<Configuration<Data, Error>>>
+    config: Readonly<Configuration<Data, Error>>
   ) => void
   onSuccess: (
     data: Data,
     key: string,
-    config: Readonly<Required<Configuration<Data, Error>>>
+    config: Readonly<Configuration<Data, Error>>
   ) => void
   onError: (
     err: Error,
     key: string,
-    config: Readonly<Required<Configuration<Data, Error>>>
+    config: Readonly<Configuration<Data, Error>>
   ) => void
   onErrorRetry: (
     err: Error,
     key: string,
-    config: Readonly<Required<Configuration<Data, Error>>>,
+    config: Readonly<Configuration<Data, Error>>,
     revalidate: Revalidator,
     revalidateOpts: Required<RevalidatorOptions>
   ) => void

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -345,9 +345,6 @@ function useSWR<Data = any, Error = any>(
         }
 
         if (shouldUpdateState) {
-          // if component is unmounted, should skip rerender
-          // if component is not mounted, should skip rerender
-          //if (unmountedRef.current || !initialMountedRef.current) return
           rerender({})
         }
       }),
@@ -578,16 +575,14 @@ function useSWR<Data = any, Error = any>(
     // we need to update the data from the cache
     // and trigger a revalidation
 
-    const currentHookData = stateRef.current.data
     const latestKeyedData = resolveData()
 
     // update the state if the key changed (not the inital render) or cache updated
     if (keyRef.current !== key) {
       keyRef.current = key
     }
-    if (!config.compare(currentHookData, latestKeyedData)) {
-      dispatch({ data: latestKeyedData })
-    }
+
+    dispatch({ data: latestKeyedData })
 
     // revalidate with deduping
     const softRevalidate = () => revalidate({ dedupe: true })
@@ -751,17 +746,10 @@ function useSWR<Data = any, Error = any>(
     }
   }
 
-  if (!config.compare(stateRef.current.data, initialData)) {
-    dispatch({
-      data: initialData
-    })
-  }
-
-  if (stateRef.current.error !== initialError) {
-    dispatch({
-      error: initialError
-    })
-  }
+  dispatch({
+    data: initialData,
+    error: initialError
+  })
 
   // define returned state
   // can be memorized since the state is a ref

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -580,10 +580,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (
-      isUpdating ||
-      willRevalidateOnMount()
-    ) {
+    if (isUpdating || willRevalidateOnMount()) {
       if (typeof latestKeyedData !== 'undefined' && !IS_SERVER) {
         // delay revalidate if there's cache
         // to not block the rendering
@@ -761,6 +758,18 @@ function useSWR<Data = any, Error = any>(
     }
   }
 
+  if (!config.compare(stateRef.current.data, initialData)) {
+    dispatch({
+      data: initialData
+    })
+  }
+
+  if (stateRef.current.error !== initialError) {
+    dispatch({
+      error: initialError
+    })
+  }
+
   // define returned state
   // can be memorized since the state is a ref
   const memoizedState = useMemo(() => {
@@ -781,7 +790,7 @@ function useSWR<Data = any, Error = any>(
           if (config.suspense) {
             return latestError
           }
-          return keyRef.current === key ? stateRef.current.error : initialError
+          return stateRef.current.error
         },
         enumerable: true
       },
@@ -791,7 +800,7 @@ function useSWR<Data = any, Error = any>(
           if (config.suspense) {
             return latestData
           }
-          return keyRef.current === key ? stateRef.current.data : initialData
+          return stateRef.current.data
         },
         enumerable: true
       },
@@ -812,16 +821,7 @@ function useSWR<Data = any, Error = any>(
     // `initialData` and `initialError` are not initial values
     // because they are changed during the lifecycle
     // so we should add them in the deps array.
-  }, [
-    revalidate,
-    initialData,
-    initialError,
-    boundMutate,
-    key,
-    config.suspense,
-    latestError,
-    latestData
-  ])
+  }, [revalidate, boundMutate, key, config.suspense, latestError, latestData])
   return memoizedState
 }
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -305,6 +305,8 @@ function useSWR<Data = any, Error = any>(
   const initialMountedRef = useRef(false)
 
   // do unmount check for callbacks
+  // do mounted check in suspense mode
+  // if key changed during the revalidation, old dispatch and config callback should not take effect.
   const safeCallback = useCallback(
     (callback: () => void) => {
       if (unmountedRef.current) return
@@ -642,16 +644,11 @@ function useSWR<Data = any, Error = any>(
       updatedIsValidating,
       dedupe = true
     ) => {
-      // update hook state
-      const validData = () =>
-        typeof updatedData !== 'undefined' &&
-        !config.compare(stateRef.current.data, updatedData)
-
       dispatch({
         error: updatedError,
         isValidating: updatedIsValidating,
         // if data is undefined we should not update stateRef.current.data
-        ...(validData() && {
+        ...(typeof updatedData !== 'undefined' && {
           data: updatedData
         })
       })

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -268,7 +268,10 @@ function useSWR<Data = any, Error = any>(
   }
 
   const resolveIsValidating = () => {
-    return !!cache.get(keyValidating) || (key && willRevalidateOnMount())
+    return (
+      !!cache.get(keyValidating) ||
+      (key && willRevalidateOnMount() ? true : false)
+    )
   }
 
   const initialData = resolveData()

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -311,8 +311,24 @@ function useSWR<Data = any, Error = any>(
     },
     [key]
   )
-
-  let dispatch = useCallback(
+  /**
+   * @param playload when you want to change stateRef, you should pass value explicitly
+   * @example
+   * ```js
+   * dispatch({
+   *   isValidating: false
+   *   data: newData // set data to newData
+   *   error: undefined // set error to undefined
+   * })
+   *
+   * dispatch({
+   *   isValidating: false
+   *   data: undefined // set data to undefined
+   *   error: Error // set error to Error
+   * })
+   * ```
+   */
+  const dispatch = useCallback(
     (payload: Action<Data, Error>) =>
       safeCallback(() => {
         let shouldUpdateState = false
@@ -516,10 +532,9 @@ function useSWR<Data = any, Error = any>(
           return false
         }
 
-        cache.set(keyErr, err)
-
         // get a new error
         // don't use deep equal for errors
+        cache.set(keyErr, err)
 
         // we keep the stale data
         dispatch({
@@ -574,7 +589,6 @@ function useSWR<Data = any, Error = any>(
     // after the component is mounted (hydrated),
     // we need to update the data from the cache
     // and trigger a revalidation
-
     const latestKeyedData = resolveData()
 
     // update the state if the key changed (not the inital render) or cache updated
@@ -633,7 +647,7 @@ function useSWR<Data = any, Error = any>(
       dispatch({
         error: updatedError,
         isValidating: updatedIsValidating,
-        // if data is undefined we should not update the current stateRef
+        // if data is undefined we should not update stateRef.current.data
         ...(validData() && {
           data: updatedData
         })
@@ -746,6 +760,7 @@ function useSWR<Data = any, Error = any>(
     }
   }
 
+  // after mounted, if stateRef does not sync with cache, we should update the stateRef and schedule another update with React
   dispatch({
     data: initialData,
     error: initialError

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -300,6 +300,7 @@ function useSWR<Data = any, Error = any>(
     (callback: () => void) => {
       if (unmountedRef.current) return
       if (key !== keyRef.current) return
+      if (!initialMountedRef.current) return
       callback()
     },
     [key]

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -268,10 +268,7 @@ function useSWR<Data = any, Error = any>(
   }
 
   const resolveIsValidating = () => {
-    return (
-      !!cache.get(keyValidating) ||
-      (key && willRevalidateOnMount() ? true : false)
-    )
+    return !!cache.get(keyValidating) || !!(key && willRevalidateOnMount())
   }
 
   const initialData = resolveData()

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -338,11 +338,7 @@ function useSWR<Data = any, Error = any>(
       safeCallback(() => {
         let shouldUpdateState = false
         const { data, error, isValidating } = payload
-        const keys = Object.keys(payload)
-        if (
-          keys.includes('data') &&
-          !config.compare(stateRef.current.data, data)
-        ) {
+        if ('data' in payload && !config.compare(stateRef.current.data, data)) {
           stateRef.current.data = data
           shouldUpdateState =
             shouldUpdateState || stateDependencies.current.data
@@ -350,7 +346,7 @@ function useSWR<Data = any, Error = any>(
 
         // always update error
         // because it can be `undefined`
-        if (stateRef.current.error !== error) {
+        if ('error' in payload && stateRef.current.error !== error) {
           stateRef.current.error = error
           shouldUpdateState =
             shouldUpdateState || stateDependencies.current.error

--- a/test/use-swr-concurrent-mode.test.tsx
+++ b/test/use-swr-concurrent-mode.test.tsx
@@ -1,0 +1,92 @@
+import { screen, fireEvent } from '@testing-library/react'
+import { createResponse, sleep } from './utils'
+
+describe('useSWR - concurrent mode', () => {
+  let React, ReactDOM, act, useSWR
+
+  beforeEach(() => {
+    jest.resetModules()
+    jest.mock('scheduler', () => require('scheduler/unstable_mock'))
+    jest.mock('react', () => require('react-experimental'))
+    jest.mock('react-dom', () => require('react-dom-experimental'))
+    jest.mock('react-dom/test-utils', () =>
+      require('react-dom-experimental/test-utils')
+    )
+    React = require('react')
+    ReactDOM = require('react-dom')
+    act = require('react-dom/test-utils').act
+    useSWR = require('../src').default
+  })
+
+  it('should fetch data in concurrent mode', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const reactRoot = ReactDOM.unstable_createRoot(root)
+
+    function Page() {
+      const { data } = useSWR(
+        'concurrent-1',
+        () => createResponse('0', { delay: 50 }),
+        {
+          dedupingInterval: 0
+        }
+      )
+      return <div>data:{data}</div>
+    }
+
+    act(() => reactRoot.render(<Page />))
+
+    screen.getByText('data:')
+    await act(() => sleep(100))
+    screen.getByText('data:0')
+
+    act(() => reactRoot.unmount())
+  })
+
+  it('should pause when changing the key inside a transition', async () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const reactRoot = ReactDOM.unstable_createRoot(root)
+
+    const fetcher = (k: string) => createResponse(k, { delay: 100 })
+    // eslint-disable-next-line react/prop-types
+    function Component({ swrKey }) {
+      const { data } = useSWR(swrKey, fetcher, {
+        dedupingInterval: 0,
+        suspense: true
+      })
+
+      return <>data:{data}</>
+    }
+    function Page() {
+      const [startTransition, isPending] = React.unstable_useTransition()
+      const [key, setKey] = React.useState('concurrent-2')
+
+      return (
+        <div onClick={() => startTransition(() => setKey('new-key'))}>
+          isPending:{isPending ? 1 : 0},
+          <React.Suspense fallback="loading">
+            <Component swrKey={key} />
+          </React.Suspense>
+        </div>
+      )
+    }
+
+    act(() => reactRoot.render(<Page />))
+
+    screen.getByText('isPending:0,loading')
+    await act(() => sleep(120))
+    screen.getByText('isPending:0,data:concurrent-2')
+    fireEvent.click(screen.getByText('isPending:0,data:concurrent-2'))
+    await act(() => sleep(10))
+
+    // Pending state
+    screen.getByText('isPending:1,data:concurrent-2')
+
+    // Transition end
+    await act(() => sleep(120))
+    screen.getByText('isPending:0,data:new-key')
+
+    act(() => reactRoot.unmount())
+  })
+})

--- a/test/use-swr-concurrent-mode.test.tsx
+++ b/test/use-swr-concurrent-mode.test.tsx
@@ -1,3 +1,8 @@
+// This file includes some basic test cases for React Concurrent Mode.
+// Due to the nature of global cache, the current SWR implementation will not
+// be perfectly consistent in Concurrent Mode in every intermediate state.
+// Only eventual consistency is guaranteed.
+
 import { screen, fireEvent } from '@testing-library/react'
 import { createResponse, sleep } from './utils'
 

--- a/test/use-swr-key.test.tsx
+++ b/test/use-swr-key.test.tsx
@@ -163,4 +163,29 @@ describe('useSWR - key', () => {
     await act(() => sleep(10))
     screen.getByText('false')
   })
+
+  it('should keep data in sync when key updates', async () => {
+    const fetcher = () => createResponse('test', { delay: 100 })
+    const values = []
+
+    function Page() {
+      const [key, setKey] = useState(null)
+
+      const { data: v1 } = useSWR(key, fetcher)
+      const { data: v2 } = useSWR(key, fetcher)
+
+      values.push([v1, v2])
+
+      return <button onClick={() => setKey('key-sync')}>update key</button>
+    }
+
+    render(<Page />)
+    screen.getByText('update key')
+
+    fireEvent.click(screen.getByText('update key'))
+    await act(() => sleep(120))
+
+    // All values should equal because they're sharing the same key
+    expect(values.some(([a, b]) => a !== b)).toBeFalsy()
+  })
 })

--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -35,8 +35,8 @@ describe('useSWR - refresh', () => {
 
     function Page() {
       const { data } = useSWR('dynamic-2', () => count++, {
-        refreshInterval: 200,
-        dedupingInterval: 300
+        refreshInterval: 100,
+        dedupingInterval: 150
       })
       return <div>count: {data}</div>
     }
@@ -48,26 +48,26 @@ describe('useSWR - refresh', () => {
     // mount
     await screen.findByText('count: 0')
 
-    await act(() => sleep(210)) // no update (deduped)
+    await act(() => sleep(110)) // no update (deduped)
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 0"`)
-    await act(() => sleep(200)) // update
+    await act(() => sleep(100)) // update
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
-    await act(() => sleep(200)) // no update (deduped)
+    await act(() => sleep(100)) // no update (deduped)
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
-    await act(() => sleep(200)) // update
+    await act(() => sleep(100)) // update
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
   })
 
   it('should update data upon interval changes', async () => {
     let count = 0
     function Page() {
-      const [int, setInt] = React.useState(200)
+      const [int, setInt] = React.useState(100)
       const { data } = useSWR('/api', () => count++, {
         refreshInterval: int,
-        dedupingInterval: 100
+        dedupingInterval: 50
       })
       return (
-        <div onClick={() => setInt(num => (num < 400 ? num + 100 : 0))}>
+        <div onClick={() => setInt(num => (num < 200 ? num + 50 : 0))}>
           count: {data}
         </div>
       )
@@ -78,39 +78,39 @@ describe('useSWR - refresh', () => {
     // mount
     await screen.findByText('count: 0')
 
-    await act(() => sleep(210))
+    await act(() => sleep(110))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
-    await act(() => sleep(50))
+    await act(() => sleep(25))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
-    await act(() => sleep(150))
+    await act(() => sleep(75))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
     fireEvent.click(container.firstElementChild)
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
 
-    await act(() => sleep(110))
+    await act(() => sleep(60))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 3"`)
 
-    await act(() => sleep(310))
+    await act(() => sleep(160))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
     fireEvent.click(container.firstElementChild)
     await act(() => {
-      // it will clear 300ms timer and setup a new 400ms timer
-      return sleep(300)
+      // it will clear 150ms timer and setup a new 200ms timer
+      return sleep(150)
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
-    await act(() => sleep(110))
+    await act(() => sleep(60))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
     fireEvent.click(container.firstElementChild)
     await act(() => {
-      // it will clear 400ms timer and stop
-      return sleep(110)
+      // it will clear 200ms timer and stop
+      return sleep(60)
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
-    await act(() => sleep(110))
+    await act(() => sleep(60))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
   })
 
@@ -124,8 +124,8 @@ describe('useSWR - refresh', () => {
         '/interval-changes-during-revalidate',
         () => count++,
         {
-          refreshInterval: shouldPoll ? 200 : 0,
-          dedupingInterval: 100,
+          refreshInterval: shouldPoll ? 100 : 0,
+          dedupingInterval: 50,
           onSuccess() {
             setFlag(value => value + 1)
           }
@@ -144,23 +144,23 @@ describe('useSWR - refresh', () => {
 
     await screen.findByText('count: 0 1')
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 1 2"`
     )
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 1 2"`
     )
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 1 2"`
     )
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 1 2"`
     )
@@ -168,33 +168,33 @@ describe('useSWR - refresh', () => {
     fireEvent.click(container.firstElementChild)
 
     await act(() => {
-      // it will setup a new 200ms timer
-      return sleep(100)
+      // it will setup a new 100ms timer
+      return sleep(50)
     })
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 1 0"`
     )
 
-    await act(() => sleep(100))
+    await act(() => sleep(50))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 2 1"`
     )
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 3 2"`
     )
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 3 2"`
     )
 
-    await act(() => sleep(200))
+    await act(() => sleep(100))
 
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"count: 3 2"`
@@ -301,7 +301,7 @@ describe('useSWR - refresh', () => {
 
   it('the previous interval timer should not call onSuccess callback if key changes too fast', async () => {
     const fetcherWithToken = jest.fn(async token => {
-      await sleep(200)
+      await sleep(100)
       return token
     })
     const onSuccess = jest.fn((data, key) => {
@@ -310,8 +310,8 @@ describe('useSWR - refresh', () => {
     function Page() {
       const [count, setCount] = useState(0)
       const { data } = useSWR(`${count.toString()}-hash`, fetcherWithToken, {
-        refreshInterval: 100,
-        dedupingInterval: 50,
+        refreshInterval: 50,
+        dedupingInterval: 25,
         onSuccess
       })
       return (
@@ -323,20 +323,20 @@ describe('useSWR - refresh', () => {
     const { container } = render(<Page />)
 
     // initial revalidate
-    await act(() => sleep(200))
+    await act(() => sleep(100))
     expect(fetcherWithToken).toBeCalledTimes(1)
     expect(onSuccess).toBeCalledTimes(1)
     expect(onSuccess).toHaveLastReturnedWith(`0-hash 0-hash`)
     // first refresh
-    await act(() => sleep(100))
+    await act(() => sleep(50))
     expect(fetcherWithToken).toBeCalledTimes(2)
     expect(fetcherWithToken).toHaveBeenLastCalledWith('0-hash')
-    await act(() => sleep(200))
+    await act(() => sleep(100))
     expect(onSuccess).toBeCalledTimes(2)
     expect(onSuccess).toHaveLastReturnedWith(`0-hash 0-hash`)
 
     // second refresh start
-    await act(() => sleep(100))
+    await act(() => sleep(50))
     expect(fetcherWithToken).toBeCalledTimes(3)
     expect(fetcherWithToken).toHaveBeenLastCalledWith('0-hash')
     // change the key during revalidation
@@ -344,10 +344,10 @@ describe('useSWR - refresh', () => {
     fireEvent.click(container.firstElementChild)
 
     // first refresh with new key 1
-    await act(() => sleep(100))
+    await act(() => sleep(50))
     expect(fetcherWithToken).toBeCalledTimes(4)
     expect(fetcherWithToken).toHaveBeenLastCalledWith('1-hash')
-    await act(() => sleep(210))
+    await act(() => sleep(110))
     expect(onSuccess).toBeCalledTimes(3)
     expect(onSuccess).toHaveLastReturnedWith(`1-hash 1-hash`)
 

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -23,6 +23,7 @@ describe('useSWR - suspense', () => {
     jest.clearAllMocks()
     jest.restoreAllMocks()
   })
+
   it('should render fallback', async () => {
     function Section() {
       const { data } = useSWR(
@@ -214,6 +215,7 @@ describe('useSWR - suspense', () => {
       `"hello, Initial"`
     )
   })
+
   it('should avoid unnecessary re-renders', async () => {
     let renderCount = 0
     let startRenderCount = 0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4262,7 +4262,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.3"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -4299,15 +4299,31 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-react-dom@16.11.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.11.0.tgz#7e7c4a5a85a569d565c2462f5d345da2dd849af5"
-  integrity sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==
+"react-dom-experimental@npm:react-dom@experimental":
+  version "0.0.0-experimental-7d06b80af"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-0.0.0-experimental-7d06b80af.tgz#a61a2e4463a37703a6bf0a204310f0bf7e040e18"
+  integrity sha512-iI7GbXqDJVNN8RBY3f1WYMKKhBKya8q9yQ7CK/TmYIv+cvZps8+Up4DcKnH7pNDmQRK8hmBT0PChRAfbLRnn0A==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.17.0"
+    scheduler "0.0.0-experimental-7d06b80af"
+
+react-dom@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
+  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.1"
+
+"react-experimental@npm:react@experimental":
+  version "0.0.0-experimental-7d06b80af"
+  resolved "https://registry.yarnpkg.com/react/-/react-0.0.0-experimental-7d06b80af.tgz#c32103deafbf00205f707c9d92c087adbcbfc19b"
+  integrity sha512-NgOfYj+Pflocms/wd+MoVQWuA1epleBvAx4ElrSXDmt4CgqAzYYdFhjsovl7jvUBaU7Vn5Pb1qhocCWyaUQNgw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 react-is@^16.12.0:
   version "16.13.1"
@@ -4324,14 +4340,13 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-react@16.11.0:
-  version "16.11.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
-  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
+react@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
+  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"
@@ -4631,10 +4646,18 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-scheduler@^0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
-  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
+scheduler@0.0.0-experimental-7d06b80af:
+  version "0.0.0-experimental-7d06b80af"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.0.0-experimental-7d06b80af.tgz#dc4d56ba912eb55197481783409a95edef9b323e"
+  integrity sha512-KPMZqd8Un0TZF3tyG3WJCAAAklj0pF86wQh/m1V3C2WYsHSkH2FoGrMmF8au4JvohpFK9026SYIiVwgCgzxPrw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.20.1:
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
+  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
## The problem
In swr, we have stateRef to store the data from the global cache.

1. In first render, stateRef will read data from cache then render it.
2. It will start a revalidation after the first mount and register an updater for the mutate function.
3. During the revalidation, if the fetcher gives new data, the cache and stateRef will update and it will schedule a rerender. So useSWR will return the fresh data
4. when mutate is called, the cache will update synchronously and updater will schedule a rerender to make useSWR return the fresh data
5. when key is changed, it will start a revalidation. repeat 3.

So if the fetcher or the mutate function makes useSWR rerender, the stateRef is always sync with the cache.

But if useSWR rerender because of the sibling hooks rerender or the parent component rerender, it may return 'previous' data and stateRef is not sync with the cache

## Related issues
Fixes #387: the parents rerender because of the mutate function, the child component will render twice, the first render will give a stale value and the second render which is scheduled by the mutate function.

Fixes #463: the sibling hooks rerender because of the fetcher, so other hook will return the 'stale' value.

Fixes #789: the parents rerender because of the timer. so the previous error is returned from the stateRef.

## Repo
|      | react 17                               | react experimental                                     |
|------|----------------------------------------|--------------------------------------------------------|
| #387 | https://codesandbox.io/s/swr-387-hspvd | https://codesandbox.io/s/swr-387-concurrent-mode-3j8iy    |
| #463 | https://codesandbox.io/s/swr-463-9gtkq | https://codesandbox.io/s/swr-463-concurrent-mode-8ng8g |
| #789 | https://codesandbox.io/s/swr-789-m21g2 | https://codesandbox.io/s/swr-789-concurrent-mode-757nt |

## Possible solution

~~what if we do step 1 in every render ?~~

During the render, we pass the current cache to the dispatch function.
* if stateRef is same as cache, nothing will happen.
* if stateRef is not same as cache,  the stateRef will be update and react will schedule another render.
https://github.com/vercel/swr/blob/2248899df280e3d6fcd78bd57d0ed6938d82ce89/src/use-swr.ts#L306-L325