### PR TITLE
First page of useSWRInfinite should reuse the cache from useSWR

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -152,11 +152,8 @@ function useSWRInfinite<Data = any, Error = any>(
         const shouldRevalidatePage =
           revalidateAll ||
           force ||
-          (typeof force === 'undefined' &&
-            i === 0 &&
-            typeof originalData !== 'undefined') ||
-          (typeof originalData !== 'undefined' &&
-            !config.compare(originalData[i], pageData)) ||
+          (typeof force === 'undefined' && i === 0 && originalData) ||
+          (originalData && !config.compare(originalData[i], pageData)) ||
           typeof pageData === 'undefined'
 
         if (shouldRevalidatePage) {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -5,6 +5,7 @@ import SWRConfigContext from './swr-config-context'
 import useSWR from './use-swr'
 
 import { keyType, fetcherFn, ConfigInterface, responseInterface } from './types'
+
 type KeyLoader<Data = any> = (
   index: number,
   previousPageData: Data | null
@@ -151,8 +152,11 @@ function useSWRInfinite<Data = any, Error = any>(
         const shouldRevalidatePage =
           revalidateAll ||
           force ||
-          (typeof force === 'undefined' && i === 0) ||
-          (originalData && !config.compare(originalData[i], pageData)) ||
+          (typeof force === 'undefined' &&
+            i === 0 &&
+            typeof originalData !== 'undefined') ||
+          (typeof originalData !== 'undefined' &&
+            !config.compare(originalData[i], pageData)) ||
           typeof pageData === 'undefined'
 
         if (shouldRevalidatePage) {


### PR DESCRIPTION
Currently `useSWRInfinite` always refetches the first page because of this line:

```js
(typeof force === 'undefined' && i === 0)
```

and it will not reuse the cache from `useSWR`. This PR fixes that so if there is no `originalData` (the first render), but has `pageData` (has cache), we directly return the cache.
