### PR TITLE
fix: ensure `revalidateOnFocus` is work

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -60,7 +60,9 @@ if (!IS_SERVER && window.addEventListener) {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
     for (const key in revalidators) {
-      if (revalidators[key][0]) revalidators[key][0]()
+      for (const fn of revalidators[key]) {
+        if (fn()) break
+      }
     }
   }
 
@@ -579,13 +581,14 @@ function useSWR<Data = any, Error = any>(
 
     let pending = false
     const onFocus = () => {
-      if (pending || !configRef.current.revalidateOnFocus) return
+      if (pending || !configRef.current.revalidateOnFocus) return false
       pending = true
       softRevalidate()
       setTimeout(
         () => (pending = false),
         configRef.current.focusThrottleInterval
       )
+      return true
     }
 
     const onReconnect = () => {

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -1115,7 +1115,8 @@ describe('useSWR - focus', () => {
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 0"`)
   })
-  it('revalidateOnFocus shoule be stateful', async () => {
+
+  it('revalidateOnFocus should be stateful', async () => {
     let value = 0
 
     function Page() {


### PR DESCRIPTION
When using the same hook in multiple places, setting `revalidateOnFocus` in one place does not work