### PR TITLE
Keep isValidating be true when there are two concurrent requests

### DIFF
--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -784,6 +784,40 @@ describe('useSWR - revalidate', () => {
     })
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"1"`)
   })
+
+  it('should keep isValidating be true when there are two concurrent requests', async () => {
+    function Page() {
+      const { isValidating, revalidate } = useSWR(
+        'keep isValidating for concurrent requests',
+        () =>
+          new Promise(res => {
+            setTimeout(res, 200)
+          }),
+        { revalidateOnMount: false }
+      )
+
+      return (
+        <button onClick={revalidate}>{isValidating ? 'true' : 'false'}</button>
+      )
+    }
+
+    const { container } = render(<Page />)
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"false"`)
+
+    await act(async () => {
+      // trigger the first revalidation
+      fireEvent.click(container.firstElementChild)
+      await new Promise(res => setTimeout(res, 100))
+      expect(container.firstChild.textContent).toMatchInlineSnapshot(`"true"`)
+      // trigger the second revalidation
+      fireEvent.click(container.firstElementChild)
+      await new Promise(res => setTimeout(res, 110))
+      // first revalidation is over, second revalidation is still in progress
+      expect(container.firstChild.textContent).toMatchInlineSnapshot(`"true"`)
+      return new Promise(res => setTimeout(res, 100))
+    })
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"false"`)
+  })
 })
 
 describe('useSWR - error', () => {


### PR DESCRIPTION
For case:
            req1 -----> res1
                 req2 ---------------->res2

The `isValidating` was false over the period of res1 and res2, and should be true.
This PR try to fix it.

See test case for detail