### PR TITLE
feature: provide config.isIdle indicating idle state and stop revalidation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,7 @@ const defaultConfig: ConfigInterface = {
   fetcher: webPreset.fetcher,
   isOnline: webPreset.isOnline,
   isDocumentVisible: webPreset.isDocumentVisible,
-  isIdle: () => false
+  isPaused: () => false
 }
 
 export { cache }

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,8 @@ const defaultConfig: ConfigInterface = {
 
   fetcher: webPreset.fetcher,
   isOnline: webPreset.isOnline,
-  isDocumentVisible: webPreset.isDocumentVisible
+  isDocumentVisible: webPreset.isDocumentVisible,
+  isIdle: () => false
 }
 
 export { cache }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface ConfigInterface<
 
   isOnline?: () => boolean
   isDocumentVisible?: () => boolean
-  isIdle?: () => boolean
+  isPaused?: () => boolean
   onLoadingSlow?: (key: string, config: ConfigInterface<Data, Error>) => void
   onSuccess?: (
     data: Data,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,7 @@ export interface ConfigInterface<
 
   isOnline?: () => boolean
   isDocumentVisible?: () => boolean
+  isIdle?: () => boolean
   onLoadingSlow?: (key: string, config: ConfigInterface<Data, Error>) => void
   onSuccess?: (
     data: Data,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -376,6 +376,7 @@ function useSWR<Data = any, Error = any>(
     ): Promise<boolean> => {
       if (!key || !fn) return false
       if (unmountedRef.current) return false
+      if (config.isIdle()) return false
       revalidateOpts = Object.assign({ dedupe: false }, revalidateOpts)
 
       let loading = true

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -376,7 +376,7 @@ function useSWR<Data = any, Error = any>(
     ): Promise<boolean> => {
       if (!key || !fn) return false
       if (unmountedRef.current) return false
-      if (config.isIdle()) return false
+      if (config.isPaused()) return false
       revalidateOpts = Object.assign({ dedupe: false }, revalidateOpts)
 
       let loading = true
@@ -499,6 +499,13 @@ function useSWR<Data = any, Error = any>(
       } catch (err) {
         delete CONCURRENT_PROMISES[key]
         delete CONCURRENT_PROMISES_TS[key]
+
+        if (config.isPaused()) {
+          dispatch({
+            isValidating: false
+          })
+          return false
+        }
 
         cache.set(keyErr, err)
 


### PR DESCRIPTION
### Description

give user ability to decide whether they want revalidation in some edge cases:

* page transition on slow connection that revalidations can cause more errors
* page is in background sometimes they don't want any revalidation

### Changes
* add `config.isPaused()`
* stop doing revalidation on `config.isPaused()` is `true`


related discussion [841](https://github.com/vercel/swr/discussions/841) 