### PR TITLE
fix: clear refresh timer on effects change and check it on starting new timer

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -671,7 +671,7 @@ function useSWR<Data = any, Error = any>(
   }, [key, revalidate])
 
   useIsomorphicLayoutEffect(() => {
-    let timer = null
+    const timer = { id: null }
     const tick = async () => {
       if (
         !stateRef.current.error &&
@@ -685,15 +685,18 @@ function useSWR<Data = any, Error = any>(
         await revalidate({ dedupe: true })
       }
       // Read the latest refreshInterval
-      if (configRef.current.refreshInterval) {
-        timer = setTimeout(tick, configRef.current.refreshInterval)
+      if (configRef.current.refreshInterval && timer.id) {
+        timer.id = setTimeout(tick, configRef.current.refreshInterval)
       }
     }
     if (configRef.current.refreshInterval) {
-      timer = setTimeout(tick, configRef.current.refreshInterval)
+      timer.id = setTimeout(tick, configRef.current.refreshInterval)
     }
     return () => {
-      if (timer) clearTimeout(timer)
+      if (timer.id) {
+        clearTimeout(timer.id)
+        timer.id = null
+      }
     }
   }, [
     config.refreshInterval,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -671,7 +671,7 @@ function useSWR<Data = any, Error = any>(
   }, [key, revalidate])
 
   useIsomorphicLayoutEffect(() => {
-    const timer = { id: null }
+    let timer = null
     const tick = async () => {
       if (
         !stateRef.current.error &&
@@ -685,17 +685,17 @@ function useSWR<Data = any, Error = any>(
         await revalidate({ dedupe: true })
       }
       // Read the latest refreshInterval
-      if (configRef.current.refreshInterval && timer.id) {
-        timer.id = setTimeout(tick, configRef.current.refreshInterval)
+      if (configRef.current.refreshInterval && timer) {
+        timer = setTimeout(tick, configRef.current.refreshInterval)
       }
     }
     if (configRef.current.refreshInterval) {
-      timer.id = setTimeout(tick, configRef.current.refreshInterval)
+      timer = setTimeout(tick, configRef.current.refreshInterval)
     }
     return () => {
-      if (timer.id) {
-        clearTimeout(timer.id)
-        timer.id = null
+      if (timer) {
+        timer = null
+        clearTimeout(timer)
       }
     }
   }, [

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -694,8 +694,8 @@ function useSWR<Data = any, Error = any>(
     }
     return () => {
       if (timer) {
-        timer = null
         clearTimeout(timer)
+        timer = null
       }
     }
   }, [


### PR DESCRIPTION
Fix #852

### Description

https://github.com/vercel/swr/blob/00c5847ce6e95902920933aa1d49c7143f8ce4ba/src/use-swr.ts#L687-L697

when timer is been cancelled, but to the timer procedure, it cannot know if the last timer is cancelled. so it started a new timer again.

steps:
start timer > revalidate > timer is cancelled due to effects > but still start a new timer (with legacy `revalidate`).

### Changes

mark timer as null when cancel it and the cancel state is kept as condition. then swr can avoid to start a new timer again.