### PR TITLE
fix: add protection for navigator

### DIFF
--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -1,5 +1,8 @@
 function isOnline(): boolean {
-  if (typeof navigator.onLine !== 'undefined') {
+  if (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.onLine !== 'undefined'
+  ) {
     return navigator.onLine
   }
   // always assume it's online


### PR DESCRIPTION
related to #522 

`navigator.isOnline` might be directly accessed in some corner cases leading to crashes. 

known runtime: 
* node.js with next.ks
* ink