### PR TITLE
ci: add GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: TypeCheck, Lint, and Test
+
+on: [push]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+    - run: yarn install
+    - run: yarn types:check
+    - run: yarn lint
+    - run: yarn test
+      env:
+        CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: TypeCheck, Lint, and Test
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - next
+  pull_request
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - next
-  pull_request
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
This PR adds GitHub Action for typecheck, test, and lint tasks.
ref. https://github.com/vercel/swr/pull/872#issuecomment-756849888

The setup is based on the configuration of TravisCI.
https://github.com/vercel/swr/blob/master/.travis.yml

The result of a GitHub Action is here.
https://github.com/koba04/swr/runs/1673115189?check_suite_focus=true

If you have any requests like running on various environments (Node versions and OS), I'll add them to the configuration.
I have also left the setting for TravisCI, so let me know if you no longer need the setting, then I'll remove it.
