### PR TITLE
fix: react-hooks/exhaustive-deps warnings

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -90,7 +90,7 @@ function useSWRInfinite<Data = any, Error = any>(
     // not ready
   }
 
-  const rerender = useState<boolean>(false)[1]
+  const [, rerender] = useState<boolean>(false)
 
   // we use cache to pass extra info (context) to fetcher so it can be globally shared
   // here we get the key of the fetcher context cache

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -302,7 +302,7 @@ function useSWR<Data = any, Error = any>(
   // display the data label in the React DevTools next to SWR hooks
   useDebugValue(stateRef.current.data)
 
-  const rerender = useState(null)[1]
+  const [, rerender] = useState(null)
   let dispatch = useCallback((payload: actionType<Data, Error>) => {
     let shouldUpdateState = false
     for (let k in payload) {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -324,7 +324,9 @@ function useSWR<Data = any, Error = any>(
         rerender({})
       }
     },
-    [config.suspense]
+    // config.suspense isn't allowed to change during the lifecycle
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   )
 
   // error ref inside revalidate (is last request errored?)


### PR DESCRIPTION
This is based on #263 and  I've fixed some warnings of `react-hooks/exhaustive-deps`, which can be safely fixed. 

- `renderer` is a setState function that `useState` returns, which is guaranteed to be stable. But the eslint plugin cannot recognize that `const rerender = useState<boolean>(false)[1]` is the setState function, so I've changed the statement.
  - https://reactjs.org/docs/hooks-reference.html#usestate
- The `dispatch` function uses `config.suspense`, but it's not in the deps array, so I've added it to the deps array.

This PR doesn't fix all warnings because some of them seem to be valid and adding missing deps variables might cause issues, so we have to fix the issues carefully and consider adding missing deps variables or `eslint-disable` comments. I'll work on that after this has been merged.