### PR TITLE
ci: remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-{
-  "language": "node_js",
-  "node_js": "node",
-  "script": "npm run types:check && npm run lint && npm test"
-}


### PR DESCRIPTION
I've added a GitHub Action to replace with Travis CI at #879.
The GitHub Action seems to work fine. So I've created a PR to remove Travis CI from this repository.
https://github.com/vercel/swr/actions

It would be nice if this PR is merged after a while.