### PR TITLE
fix: revalidateOnFocus not working on '< iOS 14' 

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -55,7 +55,7 @@ const now = (() => {
 })()
 
 // setup DOM events listeners for `focus` and `reconnect` actions
-if (!IS_SERVER && window.addEventListener) {
+if (!IS_SERVER && window.addEventListener && document.addEventListener) {
   const revalidate = revalidators => {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
@@ -65,7 +65,7 @@ if (!IS_SERVER && window.addEventListener) {
   }
 
   // focus revalidate
-  window.addEventListener(
+  document.addEventListener(
     'visibilitychange',
     () => revalidate(FOCUS_REVALIDATORS),
     false

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -55,7 +55,7 @@ const now = (() => {
 })()
 
 // setup DOM events listeners for `focus` and `reconnect` actions
-if (!IS_SERVER) {
+if (!IS_SERVER && window.addEventListener && document.addEventListener) {
   const revalidate = revalidators => {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
@@ -64,39 +64,19 @@ if (!IS_SERVER) {
     }
   }
 
-  const hasWindow = typeof window !== 'undefined'
-  const hasDocument = typeof document !== 'undefined'
-  if (hasWindow) {
-    // focus revalidate
-    if (hasDocument) {
-      // `window.addEventListener('visibilitychange', ...)` doesn't work on 'iOS < 14'
-      // Use `document.addEventListener` instead
-      // Ref: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event
-      document.addEventListener(
-        'visibilitychange',
-        () => revalidate(FOCUS_REVALIDATORS),
-        false
-      )
-    } else {
-      window.addEventListener(
-        'visibilitychange',
-        () => revalidate(FOCUS_REVALIDATORS),
-        false
-      )
-    }
-    window.addEventListener(
-      'focus',
-      () => revalidate(FOCUS_REVALIDATORS),
-      false
-    )
-
-    // reconnect revalidate
-    window.addEventListener(
-      'online',
-      () => revalidate(RECONNECT_REVALIDATORS),
-      false
-    )
-  }
+  // focus revalidate
+  document.addEventListener(
+    'visibilitychange',
+    () => revalidate(FOCUS_REVALIDATORS),
+    false
+  )
+  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
+  // reconnect revalidate
+  window.addEventListener(
+    'online',
+    () => revalidate(RECONNECT_REVALIDATORS),
+    false
+  )
 }
 
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -55,7 +55,7 @@ const now = (() => {
 })()
 
 // setup DOM events listeners for `focus` and `reconnect` actions
-if (!IS_SERVER && window.addEventListener && document.addEventListener) {
+if (!IS_SERVER) {
   const revalidate = revalidators => {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
@@ -64,19 +64,39 @@ if (!IS_SERVER && window.addEventListener && document.addEventListener) {
     }
   }
 
-  // focus revalidate
-  document.addEventListener(
-    'visibilitychange',
-    () => revalidate(FOCUS_REVALIDATORS),
-    false
-  )
-  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
-  // reconnect revalidate
-  window.addEventListener(
-    'online',
-    () => revalidate(RECONNECT_REVALIDATORS),
-    false
-  )
+  const hasWindow = typeof window !== 'undefined'
+  const hasDocument = typeof document !== 'undefined'
+  if (hasWindow) {
+    // focus revalidate
+    if (hasDocument) {
+      // `window.addEventListener('visibilitychange', ...)` doesn't work on 'iOS < 14'
+      // Use `document.addEventListener` instead
+      // Ref: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event
+      document.addEventListener(
+        'visibilitychange',
+        () => revalidate(FOCUS_REVALIDATORS),
+        false
+      )
+    } else {
+      window.addEventListener(
+        'visibilitychange',
+        () => revalidate(FOCUS_REVALIDATORS),
+        false
+      )
+    }
+    window.addEventListener(
+      'focus',
+      () => revalidate(FOCUS_REVALIDATORS),
+      false
+    )
+
+    // reconnect revalidate
+    window.addEventListener(
+      'online',
+      () => revalidate(RECONNECT_REVALIDATORS),
+      false
+    )
+  }
 }
 
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {


### PR DESCRIPTION
I found that revalidateOnFocus is not working on iOS 13. 
To fix, `window.addEventListener('visibilityevent', callback)` should be replaced by `document.addEventListener('visibilityevent', callback)`

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event
![image](https://user-images.githubusercontent.com/27319079/104179699-a1490980-544f-11eb-890e-44c9ebafa3e0.png)

