### PR TITLE
refactor: use getter functions to avoid unnecessary re-renders

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -1,11 +1,4 @@
-import {
-  useContext,
-  useRef,
-  useState,
-  useMemo,
-  useEffect,
-  useCallback
-} from 'react'
+import { useContext, useRef, useState, useEffect, useCallback } from 'react'
 
 import defaultConfig, { cache } from './config'
 import SWRConfigContext from './swr-config-context'
@@ -191,8 +184,6 @@ function useSWRInfinite<Data = any, Error = any>(
     dataRef.current = swr.data
   }, [swr.data])
 
-  const boundMutate = useMemo(() => swr.mutate, [swr])
-
   const mutate = useCallback(
     (data, shouldRevalidate = true) => {
       if (shouldRevalidate && typeof data !== 'undefined') {
@@ -204,9 +195,9 @@ function useSWRInfinite<Data = any, Error = any>(
         cache.set(contextCacheKey, { force: true })
       }
 
-      return boundMutate(data, shouldRevalidate)
+      return swr.mutate(data, shouldRevalidate)
     },
-    [boundMutate, contextCacheKey]
+    [swr.mutate, contextCacheKey]
   )
 
   // extend the SWR API
@@ -226,11 +217,23 @@ function useSWRInfinite<Data = any, Error = any>(
   )
 
   // Use getter functions to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object
-  return Object.assign(swr, {
+  return {
+    get error() {
+      return swr.error
+    },
+    get data() {
+      return swr.data
+    },
+    get revalidate() {
+      return swr.revalidate
+    },
+    get isValidating() {
+      return swr.isValidating
+    },
     mutate,
     size,
     setSize
-  }) as SWRInfiniteResponseInterface<Data, Error>
+  } as SWRInfiniteResponseInterface<Data, Error>
 }
 
 export {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -1,4 +1,11 @@
-import { useContext, useRef, useState, useEffect, useCallback } from 'react'
+import {
+  useContext,
+  useRef,
+  useState,
+  useMemo,
+  useEffect,
+  useCallback
+} from 'react'
 
 import defaultConfig, { cache } from './config'
 import SWRConfigContext from './swr-config-context'
@@ -184,6 +191,8 @@ function useSWRInfinite<Data = any, Error = any>(
     dataRef.current = swr.data
   }, [swr.data])
 
+  const boundMutate = useMemo(() => swr.mutate, [swr])
+
   const mutate = useCallback(
     (data, shouldRevalidate = true) => {
       if (shouldRevalidate && typeof data !== 'undefined') {
@@ -195,9 +204,9 @@ function useSWRInfinite<Data = any, Error = any>(
         cache.set(contextCacheKey, { force: true })
       }
 
-      return swr.mutate(data, shouldRevalidate)
+      return boundMutate(data, shouldRevalidate)
     },
-    [swr.mutate, contextCacheKey]
+    [boundMutate, contextCacheKey]
   )
 
   // extend the SWR API
@@ -217,23 +226,11 @@ function useSWRInfinite<Data = any, Error = any>(
   )
 
   // Use getter functions to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object
-  return {
-    get error() {
-      return swr.error
-    },
-    get data() {
-      return swr.data
-    },
-    get revalidate() {
-      return swr.revalidate
-    },
-    get isValidating() {
-      return swr.isValidating
-    },
+  return Object.assign(swr, {
     mutate,
     size,
     setSize
-  } as SWRInfiniteResponseInterface<Data, Error>
+  }) as SWRInfiniteResponseInterface<Data, Error>
 }
 
 export {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -216,12 +216,12 @@ function useSWRInfinite<Data = any, Error = any>(
     [mutate, pageCountCacheKey]
   )
 
-  return {
-    ...swr,
+  // Use Object.assign to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object
+  return Object.assign({}, swr, {
     mutate,
     size,
     setSize
-  } as SWRInfiniteResponseInterface<Data, Error>
+  }) as SWRInfiniteResponseInterface<Data, Error>
 }
 
 export {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -217,23 +217,26 @@ function useSWRInfinite<Data = any, Error = any>(
   )
 
   // Use getter functions to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object
-  return {
-    get error() {
-      return swr.error
+  const swrInfinite = { size, setSize, mutate }
+  Object.defineProperties(swrInfinite, {
+    error: {
+      get: () => swr.error,
+      enumerable: true
     },
-    get data() {
-      return swr.data
+    data: {
+      get: () => swr.data,
+      enumerable: true
     },
-    get revalidate() {
-      return swr.revalidate
+    revalidate: {
+      get: () => swr.revalidate,
+      enumerable: true
     },
-    get isValidating() {
-      return swr.isValidating
-    },
-    mutate,
-    size,
-    setSize
-  } as SWRInfiniteResponseInterface<Data, Error>
+    isValidating: {
+      get: () => swr.isValidating,
+      enumerable: true
+    }
+  })
+  return swrInfinite as SWRInfiniteResponseInterface<Data, Error>
 }
 
 export {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -216,12 +216,24 @@ function useSWRInfinite<Data = any, Error = any>(
     [mutate, pageCountCacheKey]
   )
 
-  // Use Object.assign to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object
-  return Object.assign({}, swr, {
+  // Use getter functions to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object
+  return {
+    get error() {
+      return swr.error
+    },
+    get data() {
+      return swr.data
+    },
+    get revalidate() {
+      return swr.revalidate
+    },
+    get isValidating() {
+      return swr.isValidating
+    },
     mutate,
     size,
     setSize
-  }) as SWRInfiniteResponseInterface<Data, Error>
+  } as SWRInfiniteResponseInterface<Data, Error>
 }
 
 export {


### PR DESCRIPTION
This PR fixes #780. I've left a comment on the intention.