### PR TITLE
 Update default fetcher documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const { data, error, isValidating, mutate } = useSWR(key, fetcher, options)
 #### Options
 
 - `suspense = false`: enable React Suspense mode [(details)](#suspense-mode)
-- `fetcher = undefined`: the default fetcher function
+- `fetcher = window.fetch`: the default fetcher function
 - `initialData`: initial data to be returned (note: This is per-hook)
 - `revalidateOnMount`: enable or disable automatic revalidation when component is mounted (by default revalidation occurs on mount when initialData is not set, use this flag to force behavior)
 - `revalidateOnFocus = true`: auto revalidate when window gets focused


### PR DESCRIPTION
Ran into issues with this when using SWR for local state sharing. It seems that the default value for the fetcher is actually `window.fetch` and not `undefined`:
https://github.com/vercel/swr/blob/master/src/config.ts#L71