### PR TITLE
Revert "First page of useSWRInfinite should reuse the cache from useSWR"

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -5,7 +5,6 @@ import SWRConfigContext from './swr-config-context'
 import useSWR from './use-swr'
 
 import { keyType, fetcherFn, ConfigInterface, responseInterface } from './types'
-
 type KeyLoader<Data = any> = (
   index: number,
   previousPageData: Data | null
@@ -152,7 +151,7 @@ function useSWRInfinite<Data = any, Error = any>(
         const shouldRevalidatePage =
           revalidateAll ||
           force ||
-          (typeof force === 'undefined' && i === 0 && originalData) ||
+          (typeof force === 'undefined' && i === 0) ||
           (originalData && !config.compare(originalData[i], pageData)) ||
           typeof pageData === 'undefined'
 

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -6,7 +6,7 @@ import {
   act
 } from '@testing-library/react'
 
-import { useSWRInfinite, mutate } from '../src'
+import { useSWRInfinite } from '../src'
 
 describe('useSWRInfinite', () => {
   it('should render the first page component', async () => {
@@ -59,7 +59,7 @@ describe('useSWRInfinite', () => {
     let pageData = ['apple', 'banana', 'pineapple']
 
     function Page() {
-      const { data, mutate: boundMutate } = useSWRInfinite<string, string>(
+      const { data, mutate } = useSWRInfinite<string, string>(
         index => [`pagetest-3`, index],
         async (_, index) => {
           await new Promise(res => setTimeout(res, 100))
@@ -74,7 +74,7 @@ describe('useSWRInfinite', () => {
         <div
           onClick={() => {
             // reload the entire list
-            boundMutate()
+            mutate()
           }}
         >
           {data}
@@ -440,27 +440,5 @@ describe('useSWRInfinite', () => {
     for (let setSize of setters) {
       expect(setSize).toEqual(setters[0])
     }
-  })
-
-  it('should share initial cache from `useSWR`', async () => {
-    const cachedData = new Date().toISOString()
-    mutate('shared-cache-0', cachedData)
-
-    function Page() {
-      const { data } = useSWRInfinite<string, string>(
-        index => `shared-cache-${index}`,
-        async () => {
-          await new Promise(res => setTimeout(res, 200))
-          return cachedData
-        }
-      )
-
-      return <div>{data}</div>
-    }
-    const { container } = render(<Page />)
-    expect(container.textContent).toMatchInlineSnapshot(`""`)
-    // after a rerender we should already have the cached data rendered
-    await act(() => new Promise(res => setTimeout(res, 10)))
-    expect(container.textContent).toMatchInlineSnapshot(`"${cachedData}"`)
   })
 })


### PR DESCRIPTION
Reverts vercel/swr#799

It's causing the first page not revalidating once it has cache.