### PR TITLE
Fix the revalidation condition of the first page

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -85,7 +85,7 @@ function useSWRInfinite<Data = any, Error = any>(
   // get the serialized key of the first page
   let firstPageKey: string | null = null
   try {
-    ;[firstPageKey] = cache.serializeKey(getKey(0, null))
+    [firstPageKey] = cache.serializeKey(getKey(0, null))
   } catch (err) {
     // not ready
   }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -150,20 +150,17 @@ function useSWRInfinite<Data = any, Error = any>(
         // should fetch (or revalidate) if:
         // - `revalidateAll` is enabled
         // - `mutate()` called
-        // - it's the first page and one of:
-        //   - first render (no dataRef) and no cache (no pageData)
-        //   - not first render (has dataRef) and cache exists (has pageData)
-        // - cache has updated
-        // - the offset has changed so the cache is missing
+        // - the cache is missing
+        // - it's the first page and it's not the first render
+        // - cache has changed
         const shouldFetchPage =
           revalidateAll ||
           force ||
+          typeof pageData === 'undefined' ||
           (typeof force === 'undefined' &&
             i === 0 &&
-            (typeof dataRef.current === 'undefined') ===
-              (typeof pageData === 'undefined')) ||
-          (originalData && !config.compare(originalData[i], pageData)) ||
-          typeof pageData === 'undefined'
+            typeof dataRef.current !== 'undefined') ||
+          (originalData && !config.compare(originalData[i], pageData))
 
         if (shouldFetchPage) {
           if (pageArgs !== null) {

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -463,4 +463,27 @@ describe('useSWRInfinite', () => {
     await act(() => new Promise(res => setTimeout(res, 10)))
     expect(container.textContent).toMatchInlineSnapshot(`"${cachedData}"`)
   })
+
+  it('should not break refreshInterval', async () => {
+    let value = 0
+    function Page() {
+      const { data } = useSWRInfinite<number, string>(
+        index => `interval-0-${index}`,
+        () => value++,
+        {
+          dedupingInterval: 0,
+          refreshInterval: 100
+        }
+      )
+
+      return <div>{data}</div>
+    }
+    const { container } = render(<Page />)
+    expect(container.textContent).toMatchInlineSnapshot(`""`)
+    await waitForDomChange({ container }) // mount
+    expect(container.textContent).toMatchInlineSnapshot(`"0"`)
+    // after 300ms the rendered result should be 3
+    await act(() => new Promise(res => setTimeout(res, 310)))
+    expect(container.textContent).toMatchInlineSnapshot(`"3"`)
+  })
 })

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -464,8 +464,6 @@ describe('useSWRInfinite', () => {
     }
     const { container } = render(<Page />)
     expect(container.textContent).toMatchInlineSnapshot(`""`)
-    await waitForDomChange({ container }) // mount
-    expect(container.textContent).toMatchInlineSnapshot(`"0"`)
     // after 300ms the rendered result should be 3
     await act(() => new Promise(res => setTimeout(res, 310)))
     expect(container.textContent).toMatchInlineSnapshot(`"3"`)


### PR DESCRIPTION
This PR fixes a `useSWRInfinite` bug introduced in #799 by me (thanks @pacocoursey for reporting). To reproduce, just simply use `refreshInterval` with `useSWRInfinite`, and the first page will never be revalidated:

Reproduction: https://codesandbox.io/s/swr-infinite-forked-mi7rf?file=/src/App.js

## Postmortem and Fix

The cause of the bug is this LOC: 

```js
(typeof force === 'undefined' && i === 0 && originalData) ||
```

...to determine if we should fetch this page or not, which can break down into:
- `typeof force === 'undefined`: It's not a force revalidation, like `mutate()`.
- `i === 0`: It's the first page, we don't want to revalidate every page upon focus.
- `originalData`: It's not the first render. **This is the mistake**.

What we want to achieve for `useSWRInfinite` is this experience: If we have the cache and the screen is empty (first render), we display the cache ASAP. So we added the third condition above. But we should check `dataRef` instead of `originalData` (`originalData` is specifically for mutations).

Also added another test.