### PR TITLE
feat: warn for chaning the config.suspense option during the lifecycle

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -221,6 +221,8 @@ const mutate: mutateInterface = async (
   return data
 }
 
+let didWarnChangingConfigSuspense = false
+
 function useSWR<Data = any, Error = any>(
   key: keyInterface
 ): responseInterface<Data, Error>
@@ -270,6 +272,20 @@ function useSWR<Data = any, Error = any>(
   useIsomorphicLayoutEffect(() => {
     configRef.current = config
   })
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (
+      !didWarnChangingConfigSuspense &&
+      configRef.current &&
+      typeof configRef.current.suspense !== 'undefined' &&
+      configRef.current.suspense !== config.suspense
+    ) {
+      console.error(
+        'config.suspense should not be changed during the lifecycle'
+      )
+      didWarnChangingConfigSuspense = true
+    }
+  }
 
   if (typeof fn === 'undefined') {
     // use the global fetcher


### PR DESCRIPTION
This PR follows up https://github.com/vercel/swr/pull/886#discussion_r555957124.

This adds a warning for changing the `config.suspense` option during the lifecycle. Printing the warning on every render is noisy, so this prints the warning only once, which is a technique used in the internal of React.

This also introduces the concept of development warnings. The implementation depends on the value of `process.env.NODE_ENV`, which is the same way that React does. `swr` is a library for React hooks, so I think `swr` can depend on the same way with React.
https://reactjs.org/docs/optimizing-performance.html#use-the-production-build
Should I mention `process.env.NODE_ENV` in the documentation?

I think the concept of development warnings makes `swr` more developer-friendly because it makes it possible to add more warnings without affecting production builds.
