### PR TITLE
fix: add server check back before calling rAF

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -577,7 +577,7 @@ function useSWR<Data = any, Error = any>(
       config.revalidateOnMount ||
       (!config.initialData && config.revalidateOnMount === undefined)
     ) {
-      if (typeof latestKeyedData !== 'undefined') {
+      if (typeof latestKeyedData !== 'undefined' && !IS_SERVER) {
         // delay revalidate if there's cache
         // to not block the rendering
         rAF(softRevalidate)


### PR DESCRIPTION
Update from 0.2.3 to 0.3.0 would cause issues when running my Jest tests, it would report an undefined function. After some research, the function in question is `rAF` which is set to `null` in server environments. 

Looking at the diff between 0.2.3 and 0.3.0 (https://github.com/vercel/swr/compare/0.2.3...0.3.0) there used to be a check for `IS_SERVER` but it was removed (`rAF` is named as `rIC` still in the diff).

Since im not that familiar with the project i'm not sure if this is meant to be like this or if adding back the `IS_SERVER` is okay, but i wanted to approach the issue via a PR rather than an issue.