### PR TITLE
refactor: fix all react-hooks/exhaustive-deps warnings in tests

### DIFF
--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -34,6 +34,8 @@ describe('useSWRInfinite', () => {
       useEffect(() => {
         // load next page if the current one is ready
         if (size <= 2) setSize(size + 1)
+        // The setSize function is guaranteed to be referential equal
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [size])
 
       return <div>{data}</div>

--- a/test/use-swr-int.test.tsx
+++ b/test/use-swr-int.test.tsx
@@ -216,6 +216,8 @@ describe('useSWR', () => {
           revalidate()
         }, 200)
         return () => clearTimeout(timeout)
+        // the revalidate function is always the same reference because the key of the useSWR is static (broadcast-3)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [])
       return <>{isValidating ? 'true' : 'false'}</>
     }

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -520,6 +520,8 @@ describe('useSWR - local mutation', () => {
             return 2
           }, false)
         }, 1)
+        // the mutate function is guaranteed to be the same reference
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [])
 
       renderRecivedValues.push(data) // should be 0 -> 2, never render 1 in between

--- a/test/use-swr.test.tsx
+++ b/test/use-swr.test.tsx
@@ -240,6 +240,8 @@ describe('useSWR', () => {
           revalidate()
         }, 200)
         return () => clearTimeout(timeout)
+        // the revalidate function is always the same reference because the key of the useSWR is static (broadcast-3)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [])
       return <>{isValidating ? 'true' : 'false'}</>
     }
@@ -1888,6 +1890,8 @@ describe('useSWR - local mutation', () => {
             return 2
           }, false)
         }, 1)
+        // the mutate function is guaranteed to be the same reference
+        // eslint-disable-next-line react-hooks/exhaustive-deps
       }, [])
 
       renderRecivedValues.push(data) // should be 0 -> 2, never render 1 in between


### PR DESCRIPTION
This is a PR to follow up #886 and fixes all `react-hooks/exhaustive-deps` warnings in tests.
They can safely be ignored in these cases.

As I mentioned on https://github.com/vercel/swr/pull/901#issuecomment-760216332, there are duplicated tests and I've fixed each warning twice.

I'll remove the tests if there is no reason for the duplication.