### PR TITLE
docs: use a fake GraphQL endpoint instead of graph.cool

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,7 @@ Or using GraphQL:
 ```js
 import { request } from 'graphql-request'
 
-const API = 'https://api.graph.cool/simple/v1/movies'
-const fetcher = query => request(API, query)
+const fetcher = query => request('/api/graphql', query)
 
 function App() {
   const { data, error } = useSWR(


### PR DESCRIPTION
fixes #353 
I've replaced a Graph.Cool endpoint with a fake GraphQL endpoint.