### PR TITLE
refactor: fix all react-hooks/exhaustive-deps warnings in useSWRInfinite

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -118,6 +118,8 @@ function useSWRInfinite<Data = any, Error = any>(
     } else {
       didMountRef.current = true
     }
+    // initialSize isn't allowed to change during the lifecycle
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firstPageKey])
 
   // actual swr of all pages
@@ -197,7 +199,9 @@ function useSWRInfinite<Data = any, Error = any>(
 
       return swr.mutate(data, shouldRevalidate)
     },
-    [swr.mutate, contextCacheKey]
+    // swr.mutate is always the same reference
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [contextCacheKey]
   )
 
   // extend the SWR API


### PR DESCRIPTION
This is a PR to follow up #902 and #886, and fixes all react-hooks/exhaustive-deps warnings in `useSWRInfinite`.
I've disabled the warnings by `eslint-disable-next-line` comments and removed `swr.mutate` because it's an immutable reference.
https://github.com/vercel/swr/blob/81824c7df8666817075d386854711bfc153cc99a/src/use-swr.ts#L348-L353