### PR TITLE
chore: add a comment why fetcher accepts null

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+// `null` is used for a hack to manage shared state with SWR
+// https://github.com/vercel/swr/pull/918
 export type fetcherFn<Data> = ((...args: any) => Data | Promise<Data>) | null
 export interface ConfigInterface<
   Data = any,


### PR DESCRIPTION
**UPDATED** This PR adds a comment to describe why `fetchFn` accepts `null`.

-----

This PR removes `null` from the type definition for `fetchFn`, but please correct me if I'm wrong.
I couldn't find any documentation about the behavior for passing null as a `fetcher` function. A case with `undefined` is documented though.
I also couldn't find any implementation for the case.

Is SWR supporting the case? If so, what is the expected behavior for the case?

