### PR TITLE
refactor: fix all react-hooks/exhaustive-deps warnings in useSWR

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -549,6 +549,16 @@ function useSWR<Data = any, Error = any>(
       loading = false
       return true
     },
+    // dispatch is immutable, and `eventsCallback`, `fnArgs`, `keyErr`, and `keyValidating` are based on `key`,
+    // so we can them from the deps array.
+    //
+    // FIXME:
+    // `fn` and `config` might be changed during the lifecycle,
+    // but they might be changed every render like this.
+    // useSWR('key', () => fetch('/api/'), { suspense: true })
+    // So we omit the values from the deps array
+    // even though it might cause unexpected behaviors.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [key]
   )
 
@@ -746,7 +756,13 @@ function useSWR<Data = any, Error = any>(
     })
 
     return state
-  }, [revalidate])
+    // `boundMutate` is immutable, and the immutability of `revalidate` depends on `key`
+    // so we can omit them from the deps array,
+    // but we put it to enable react-hooks/exhaustive-deps rule.
+    // `initialData` and `initialError` are not initial values
+    // because they are changed during the lifecycle
+    // so we should add them in the deps array.
+  }, [revalidate, initialData, initialError, boundMutate, key])
 
   // suspense
   if (config.suspense) {


### PR DESCRIPTION
This is the last PR to fix all `react-hooks/exhaustive-deps` warnings.
The PR fixes the warnings in `useSWR`, which adds some deps for `memoizedState` and disables the rule for `revalidate`.

For `memoizedState`, I've added all deps in the deps array. `boundMutate` is an immutable function, so we can omit it, but I've added it to the deps array to enable `react-hooks/exhaustive-deps` rule. It's an immutable function, so it shouldn't be a problem.

For `revalidate`, I've disabled the `react-hooks/exhaustive-deps` rule because `fn` and `config` are defined as the arguments of `useSWR` call, which means those values would be changed every time.
I could add `eventsCallback`, `fnArgs`, `keyErr`, and `keyValidating` into the deps array. It should be safe because they only depend on `key` that is already in the deps array.
But it makes tests flakier because current tests depends on JavaScript timer naively. If I added meaning-less values in the deps array for `revalidate`, tests would be failed frequently. So I didn't add them into the deps array.

```js
[key, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
```

I'll investigate the way to fix flaky tests.