### PR TITLE
chore: add comments that revalidate will be deprecated

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -236,6 +236,9 @@ function useSWRInfinite<Data = any, Error = any>(
       get: () => swr.data,
       enumerable: true
     },
+    // revalidate will be deprecated in the 1.x release
+    // because mutate() covers the same use case of revalidate().
+    // This remains only for backward compatibility
     revalidate: {
       get: () => swr.revalidate,
       enumerable: true

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -814,6 +814,9 @@ function useSWR<Data = any, Error = any>(
     return {
       error: latestError,
       data: latestData,
+      // revalidate will be deprecated in the 1.x release
+      // because mutate() covers the same use case of revalidate().
+      // This remains only for backward compatibility
       revalidate,
       mutate: boundMutate,
       isValidating: stateRef.current.isValidating


### PR DESCRIPTION
According to https://github.com/vercel/swr-site/pull/70#pullrequestreview-577603458, `revalidate()` will be deprecated in 1.x. I think it would be nice If it's commented as a source comment to tell the intention. It is helpful for contributors and developers who dig into the implementation.

Feel free to close this if it doesn't make sense 🙏 