### PR TITLE
Remove legacy useSWRPages types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -94,33 +94,6 @@ export type revalidateType = (
   revalidateOpts: RevalidateOptionInterface
 ) => Promise<boolean>
 
-export type pagesWithSWRType<Data, Error> = (
-  swr: responseInterface<Data, Error>
-) => responseInterface<Data, Error>
-export type pagesPropsInterface<Offset, Data, Error> = {
-  // offset can be any type
-  offset: Offset
-  withSWR: pagesWithSWRType<Data, Error>
-}
-
-export type pageComponentType<Offset, Data, Error> = (
-  props: pagesPropsInterface<Offset, Data, Error>
-) => any
-export type pageOffsetMapperType<Offset, Data, Error> = (
-  SWR: responseInterface<Data, Error>,
-  index: number
-) => Offset
-
-export type pagesResponseInterface<Data, Error> = {
-  pages: any
-  pageCount: number
-  pageSWRs: responseInterface<Data, Error>[]
-  isLoadingMore: boolean
-  isReachingEnd: boolean
-  isEmpty: boolean
-  loadMore: () => void
-}
-
 export type actionType<Data, Error> = {
   data?: Data
   error?: Error


### PR DESCRIPTION
Those types are for `useSWRPages`, which was an experimental API (never went public) and was replaced by `useSWRInfinite` in #435. So let's remove them.