### PR TITLE
test: fix flaky tests for focus and location mutation

### DIFF
--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react'
 import useSWR from '../src'
 import { sleep } from './utils'
 
+const waitForDedupingInterval = async () => await act(() => sleep(1))
+
 describe('useSWR - focus', () => {
   it('should revalidate on focus by default', async () => {
     let value = 0
@@ -19,9 +21,8 @@ describe('useSWR - focus', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
     // mount
     await screen.findByText('data: 0')
-    // wait for interval
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // trigger revalidation
     fireEvent.focus(window)
     await screen.findByText('data: 1')
@@ -43,9 +44,8 @@ describe('useSWR - focus', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
     // mount
     await screen.findByText('data: 0')
-    // wait for interval
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // trigger revalidation
     fireEvent.focus(window)
     // should not be revalidated
@@ -69,8 +69,8 @@ describe('useSWR - focus', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
     // mount
     await screen.findByText('data: 0')
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // trigger revalidation
     fireEvent.focus(window)
     // data should not change
@@ -82,15 +82,14 @@ describe('useSWR - focus', () => {
     fireEvent.focus(window)
     // data should update
     await screen.findByText('data: 1')
-    // wait for inteval
-    await act(() => sleep(20))
 
+    await waitForDedupingInterval()
     // trigger revalidation
     fireEvent.focus(window)
     // data should update
     await screen.findByText('data: 2')
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // change revalidateOnFocus to false
     fireEvent.click(container.firstElementChild)
     // trigger revalidation
@@ -120,8 +119,8 @@ describe('useSWR - focus', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
     // mount
     await screen.findByText('data: 0')
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // trigger revalidation
     fireEvent.focus(window)
     // still in throttling interval
@@ -129,7 +128,7 @@ describe('useSWR - focus', () => {
     // should be throttled
     fireEvent.focus(window)
     await screen.findByText('data: 1')
-    // wait focusThrottleInterval
+    // wait for focusThrottleInterval
     await act(() => sleep(100))
 
     // trigger revalidation again
@@ -159,8 +158,8 @@ describe('useSWR - focus', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
     // mount
     await screen.findByText('data: 0')
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // trigger revalidation
     fireEvent.focus(window)
     // wait for throttle interval
@@ -168,8 +167,8 @@ describe('useSWR - focus', () => {
     // trigger revalidation
     fireEvent.focus(window)
     await screen.findByText('data: 2')
-    await act(() => sleep(1))
 
+    await waitForDedupingInterval()
     // increase focusThrottleInterval
     fireEvent.click(container.firstElementChild)
     // wait for throttle interval
@@ -181,7 +180,6 @@ describe('useSWR - focus', () => {
     // should be throttled
     fireEvent.focus(window)
     await screen.findByText('data: 3')
-    await act(() => sleep(1))
 
     // wait for throttle interval
     await act(() => sleep(150))

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -187,7 +187,7 @@ describe('useSWR - local mutation', () => {
       // mutate and revalidate
       return mutate(
         'mutate-async-fn',
-        async () => new Promise(res => setTimeout(() => res(999), 10)),
+        async () => new Promise(res => setTimeout(() => res(999), 100)),
         false
       )
     })

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -180,9 +180,9 @@ describe('useSWR - local mutation', () => {
     expect(container.textContent).toMatchInlineSnapshot(`"data: "`)
     //mount
     await screen.findByText('data: 0')
-    // wait for interval
-    await act(() => sleep(1))
 
+    // wait for dedupingInterval
+    await act(() => sleep(1))
     await act(() => {
       // mutate and revalidate
       return mutate(

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -178,21 +178,20 @@ describe('useSWR - local mutation', () => {
 
     // hydration
     expect(container.textContent).toMatchInlineSnapshot(`"data: "`)
-
     //mount
     await screen.findByText('data: 0')
+    // wait for interval
+    await act(() => sleep(1))
 
     await act(() => {
       // mutate and revalidate
       return mutate(
         'mutate-async-fn',
-        async () => new Promise(res => setTimeout(() => res(999), 100)),
+        async () => new Promise(res => setTimeout(() => res(999), 10)),
         false
       )
     })
-    await act(() => sleep(110))
-
-    expect(container.textContent).toMatchInlineSnapshot(`"data: 999"`)
+    await screen.findByText('data: 999')
   })
 
   it('should trigger on mutation without data', async () => {


### PR DESCRIPTION
Fixes #940

I've inspected why the focus tests are flaky.
I've found that some tests didn't wait for a deduping interval, which means that a mutation in the next test might be deduped and failed.
To fix this, I've added `await act(() => sleep(1))` before the next mutation. But the intention of the code is very unclear, so I've separated it as another function called `waitForDedupingInterval`.

In addition, many of the current tests depend on a real timer, which makes tests flaky, so I've refactored to avoid depending on a real timer as much possible as I can by using `screen.findByText`.

I've also noticed that a test in `use-swr-local-mutation.test.tsx` is flaky, so I've fixed it too.

I think there are more flaky tests in SWR, so I'll fix them so that tests are more reliable. #932 and #933 are PRs for it.