### PR TITLE
types: makes types fn and config and key more strictly

### DIFF
--- a/src/swr-config-context.ts
+++ b/src/swr-config-context.ts
@@ -2,7 +2,7 @@ import { createContext } from 'react'
 
 import { ConfigInterface } from './types'
 
-const SWRConfigContext = createContext<ConfigInterface>({})
+const SWRConfigContext = createContext<Partial<ConfigInterface>>({})
 SWRConfigContext.displayName = 'SWRConfigContext'
 
 export default SWRConfigContext

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,42 +1,40 @@
-// `null` is used for a hack to manage shared state with SWR
-// https://github.com/vercel/swr/pull/918
-export type fetcherFn<Data> = ((...args: any) => Data | Promise<Data>) | null
+export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
 export interface ConfigInterface<
   Data = any,
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > {
-  errorRetryInterval?: number
+  errorRetryInterval: number
   errorRetryCount?: number
-  loadingTimeout?: number
-  focusThrottleInterval?: number
-  dedupingInterval?: number
-  refreshInterval?: number
-  refreshWhenHidden?: boolean
-  refreshWhenOffline?: boolean
-  revalidateOnFocus?: boolean
+  loadingTimeout: number
+  focusThrottleInterval: number
+  dedupingInterval: number
+  refreshInterval: number
+  refreshWhenHidden: boolean
+  refreshWhenOffline: boolean
+  revalidateOnFocus: boolean
   revalidateOnMount?: boolean
-  revalidateOnReconnect?: boolean
-  shouldRetryOnError?: boolean
-  fetcher?: Fn
-  suspense?: boolean
+  revalidateOnReconnect: boolean
+  shouldRetryOnError: boolean
+  fetcher: Fn
+  suspense: boolean
   initialData?: Data
 
-  isOnline?: () => boolean
-  isDocumentVisible?: () => boolean
-  isPaused?: () => boolean
-  onLoadingSlow?: (key: string, config: ConfigInterface<Data, Error>) => void
-  onSuccess?: (
+  isOnline: () => boolean
+  isDocumentVisible: () => boolean
+  isPaused: () => boolean
+  onLoadingSlow: (key: string, config: ConfigInterface<Data, Error>) => void
+  onSuccess: (
     data: Data,
     key: string,
     config: ConfigInterface<Data, Error>
   ) => void
-  onError?: (
+  onError: (
     err: Error,
     key: string,
     config: ConfigInterface<Data, Error>
   ) => void
-  onErrorRetry?: (
+  onErrorRetry: (
     err: Error,
     key: string,
     config: ConfigInterface<Data, Error>,
@@ -44,7 +42,7 @@ export interface ConfigInterface<
     revalidateOpts: RevalidateOptionInterface
   ) => void
 
-  compare?: (a: Data | undefined, b: Data | undefined) => boolean
+  compare: (a: Data | undefined, b: Data | undefined) => boolean
 }
 
 export interface RevalidateOptionInterface {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -34,39 +34,36 @@ function useSWRInfinite<Data = any, Error = any>(
 ): SWRInfiniteResponseInterface<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
-  config?: SWRInfiniteConfigInterface<Data, Error>
+  config?: Partial<SWRInfiniteConfigInterface<Data, Error>>
 ): SWRInfiniteResponseInterface<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
   fn?: fetcherFn<Data>,
-  config?: SWRInfiniteConfigInterface<Data, Error>
+  config?: Partial<SWRInfiniteConfigInterface<Data, Error>>
 ): SWRInfiniteResponseInterface<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
-  ...args
+  getKey: KeyLoader<Data>,
+  ...options: any[]
 ): SWRInfiniteResponseInterface<Data, Error> {
-  let getKey: KeyLoader<Data>,
-    fn: fetcherFn<Data> | undefined,
-    config: SWRInfiniteConfigInterface<Data, Error> = {}
+  let _fn: fetcherFn<Data> | undefined,
+    _config: Partial<SWRInfiniteConfigInterface<Data, Error>> = {}
 
-  if (args.length >= 1) {
-    getKey = args[0]
-  }
-  if (args.length > 2) {
-    fn = args[1]
-    config = args[2]
+  if (options.length > 1) {
+    _fn = options[0]
+    _config = options[1]
   } else {
-    if (typeof args[1] === 'function') {
-      fn = args[1]
-    } else if (typeof args[1] === 'object') {
-      config = args[1]
+    if (typeof options[0] === 'function') {
+      _fn = options[0]
+    } else if (typeof options[0] === 'object') {
+      _config = options[0]
     }
   }
 
-  config = Object.assign(
+  const config: SWRInfiniteConfigInterface<Data, Error> = Object.assign(
     {},
     defaultConfig,
     useContext(SWRConfigContext),
-    config
+    _config
   )
   let {
     initialSize = 1,
@@ -76,11 +73,7 @@ function useSWRInfinite<Data = any, Error = any>(
     ...extraConfig
   } = config
 
-  if (typeof fn === 'undefined') {
-    // use the global fetcher
-    // we have to convert the type here
-    fn = (defaultFetcher as unknown) as fetcherFn<Data>
-  }
+  const fn = typeof _fn !== 'undefined' ? _fn : defaultFetcher
 
   // get the serialized key of the first page
   let firstPageKey: string | null = null

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -226,30 +226,29 @@ function useSWR<Data = any, Error = any>(
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: keyInterface,
-  config?: ConfigInterface<Data, Error>
+  config?: Partial<ConfigInterface<Data, Error>>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: keyInterface,
-  fn?: fetcherFn<Data>,
-  config?: ConfigInterface<Data, Error>
+  // `null` is used for a hack to manage shared state with SWR
+  // https://github.com/vercel/swr/pull/918
+  fn?: fetcherFn<Data> | null,
+  config?: Partial<ConfigInterface<Data, Error>>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
-  ...args
+  _key: keyInterface,
+  ...options: any[]
 ): responseInterface<Data, Error> {
-  let _key: keyInterface,
-    fn: fetcherFn<Data> | undefined,
-    config: ConfigInterface<Data, Error> = {}
-  if (args.length >= 1) {
-    _key = args[0]
-  }
-  if (args.length > 2) {
-    fn = args[1]
-    config = args[2]
+  let _fn: fetcherFn<Data> | undefined,
+    _config: Partial<ConfigInterface<Data, Error>> = {}
+  if (options.length > 1) {
+    _fn = options[0]
+    _config = options[1]
   } else {
-    if (typeof args[1] === 'function') {
-      fn = args[1]
-    } else if (typeof args[1] === 'object') {
-      config = args[1]
+    if (typeof options[0] === 'function') {
+      _fn = options[0]
+    } else if (typeof options[0] === 'object') {
+      _config = options[0]
     }
   }
 
@@ -259,11 +258,11 @@ function useSWR<Data = any, Error = any>(
   // `keyErr` is the cache key for error objects
   const [key, fnArgs, keyErr, keyValidating] = cache.serializeKey(_key)
 
-  config = Object.assign(
+  const config: ConfigInterface<Data, Error> = Object.assign(
     {},
     defaultConfig,
     useContext(SWRConfigContext),
-    config
+    _config
   )
 
   const configRef = useRef(config)
@@ -271,10 +270,7 @@ function useSWR<Data = any, Error = any>(
     configRef.current = config
   })
 
-  if (typeof fn === 'undefined') {
-    // use the global fetcher
-    fn = config.fetcher
-  }
+  const fn = typeof _fn !== 'undefined' ? _fn : config.fetcher
 
   const resolveData = () => {
     const cachedData = cache.get(key)


### PR DESCRIPTION
This is a PR to make internal types (`fn`, `config`, and `key`)  more strictly.
This helps refactoring and code completion.

In the future, it would be nice if SWR could enable the TypeScript's `strict` mode.
