### PR TITLE
fix: revalidate with initialData when changing the key

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -232,9 +232,9 @@ function useSWR<Data = any, Error = any>(
     ? args[1]
     : args.length === 2 && typeof args[1] === 'function'
     ? args[1]
-    : /** 
-          pass fn as null will disable revalidate 
-          https://paco.sh/blog/shared-hook-state-with-swr 
+    : /**
+          pass fn as null will disable revalidate
+          https://paco.sh/blog/shared-hook-state-with-swr
         */
     args[1] === null
     ? args[1]
@@ -558,6 +558,7 @@ function useSWR<Data = any, Error = any>(
     // after `key` updates, we need to mark it as mounted
     unmountedRef.current = false
 
+    const isUpdating = initialMountedRef.current
     initialMountedRef.current = true
 
     // after the component is mounted (hydrated),
@@ -579,7 +580,10 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (willRevalidateOnMount()) {
+    if (
+      isUpdating ||
+      willRevalidateOnMount()
+    ) {
       if (typeof latestKeyedData !== 'undefined' && !IS_SERVER) {
         // delay revalidate if there's cache
         // to not block the rendering

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -1,5 +1,5 @@
-import { act, render, screen } from '@testing-library/react'
-import React, { useEffect } from 'react'
+import { act, render, screen, fireEvent } from '@testing-library/react'
+import React, { useState, useEffect } from 'react'
 import useSWR from '../src'
 import { sleep } from './utils'
 
@@ -309,6 +309,34 @@ describe('useSWR', () => {
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"hello, Initial"`
     )
+  })
+
+  it('should revalidate even if initialData is provided', async () => {
+    const fetcher = key => key
+
+    function Page() {
+      const [key, setKey] = useState('initial-data-with-initial-data')
+      const { data } = useSWR(key, fetcher, {
+        initialData: 'Initial'
+      })
+      return (
+        <div onClick={() => setKey('initial-data-with-initial-data-update')}>
+          hello, {data}
+        </div>
+      )
+    }
+
+    const { container } = render(<Page />)
+
+    // render with the initial data
+    await screen.findByText('hello, Initial')
+
+    // change the key
+    await act(() => sleep(1))
+    fireEvent.click(container.firstElementChild)
+
+    // render with data the fetcher returns
+    await screen.findByText('hello, initial-data-with-initial-data-update')
   })
 
   it('should set config as second parameter', async () => {

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -345,7 +345,11 @@ describe('useSWR', () => {
 
     // a request is still in flight
     await act(() => sleep(10))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"loading"`)
+    // while validating, SWR returns the initialData
+    // https://github.com/vercel/swr/pull/961/files#r588928241
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(
+      `"hello, Initial"`
+    )
 
     // render with data the fetcher returns
     await screen.findByText('hello, initial-data-with-initial-data-update')


### PR DESCRIPTION
This fixes #947.
SWR seems not to revalidate when having `initialData`.

> Another strange thing: when state contains empty string refetching happens. But if you change state to any string it returns initial data.

This PR doesn't fix the above that is also mentioned on #947.
I'll investigate it as another issue.