### PR TITLE
fix: checking if document is defined

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -55,7 +55,12 @@ const now = (() => {
 })()
 
 // setup DOM events listeners for `focus` and `reconnect` actions
-if (!IS_SERVER && window.addEventListener && document.addEventListener) {
+if (
+  !IS_SERVER &&
+  window.addEventListener &&
+  typeof document !== 'undefined' &&
+  typeof document.addEventListener !== 'undefined'
+) {
   const revalidate = revalidators => {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 


### PR DESCRIPTION
Fixes #953.
This seems to be caused by the change of  #889.
I've added the check if `document` is defined before SWR uses `document.addEventListener`.

The check is already being used at https://github.com/vercel/swr/blob/70ffd2c37dfed75ab703e70af1fdad666889f13f/src/libs/web-preset.ts#L14