### PR TITLE
refactor: move DOM event handlers into web-preset

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -71,7 +71,9 @@ const defaultConfig: ConfigInterface = {
   fetcher: webPreset.fetcher,
   isOnline: webPreset.isOnline,
   isDocumentVisible: webPreset.isDocumentVisible,
-  isPaused: () => false
+  isPaused: () => false,
+  onFocus: webPreset.onFocus,
+  onReconnect: webPreset.onReconnect
 }
 
 export { cache }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -22,8 +22,33 @@ function isDocumentVisible(): boolean {
 
 const fetcher = url => fetch(url).then(res => res.json())
 
+function onFocus(cb: () => void) {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.addEventListener !== 'undefined' &&
+    typeof document !== 'undefined' &&
+    typeof document.addEventListener !== 'undefined'
+  ) {
+    // focus revalidate
+    document.addEventListener('visibilitychange', () => cb(), false)
+    window.addEventListener('focus', () => cb(), false)
+  }
+}
+
+function onReconnect(cb: () => void) {
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.addEventListener !== 'undefined'
+  ) {
+    // reconnect revalidate
+    window.addEventListener('online', () => cb(), false)
+  }
+}
+
 export default {
   isOnline,
   isDocumentVisible,
-  fetcher
+  fetcher,
+  onFocus,
+  onReconnect
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,8 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     revalidateOpts: RevalidateOptionInterface
   ) => void
+  onFocus?: (cb: () => void) => void
+  onReconnect?: (cb: () => void) => void
 
   compare: (a: Data | undefined, b: Data | undefined) => boolean
 }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -55,12 +55,7 @@ const now = (() => {
 })()
 
 // setup DOM events listeners for `focus` and `reconnect` actions
-if (
-  !IS_SERVER &&
-  window.addEventListener &&
-  typeof document !== 'undefined' &&
-  typeof document.addEventListener !== 'undefined'
-) {
+if (!IS_SERVER) {
   const revalidate = revalidators => {
     if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
@@ -69,19 +64,13 @@ if (
     }
   }
 
-  // focus revalidate
-  document.addEventListener(
-    'visibilitychange',
-    () => revalidate(FOCUS_REVALIDATORS),
-    false
-  )
-  window.addEventListener('focus', () => revalidate(FOCUS_REVALIDATORS), false)
-  // reconnect revalidate
-  window.addEventListener(
-    'online',
-    () => revalidate(RECONNECT_REVALIDATORS),
-    false
-  )
+  if (typeof defaultConfig.onFocus === 'function') {
+    defaultConfig.onFocus(() => revalidate(FOCUS_REVALIDATORS))
+  }
+
+  if (typeof defaultConfig.onReconnect === 'function') {
+    defaultConfig.onReconnect(() => revalidate(RECONNECT_REVALIDATORS))
+  }
 }
 
 const trigger: triggerInterface = (_key, shouldRevalidate = true) => {


### PR DESCRIPTION
This PR separates DOM event handlers from `use-swr` and defined them in `web-preset`.
ref. https://github.com/vercel/swr/pull/963#issuecomment-773380777

These handlers are only used on browsers and SWR already has a file for browser APIs. So these handers should be placed in the file.
This would also make it possible to provide `defaultConfig` for each environment, which enables us to only include implementations that are required on the platform.