### PR TITLE
fix: do not cache when mutate throws an error synchronously

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -155,6 +155,8 @@ const mutate: mutateInterface = async (
     try {
       _data = _data(cache.get(key))
     } catch (err) {
+      // if `_data` function throws an error synchronously, it shouldn't be cached
+      _data = undefined
       error = err
     }
   }

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -454,12 +454,14 @@ describe('useSWR - local mutation', () => {
       }
     })
 
-    const [, , keyErr] = cache.serializeKey(key)
+    const [keyData, , keyErr] = cache.serializeKey(key)
     let cacheError = cache.get(keyErr)
     expect(cacheError.message).toMatchInlineSnapshot(`"${message}"`)
     expect(container.firstChild.textContent).toMatchInlineSnapshot(
       `"${message}"`
     )
+    // if mutate throws an error synchronously, the cache shouldn't be updated
+    expect(cache.get(keyData)).toBe(value)
     // if mutate succeed, error should be cleared
     await act(async () => {
       return mutate(key, value, false)


### PR DESCRIPTION
Fixes #975.
But I'm not sure what the expected behavior when `mutate` throws an error synchronously.
As #975 mentioned, currently the `mutate` function is cached as the data, which is definitely an unexpected behavior.

This PR makes SWR skip caching the data in this case.