### PR TITLE
refactor: add the register prefix to onFocus and onReconnect

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -72,8 +72,8 @@ const defaultConfig: ConfigInterface = {
   isOnline: webPreset.isOnline,
   isDocumentVisible: webPreset.isDocumentVisible,
   isPaused: () => false,
-  onFocus: webPreset.onFocus,
-  onReconnect: webPreset.onReconnect
+  registerOnFocus: webPreset.registerOnFocus,
+  registerOnReconnect: webPreset.registerOnReconnect
 }
 
 export { cache }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -22,7 +22,7 @@ function isDocumentVisible(): boolean {
 
 const fetcher = url => fetch(url).then(res => res.json())
 
-function onFocus(cb: () => void) {
+function registerOnFocus(cb: () => void) {
   if (
     typeof window !== 'undefined' &&
     typeof window.addEventListener !== 'undefined' &&
@@ -35,7 +35,7 @@ function onFocus(cb: () => void) {
   }
 }
 
-function onReconnect(cb: () => void) {
+function registerOnReconnect(cb: () => void) {
   if (
     typeof window !== 'undefined' &&
     typeof window.addEventListener !== 'undefined'
@@ -49,6 +49,6 @@ export default {
   isOnline,
   isDocumentVisible,
   fetcher,
-  onFocus,
-  onReconnect
+  registerOnFocus,
+  registerOnReconnect
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,8 +41,8 @@ export interface ConfigInterface<
     revalidate: revalidateType,
     revalidateOpts: RevalidateOptionInterface
   ) => void
-  onFocus?: (cb: () => void) => void
-  onReconnect?: (cb: () => void) => void
+  registerOnFocus?: (cb: () => void) => void
+  registerOnReconnect?: (cb: () => void) => void
 
   compare: (a: Data | undefined, b: Data | undefined) => boolean
 }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -64,12 +64,12 @@ if (!IS_SERVER) {
     }
   }
 
-  if (typeof defaultConfig.onFocus === 'function') {
-    defaultConfig.onFocus(() => revalidate(FOCUS_REVALIDATORS))
+  if (typeof defaultConfig.registerOnFocus === 'function') {
+    defaultConfig.registerOnFocus(() => revalidate(FOCUS_REVALIDATORS))
   }
 
-  if (typeof defaultConfig.onReconnect === 'function') {
-    defaultConfig.onReconnect(() => revalidate(RECONNECT_REVALIDATORS))
+  if (typeof defaultConfig.registerOnReconnect === 'function') {
+    defaultConfig.registerOnReconnect(() => revalidate(RECONNECT_REVALIDATORS))
   }
 }
 


### PR DESCRIPTION
As @huozhi  mentioned https://github.com/vercel/swr/pull/972#issuecomment-783038279, I've renamed `onFocus` and `onConnect` to `registerOnFocus` and `registerOnConnect`.