### PR TITLE
Fix: do not depend on navigator.onLine; code optimizations

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,34 +47,32 @@ const slowConnection =
   ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1
 
 // config
-const defaultConfig: ConfigInterface = {
-  // events
-  onLoadingSlow: () => {},
-  onSuccess: () => {},
-  onError: () => {},
-  onErrorRetry,
+const defaultConfig: ConfigInterface = Object.assign(
+  {
+    // events
+    onLoadingSlow: () => {},
+    onSuccess: () => {},
+    onError: () => {},
+    onErrorRetry,
 
-  errorRetryInterval: (slowConnection ? 10 : 5) * 1000,
-  focusThrottleInterval: 5 * 1000,
-  dedupingInterval: 2 * 1000,
-  loadingTimeout: (slowConnection ? 5 : 3) * 1000,
+    errorRetryInterval: (slowConnection ? 10 : 5) * 1000,
+    focusThrottleInterval: 5 * 1000,
+    dedupingInterval: 2 * 1000,
+    loadingTimeout: (slowConnection ? 5 : 3) * 1000,
 
-  refreshInterval: 0,
-  revalidateOnFocus: true,
-  revalidateOnReconnect: true,
-  refreshWhenHidden: false,
-  refreshWhenOffline: false,
-  shouldRetryOnError: true,
-  suspense: false,
-  compare: dequal,
+    refreshInterval: 0,
+    revalidateOnFocus: true,
+    revalidateOnReconnect: true,
+    refreshWhenHidden: false,
+    refreshWhenOffline: false,
+    shouldRetryOnError: true,
+    suspense: false,
+    compare: dequal,
 
-  fetcher: webPreset.fetcher,
-  isOnline: webPreset.isOnline,
-  isDocumentVisible: webPreset.isDocumentVisible,
-  isPaused: () => false,
-  registerOnFocus: webPreset.registerOnFocus,
-  registerOnReconnect: webPreset.registerOnReconnect
-}
+    isPaused: () => false
+  },
+  webPreset
+)
 
 export { cache }
 export default defaultConfig

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -11,7 +11,7 @@ const isOnline = () => online
 const isDocumentVisible = () => {
   if (
     typeof document !== 'undefined' &&
-    typeof document.visibilityState !== 'undefined'
+    document.visibilityState !== undefined
   ) {
     return document.visibilityState !== 'hidden'
   }
@@ -24,9 +24,9 @@ const fetcher = url => fetch(url).then(res => res.json())
 const registerOnFocus = (cb: () => void) => {
   if (
     typeof window !== 'undefined' &&
-    typeof window.addEventListener !== 'undefined' &&
+    window.addEventListener !== undefined &&
     typeof document !== 'undefined' &&
-    typeof document.addEventListener !== 'undefined'
+    document.addEventListener !== undefined
   ) {
     // focus revalidate
     document.addEventListener('visibilitychange', () => cb(), false)
@@ -35,10 +35,7 @@ const registerOnFocus = (cb: () => void) => {
 }
 
 const registerOnReconnect = (cb: () => void) => {
-  if (
-    typeof window !== 'undefined' &&
-    typeof window.addEventListener !== 'undefined'
-  ) {
+  if (typeof window !== 'undefined' && window.addEventListener !== undefined) {
     // reconnect revalidate
     window.addEventListener(
       'online',

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -1,13 +1,12 @@
-function isOnline(): boolean {
-  if (
-    typeof navigator !== 'undefined' &&
-    typeof navigator.onLine !== 'undefined'
-  ) {
-    return navigator.onLine
-  }
-  // always assume it's online
-  return true
-}
+/**
+ * Due to bug https://bugs.chromium.org/p/chromium/issues/detail?id=678075,
+ * it's not reliable to detect if the browser is currently online or offline
+ * based on `navigator.onLine`.
+ * As a work around, we always assume it's online on first load, and change
+ * the status upon `online` or `offline` events.
+ */
+let online = true
+const isOnline = () => online
 
 function isDocumentVisible(): boolean {
   if (
@@ -41,7 +40,17 @@ function registerOnReconnect(cb: () => void) {
     typeof window.addEventListener !== 'undefined'
   ) {
     // reconnect revalidate
-    window.addEventListener('online', () => cb(), false)
+    window.addEventListener(
+      'online',
+      () => {
+        online = true
+        cb()
+      },
+      false
+    )
+
+    // nothing to revalidate, just update the status
+    window.addEventListener('offline', () => (online = false), false)
   }
 }
 

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -8,7 +8,7 @@
 let online = true
 const isOnline = () => online
 
-function isDocumentVisible(): boolean {
+const isDocumentVisible = () => {
   if (
     typeof document !== 'undefined' &&
     typeof document.visibilityState !== 'undefined'
@@ -21,7 +21,7 @@ function isDocumentVisible(): boolean {
 
 const fetcher = url => fetch(url).then(res => res.json())
 
-function registerOnFocus(cb: () => void) {
+const registerOnFocus = (cb: () => void) => {
   if (
     typeof window !== 'undefined' &&
     typeof window.addEventListener !== 'undefined' &&
@@ -34,7 +34,7 @@ function registerOnFocus(cb: () => void) {
   }
 }
 
-function registerOnReconnect(cb: () => void) {
+const registerOnReconnect = (cb: () => void) => {
   if (
     typeof window !== 'undefined' &&
     typeof window.addEventListener !== 'undefined'

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -3,7 +3,11 @@ import React, { useState } from 'react'
 import useSWR from '../src'
 import { sleep } from './utils'
 
-const waitForNextTick = async () => await act(() => sleep(1))
+const waitForNextTick = () => act(() => sleep(1))
+const focusWindow = () =>
+  act(async () => {
+    fireEvent.focus(window)
+  })
 
 describe('useSWR - focus', () => {
   it('should revalidate on focus by default', async () => {
@@ -24,7 +28,8 @@ describe('useSWR - focus', () => {
 
     await waitForNextTick()
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
+
     await screen.findByText('data: 1')
   })
 
@@ -47,7 +52,7 @@ describe('useSWR - focus', () => {
 
     await waitForNextTick()
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // should not be revalidated
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 0"`)
   })
@@ -72,20 +77,20 @@ describe('useSWR - focus', () => {
 
     await waitForNextTick()
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // data should not change
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 0"`)
 
     // change revalidateOnFocus to true
     fireEvent.click(container.firstElementChild)
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // data should update
     await screen.findByText('data: 1')
 
     await waitForNextTick()
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // data should update
     await screen.findByText('data: 2')
 
@@ -93,7 +98,7 @@ describe('useSWR - focus', () => {
     // change revalidateOnFocus to false
     fireEvent.click(container.firstElementChild)
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // data should not change
     expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 2"`)
   })
@@ -122,17 +127,17 @@ describe('useSWR - focus', () => {
 
     await waitForNextTick()
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // still in throttling interval
     await act(() => sleep(20))
     // should be throttled
-    fireEvent.focus(window)
+    await focusWindow()
     await screen.findByText('data: 1')
     // wait for focusThrottleInterval
     await act(() => sleep(100))
 
     // trigger revalidation again
-    fireEvent.focus(window)
+    await focusWindow()
     await screen.findByText('data: 2')
   })
 
@@ -161,11 +166,11 @@ describe('useSWR - focus', () => {
 
     await waitForNextTick()
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // wait for throttle interval
     await act(() => sleep(100))
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     await screen.findByText('data: 2')
 
     await waitForNextTick()
@@ -174,21 +179,21 @@ describe('useSWR - focus', () => {
     // wait for throttle interval
     await act(() => sleep(100))
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // wait for throttle interval
     await act(() => sleep(100))
     // should be throttled
-    fireEvent.focus(window)
+    await focusWindow()
     await screen.findByText('data: 3')
 
     // wait for throttle interval
     await act(() => sleep(150))
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     // wait for throttle intervals
     await act(() => sleep(150))
     // trigger revalidation
-    fireEvent.focus(window)
+    await focusWindow()
     await screen.findByText('data: 5')
   })
 })

--- a/test/use-swr-offline.test.tsx
+++ b/test/use-swr-offline.test.tsx
@@ -1,0 +1,67 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import useSWR from '../src'
+import { sleep } from './utils'
+
+const waitForNextTick = () => act(() => sleep(1))
+const focusWindow = () =>
+  act(async () => {
+    fireEvent.focus(window)
+  })
+const dispatchWindowEvent = event =>
+  act(async () => {
+    window.dispatchEvent(new Event(event))
+  })
+
+describe('useSWR - offline', () => {
+  it('should not revalidate when offline', async () => {
+    let value = 0
+
+    function Page() {
+      const { data } = useSWR('offline-1', () => value++, {
+        dedupingInterval: 0
+      })
+      return <div>data: {data}</div>
+    }
+    const { container } = render(<Page />)
+
+    // hydration
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
+    // mount
+    await screen.findByText('data: 0')
+
+    // simulate offline
+    await waitForNextTick()
+    await dispatchWindowEvent('offline')
+
+    // trigger focus revalidation
+    await focusWindow()
+
+    // should not be revalidated
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 0"`)
+  })
+
+  it('should revalidate immediately when becoming online', async () => {
+    let value = 0
+
+    function Page() {
+      const { data } = useSWR('offline-2', () => value++, {
+        dedupingInterval: 0
+      })
+      return <div>data: {data}</div>
+    }
+    const { container } = render(<Page />)
+
+    // hydration
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: "`)
+    // mount
+    await screen.findByText('data: 0')
+
+    // simulate online
+    await waitForNextTick()
+    await dispatchWindowEvent('online')
+
+    // should be revalidated
+    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"data: 1"`)
+  })
+})


### PR DESCRIPTION
As mentioned in the code comments, `navigator.onLine` isn't always reliable due to [this bug](https://bugs.chromium.org/p/chromium/issues/detail?id=678075). Instead of depending on it, we have to use another approach to always assume it's online (since the page loads, it's _very likely_ to be online). And when we receive the `offline` event from `window`, we set the internal state to offline.

With this change, SWR will still try to revalidate even it's offline, if **both** requirements are meet: 
- the app is running with Service Worker (or RN), and it's offline. 
- Chrome (or the navigator) is having the bug mentioned above.  

It's an extremely rare case.

Also did some code optimizations (results in a smaller bundle with ncc) and updated tests.