### PR TITLE
fix: support multiple useSWRInfinite hooks in a page

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,16 @@
+import { useEffect, useLayoutEffect } from 'react'
+
+export const IS_SERVER =
+  typeof window === 'undefined' ||
+  // @ts-ignore
+  !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
+
+// polyfill for requestAnimationFrame
+export const rAF = IS_SERVER
+  ? null
+  : window['requestAnimationFrame'] || (f => setTimeout(f, 1))
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+export const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -1,5 +1,3 @@
-import { useEffect, useLayoutEffect } from 'react'
-
 /**
  * Due to bug https://bugs.chromium.org/p/chromium/issues/detail?id=678075,
  * it's not reliable to detect if the browser is currently online or offline
@@ -53,28 +51,10 @@ const registerOnReconnect = (cb: () => void) => {
   }
 }
 
-const IS_SERVER =
-  typeof window === 'undefined' ||
-  // @ts-ignore
-  !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
-
-// polyfill for requestAnimationFrame
-const rAF = IS_SERVER
-  ? null
-  : window['requestAnimationFrame'] || (f => setTimeout(f, 1))
-
-// React currently throws a warning when using useLayoutEffect on the server.
-// To get around it, we can conditionally useEffect on the server (no-op) and
-// useLayoutEffect in the browser.
-const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
-
 export default {
   isOnline,
   isDocumentVisible,
   fetcher,
   registerOnFocus,
-  registerOnReconnect,
-  rAF,
-  useIsomorphicLayoutEffect,
-  IS_SERVER
+  registerOnReconnect
 }

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -1,3 +1,5 @@
+import { useEffect, useLayoutEffect } from 'react'
+
 /**
  * Due to bug https://bugs.chromium.org/p/chromium/issues/detail?id=678075,
  * it's not reliable to detect if the browser is currently online or offline
@@ -51,10 +53,28 @@ const registerOnReconnect = (cb: () => void) => {
   }
 }
 
+const IS_SERVER =
+  typeof window === 'undefined' ||
+  // @ts-ignore
+  !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
+
+// polyfill for requestAnimationFrame
+const rAF = IS_SERVER
+  ? null
+  : window['requestAnimationFrame'] || (f => setTimeout(f, 1))
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
+
 export default {
   isOnline,
   isDocumentVisible,
   fetcher,
   registerOnFocus,
-  registerOnReconnect
+  registerOnReconnect,
+  rAF,
+  useIsomorphicLayoutEffect,
+  IS_SERVER
 }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -1,5 +1,5 @@
 // TODO: use @ts-expect-error
-import { useContext, useRef, useEffect, useCallback } from 'react'
+import { useContext, useRef, useState, useEffect, useCallback } from 'react'
 
 import defaultConfig, { cache } from './config'
 import SWRConfigContext from './swr-config-context'
@@ -67,6 +67,8 @@ function useSWRInfinite<Data = any, Error = any>(
   } catch (err) {
     // not ready
   }
+
+  const [, rerender] = useState<boolean>(false)
 
   // we use cache to pass extra info (context) to fetcher so it can be globally shared
   // here we get the key of the fetcher context cache
@@ -187,6 +189,7 @@ function useSWRInfinite<Data = any, Error = any>(
         cache.set(pageCountCacheKey, arg)
         lastPageCountRef.current = arg
       }
+      rerender(v => !v)
       return mutate(v => v)
     },
     [pageCountCacheKey, resolvePageCount, mutate]

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -87,14 +87,16 @@ function useSWRInfinite<Data = any, Error = any>(
     () => cache.get(pageCountCacheKey) || initialSize,
     [pageCountCacheKey, initialSize]
   )
+  const lastPageCountRef = useRef<number>(resolvePageCount())
 
   // every time the key changes, we reset the page size if it's not persisted
   useEffect(() => {
     if (didMountRef.current) {
-      if (!persistSize) {
-        cache.set(pageCountCacheKey, initialSize)
-        swr.mutate()
-      }
+      cache.set(
+        pageCountCacheKey,
+        persistSize ? lastPageCountRef.current : initialSize
+      )
+      swr.mutate()
     } else {
       didMountRef.current = true
     }
@@ -197,8 +199,10 @@ function useSWRInfinite<Data = any, Error = any>(
     arg => {
       if (typeof arg === 'function') {
         cache.set(pageCountCacheKey, arg(resolvePageCount()))
+        lastPageCountRef.current = arg(resolvePageCount())
       } else if (typeof arg === 'number') {
         cache.set(pageCountCacheKey, arg)
+        lastPageCountRef.current = arg
       }
       swr.mutate()
     },

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -3,7 +3,7 @@ import { useContext, useRef, useState, useCallback } from 'react'
 
 import defaultConfig, { cache } from './config'
 import SWRConfigContext from './swr-config-context'
-import useSWR, { useIsomorphicLayoutEffect } from './use-swr'
+import useSWR from './use-swr'
 
 import {
   ValueKey,
@@ -57,6 +57,7 @@ function useSWRInfinite<Data = any, Error = any>(
     initialSize = 1,
     revalidateAll = false,
     persistSize = false,
+    useIsomorphicLayoutEffect,
     ...extraConfig
   } = config
 

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -2,8 +2,9 @@
 import { useContext, useRef, useState, useCallback } from 'react'
 
 import defaultConfig, { cache } from './config'
+import { useIsomorphicLayoutEffect } from './env'
 import SWRConfigContext from './swr-config-context'
-import useSWR, { useIsomorphicLayoutEffect } from './use-swr'
+import useSWR from './use-swr'
 
 import {
   ValueKey,

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -206,7 +206,7 @@ function useSWRInfinite<Data = any, Error = any>(
       }
       return mutate(v => v)
     },
-    [pageCountCacheKey, resolvePageCount]
+    [pageCountCacheKey, resolvePageCount, mutate]
   )
 
   // Use getter functions to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -92,9 +92,6 @@ function useSWRInfinite<Data = any, Error = any>(
   // keep the last page size to restore it with the persistSize option
   const lastPageSizeRef = useRef<number>(resolvePageSize())
 
-  // keep the data inside a ref
-  const dataRef = useRef<Data[]>()
-
   // every time the key changes, we reset the page size if it's not persisted
   useIsomorphicLayoutEffect(() => {
     if (!didMountRef.current) {
@@ -109,6 +106,9 @@ function useSWRInfinite<Data = any, Error = any>(
     // initialSize isn't allowed to change during the lifecycle
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firstPageKey])
+
+  // keep the data inside a ref
+  const dataRef = useRef<Data[]>()
 
   // actual swr of all pages
   const swr = useSWR<Data[], Error>(

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -204,7 +204,7 @@ function useSWRInfinite<Data = any, Error = any>(
         cache.set(pageCountCacheKey, arg)
         lastPageCountRef.current = arg
       }
-      swr.mutate()
+      return mutate(v => v)
     },
     [pageCountCacheKey, resolvePageCount]
   )

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -3,7 +3,7 @@ import { useContext, useRef, useState, useCallback } from 'react'
 
 import defaultConfig, { cache } from './config'
 import SWRConfigContext from './swr-config-context'
-import useSWR from './use-swr'
+import useSWR, { useIsomorphicLayoutEffect } from './use-swr'
 
 import {
   ValueKey,
@@ -57,7 +57,6 @@ function useSWRInfinite<Data = any, Error = any>(
     initialSize = 1,
     revalidateAll = false,
     persistSize = false,
-    useIsomorphicLayoutEffect,
     ...extraConfig
   } = config
 

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -86,10 +86,8 @@ function useSWRInfinite<Data = any, Error = any>(
     () => cache.get(pageCountCacheKey) || initialSize,
     [pageCountCacheKey, initialSize]
   )
-  // this is used to support the persistSize option
+  // keep the last page count to restore it with the persistSize option
   const lastPageCountRef = useRef<number>(resolvePageCount())
-  // this is used to return the last fetched data while revalidating
-  const lastFetchedDataRef = useRef<Data[]>()
 
   // keep the data inside a ref
   const dataRef = useRef<Data[]>()
@@ -145,7 +143,6 @@ function useSWRInfinite<Data = any, Error = any>(
 
         data.push(pageData)
         previousPageData = pageData
-        lastFetchedDataRef.current = data
       }
 
       // once we executed the data fetching based on the context, clear the context

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -812,5 +812,5 @@ function useSWR<Data = any, Error = any>(
 
 const SWRConfig = SWRConfigContext.Provider
 
-export { trigger, mutate, SWRConfig, useIsomorphicLayoutEffect }
+export { trigger, mutate, SWRConfig }
 export default useSWR

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -584,10 +584,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (
-      isUpdating ||
-      willRevalidateOnMount()
-    ) {
+    if (isUpdating || willRevalidateOnMount()) {
       if (typeof latestKeyedData !== 'undefined' && !IS_SERVER) {
         // delay revalidate if there's cache
         // to not block the rendering

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -2,8 +2,6 @@
 import {
   useCallback,
   useContext,
-  useEffect,
-  useLayoutEffect,
   useState,
   useRef,
   useMemo,
@@ -11,6 +9,7 @@ import {
 } from 'react'
 
 import defaultConfig, { cache } from './config'
+import { IS_SERVER, rAF, useIsomorphicLayoutEffect } from './env'
 import SWRConfigContext from './swr-config-context'
 import {
   Action,
@@ -24,21 +23,6 @@ import {
   Updater,
   SWRConfiguration
 } from './types'
-
-const IS_SERVER =
-  typeof window === 'undefined' ||
-  // @ts-ignore
-  !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
-
-// polyfill for requestAnimationFrame
-const rAF = IS_SERVER
-  ? null
-  : window['requestAnimationFrame'] || (f => setTimeout(f, 1))
-
-// React currently throws a warning when using useLayoutEffect on the server.
-// To get around it, we can conditionally useEffect on the server (no-op) and
-// useLayoutEffect in the browser.
-const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
 
 type Revalidator = (...args: any[]) => void
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -2,6 +2,8 @@
 import {
   useCallback,
   useContext,
+  useEffect,
+  useLayoutEffect,
   useState,
   useRef,
   useMemo,
@@ -23,6 +25,21 @@ import {
   SWRConfiguration
 } from './types'
 
+const IS_SERVER =
+  typeof window === 'undefined' ||
+  // @ts-ignore
+  !!(typeof Deno !== 'undefined' && Deno && Deno.version && Deno.version.deno)
+
+// polyfill for requestAnimationFrame
+const rAF = IS_SERVER
+  ? null
+  : window['requestAnimationFrame'] || (f => setTimeout(f, 1))
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
+
 type Revalidator = (...args: any[]) => void
 
 // global state managers
@@ -40,30 +57,22 @@ const now = (() => {
   return () => ++ts
 })()
 
-const {
-  isOnline,
-  isDocumentVisible,
-  registerOnFocus,
-  registerOnReconnect,
-  IS_SERVER
-} = defaultConfig
-
 // setup DOM events listeners for `focus` and `reconnect` actions
 if (!IS_SERVER) {
   const revalidate = (revalidators: Record<string, Revalidator[]>) => {
-    if (!isDocumentVisible() || !isOnline()) return
+    if (!defaultConfig.isDocumentVisible() || !defaultConfig.isOnline()) return
 
     for (const key in revalidators) {
       if (revalidators[key][0]) revalidators[key][0]()
     }
   }
 
-  if (typeof registerOnFocus === 'function') {
-    registerOnFocus(() => revalidate(FOCUS_REVALIDATORS))
+  if (typeof defaultConfig.registerOnFocus === 'function') {
+    defaultConfig.registerOnFocus(() => revalidate(FOCUS_REVALIDATORS))
   }
 
-  if (typeof registerOnReconnect === 'function') {
-    registerOnReconnect(() => revalidate(RECONNECT_REVALIDATORS))
+  if (typeof defaultConfig.registerOnReconnect === 'function') {
+    defaultConfig.registerOnReconnect(() => revalidate(RECONNECT_REVALIDATORS))
   }
 }
 
@@ -219,8 +228,6 @@ function useSWR<Data = any, Error = any>(
       ? args[1]
       : {}
   )
-
-  const { rAF, useIsomorphicLayoutEffect } = config
 
   // in typescript args.length > 2 is not same as args.lenth === 3
   // we do a safe type assertion here
@@ -821,5 +828,5 @@ function useSWR<Data = any, Error = any>(
 
 const SWRConfig = SWRConfigContext.Provider
 
-export { trigger, mutate, SWRConfig }
+export { trigger, mutate, SWRConfig, useIsomorphicLayoutEffect }
 export default useSWR

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -828,5 +828,5 @@ function useSWR<Data = any, Error = any>(
 
 const SWRConfig = SWRConfigContext.Provider
 
-export { trigger, mutate, SWRConfig }
+export { trigger, mutate, SWRConfig, useIsomorphicLayoutEffect }
 export default useSWR

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -160,7 +160,7 @@ describe('useSWR - config callbacks', () => {
     expect(state).toEqual(null)
 
     // should trigger a loading slow event
-    await act(() => sleep(LOADING_TIMEOUT))
+    await act(() => sleep(LOADING_TIMEOUT * 1.5))
     screen.getByText('hello, , a')
     expect(state).toEqual('a')
 

--- a/test/use-swr-configs.test.tsx
+++ b/test/use-swr-configs.test.tsx
@@ -6,7 +6,7 @@ import { sleep } from './utils'
 describe('useSWR - configs', () => {
   it('should read the config fallback from the context', async () => {
     let value = 0
-    const INTERVAL = 10
+    const INTERVAL = 100
     const fetcher = () => value++
 
     function Section() {

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -547,7 +547,7 @@ describe('useSWRInfinite', () => {
               </li>
             ))}
           </ul>
-          <button onClick={() => setSize(size + 1)}>click</button>
+          <button onClick={() => setSize(size + 1)}>{props.label}:click</button>
         </>
       )
     }
@@ -566,7 +566,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('A:page-1-2')
     await screen.findByText('B:page-1-2')
 
-    fireEvent.click(screen.getByText('click'))
+    fireEvent.click(screen.getByText('A:click'))
 
     // render responses for page=2
     await screen.findByText('A:page-2-2')

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -514,4 +514,62 @@ describe('useSWRInfinite', () => {
     await screen.findByText('page-1-1, page-1-2, page-2-1, page-2-2')
     expect(requests).toEqual(['/api?page=1', '/api?page=2'])
   })
+
+  it('should share data between multiple hooks have the same key', async () => {
+    const dummyResponses = {
+      '/api?page=1': ['page-1-1', 'page-1-2'],
+      '/api?page=2': ['page-2-1', 'page-2-2']
+    }
+    const useCustomSWRInfinite = () => {
+      const { data, setSize, size } = useSWRInfinite<string[], string>(
+        index => {
+          return [`page-test-11`, `/api?page=${index + 1}`]
+        },
+        async (_, index) => {
+          return dummyResponses[index]
+        }
+      )
+      return {
+        data: data ? [].concat(...data) : [],
+        setSize,
+        size
+      }
+    }
+
+    const Component = (props: { label: string }) => {
+      const { data, size, setSize } = useCustomSWRInfinite()
+      return (
+        <>
+          <ul>
+            {data.map(value => (
+              <li key={value}>
+                {props.label}:{value}
+              </li>
+            ))}
+          </ul>
+          <button onClick={() => setSize(size + 1)}>click</button>
+        </>
+      )
+    }
+
+    function Page() {
+      return (
+        <div>
+          <Component label="A" />
+          <Component label="B" />
+        </div>
+      )
+    }
+    render(<Page />)
+
+    // render responses for page=1
+    await screen.findByText('A:page-1-2')
+    await screen.findByText('B:page-1-2')
+
+    fireEvent.click(screen.getByText('click'))
+
+    // render responses for page=2
+    await screen.findByText('A:page-2-2')
+    await screen.findByText('B:page-2-2')
+  })
 })


### PR DESCRIPTION
fixes #976
This PR fixes issues caused by using multiple `useSWRInfinite` on a page.
You can see the issues in the following link (v0.42).

- **v0.42**: https://codesandbox.io/s/swr-basic-forked-nw6z4
- **THIS PR**: https://codesandbox.io/s/swr-basic-forked-uo7r0

This PR also fixes #976.
https://codesandbox.io/s/swr-basic-forked-mbx6y

I guess this is a naive implementation and would change some behaviors of `useSWRInfinite`, so it should be merged carefully.