### PR TITLE
Clean up types

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,7 @@
-import { CacheInterface, keyInterface, cacheListener } from './types'
+import { Cache as CacheType, keyInterface, cacheListener } from './types'
 import hash from './libs/hash'
 
-export default class Cache implements CacheInterface {
+export default class Cache implements CacheType {
   private __cache: Map<string, any>
   private __listeners: cacheListener[]
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,9 +1,9 @@
-import { Cache as CacheType, Key, cacheListener } from './types'
+import { Cache as CacheType, Key, CacheListener } from './types'
 import hash from './libs/hash'
 
 export default class Cache implements CacheType {
   private __cache: Map<string, any>
-  private __listeners: cacheListener[]
+  private __listeners: CacheListener[]
 
   constructor(initialData: any = {}) {
     this.__cache = new Map(Object.entries(initialData))
@@ -68,7 +68,7 @@ export default class Cache implements CacheType {
     return [key, args, errorKey, isValidatingKey]
   }
 
-  subscribe(listener: cacheListener) {
+  subscribe(listener: CacheListener) {
     if (typeof listener !== 'function') {
       throw new Error('Expected the listener to be a function.')
     }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,4 @@
-import { Cache as CacheType, keyInterface, cacheListener } from './types'
+import { Cache as CacheType, Key, cacheListener } from './types'
 import hash from './libs/hash'
 
 export default class Cache implements CacheType {
@@ -10,12 +10,12 @@ export default class Cache implements CacheType {
     this.__listeners = []
   }
 
-  get(key: keyInterface): any {
+  get(key: Key): any {
     const [_key] = this.serializeKey(key)
     return this.__cache.get(_key)
   }
 
-  set(key: keyInterface, value: any): any {
+  set(key: Key, value: any): any {
     const [_key] = this.serializeKey(key)
     this.__cache.set(_key, value)
     this.notify()
@@ -25,7 +25,7 @@ export default class Cache implements CacheType {
     return Array.from(this.__cache.keys())
   }
 
-  has(key: keyInterface) {
+  has(key: Key) {
     const [_key] = this.serializeKey(key)
     return this.__cache.has(_key)
   }
@@ -35,14 +35,14 @@ export default class Cache implements CacheType {
     this.notify()
   }
 
-  delete(key: keyInterface) {
+  delete(key: Key) {
     const [_key] = this.serializeKey(key)
     this.__cache.delete(_key)
     this.notify()
   }
 
   // TODO: introduce namespace for the cache
-  serializeKey(key: keyInterface): [string, any, string, string] {
+  serializeKey(key: Key): [string, any, string, string] {
     let args = null
     if (typeof key === 'function') {
       try {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { dequal } from 'dequal/lite'
 import {
-  ConfigInterface,
+  SWRConfiguration,
   RevalidateOptionInterface,
   revalidateType
 } from './types'
@@ -14,7 +14,7 @@ const cache = new Cache()
 function onErrorRetry(
   _,
   __,
-  config: ConfigInterface,
+  config: SWRConfiguration,
   revalidate: revalidateType,
   opts: RevalidateOptionInterface
 ): void {
@@ -47,7 +47,7 @@ const slowConnection =
   ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1
 
 // config
-const defaultConfig: ConfigInterface = Object.assign(
+const defaultConfig: SWRConfiguration = Object.assign(
   {
     // events
     onLoadingSlow: () => {},

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { dequal } from 'dequal/lite'
-import { SWRConfiguration, RevalidateOptions, revalidateType } from './types'
+import { SWRConfiguration, RevalidateOptions, Revalidator } from './types'
 import Cache from './cache'
 import webPreset from './libs/web-preset'
 
@@ -11,7 +11,7 @@ function onErrorRetry(
   _,
   __,
   config: SWRConfiguration,
-  revalidate: revalidateType,
+  revalidate: Revalidator,
   opts: RevalidateOptions
 ): void {
   if (!config.isDocumentVisible()) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,9 +1,5 @@
 import { dequal } from 'dequal/lite'
-import {
-  SWRConfiguration,
-  RevalidateOptionInterface,
-  revalidateType
-} from './types'
+import { SWRConfiguration, RevalidateOptions, revalidateType } from './types'
 import Cache from './cache'
 import webPreset from './libs/web-preset'
 
@@ -16,7 +12,7 @@ function onErrorRetry(
   __,
   config: SWRConfiguration,
   revalidate: revalidateType,
-  opts: RevalidateOptionInterface
+  opts: RevalidateOptions
 ): void {
   if (!config.isDocumentVisible()) {
     // if it's hidden, stop

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { dequal } from 'dequal/lite'
-import { SWRConfiguration, RevalidateOptions, Revalidator } from './types'
+import { SWRConfiguration, RevalidatorOptions, Revalidator } from './types'
 import Cache from './cache'
 import webPreset from './libs/web-preset'
 
@@ -12,7 +12,7 @@ function onErrorRetry(
   __,
   config: SWRConfiguration,
   revalidate: Revalidator,
-  opts: RevalidateOptions
+  opts: RevalidatorOptions
 ): void {
   if (!config.isDocumentVisible()) {
     // if it's hidden, stop

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,11 +11,6 @@ export { cache } from './config'
 
 // Types
 export {
-  // Legacy
-  ConfigInterface,
-  SWRInfiniteConfigInterface,
-  SWRInfiniteResponseInterface,
-  // Latest
   SWRConfiguration,
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
@@ -23,5 +18,10 @@ export {
   RevalidateOptionInterface,
   keyInterface,
   responseInterface,
+  Cache,
+  // Legacy, for backwards compatibility
+  ConfigInterface,
+  SWRInfiniteConfigInterface,
+  SWRInfiniteResponseInterface,
   CacheInterface
 } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export {
   Revalidator,
   RevalidateOptions,
   Key,
-  responseInterface,
+  SWRResponse,
   Cache,
   // Legacy, for backwards compatibility
   ConfigInterface,
@@ -26,5 +26,6 @@ export {
   revalidateType,
   RevalidateOptionInterface,
   keyInterface,
+  responseInterface,
   CacheInterface
 } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export {
   SWRConfiguration,
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
-  revalidateType,
+  Revalidator,
   RevalidateOptions,
   Key,
   responseInterface,
@@ -23,7 +23,8 @@ export {
   ConfigInterface,
   SWRInfiniteConfigInterface,
   SWRInfiniteResponseInterface,
+  revalidateType,
   RevalidateOptionInterface,
-  CacheInterface,
-  keyInterface
+  keyInterface,
+  CacheInterface
 } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,7 @@ export default useSWR
 export * from './use-swr'
 
 // `useSWRInfinite`
-export {
-  useSWRInfinite,
-  SWRInfiniteConfigInterface,
-  SWRInfiniteResponseInterface
-} from './use-swr-infinite'
+export { useSWRInfinite } from './use-swr-infinite'
 
 // Cache related, to be replaced by the new APIs
 export { cache } from './config'
@@ -17,8 +13,12 @@ export { cache } from './config'
 export {
   // Legacy
   ConfigInterface,
+  SWRInfiniteConfigInterface,
+  SWRInfiniteResponseInterface,
   // Latest
   SWRConfiguration,
+  SWRInfiniteConfiguration,
+  SWRInfiniteResponse,
   revalidateType,
   RevalidateOptionInterface,
   keyInterface,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   Revalidator,
-  RevalidateOptions,
+  RevalidatorOptions,
   Key,
   SWRResponse,
   Cache,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,15 @@ export {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   revalidateType,
-  RevalidateOptionInterface,
-  keyInterface,
+  RevalidateOptions,
+  Key,
   responseInterface,
   Cache,
   // Legacy, for backwards compatibility
   ConfigInterface,
   SWRInfiniteConfigInterface,
   SWRInfiniteResponseInterface,
-  CacheInterface
+  RevalidateOptionInterface,
+  CacheInterface,
+  keyInterface
 } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,27 @@
-export * from './use-swr'
+// `useSWR` and related APIs
 import { default as useSWR } from './use-swr'
+export default useSWR
+export * from './use-swr'
+
+// `useSWRInfinite`
 export {
   useSWRInfinite,
   SWRInfiniteConfigInterface,
   SWRInfiniteResponseInterface
 } from './use-swr-infinite'
+
+// Cache related, to be replaced by the new APIs
 export { cache } from './config'
+
+// Types
 export {
+  // Legacy
   ConfigInterface,
+  // Latest
+  SWRConfiguration,
   revalidateType,
   RevalidateOptionInterface,
   keyInterface,
   responseInterface,
   CacheInterface
 } from './types'
-export default useSWR

--- a/src/swr-config-context.ts
+++ b/src/swr-config-context.ts
@@ -1,8 +1,8 @@
 import { createContext } from 'react'
 
-import { ConfigInterface } from './types'
+import { SWRConfiguration } from './types'
 
-const SWRConfigContext = createContext<Partial<ConfigInterface>>({})
+const SWRConfigContext = createContext<SWRConfiguration>({})
 SWRConfigContext.displayName = 'SWRConfigContext'
 
 export default SWRConfigContext

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type Configuration<
     key: string,
     config: Configuration<Data, Error>,
     revalidate: revalidateType,
-    revalidateOpts: RevalidateOptionInterface
+    revalidateOpts: RevalidateOptions
   ) => void
   registerOnFocus?: (cb: () => void) => void
   registerOnReconnect?: (cb: () => void) => void
@@ -46,14 +46,9 @@ export type Configuration<
   compare: (a: Data | undefined, b: Data | undefined) => boolean
 }
 
-export interface RevalidateOptionInterface {
-  retryCount?: number
-  dedupe?: boolean
-}
-
 export type keyType = string | any[] | null
 type keyFunction = () => keyType
-export type keyInterface = keyFunction | keyType
+
 export type updaterInterface<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,
@@ -62,14 +57,14 @@ export type updaterInterface<Data = any, Error = any> = (
   dedupe?: boolean
 ) => boolean | Promise<boolean>
 export type triggerInterface = (
-  key: keyInterface,
+  key: Key,
   shouldRevalidate?: boolean
 ) => Promise<any>
 export type mutateCallback<Data = any> = (
   currentValue: undefined | Data
 ) => Promise<undefined | Data> | undefined | Data
 export type mutateInterface<Data = any> = (
-  key: keyInterface,
+  key: Key,
   data?: Data | Promise<Data> | mutateCallback<Data>,
   shouldRevalidate?: boolean
 ) => Promise<Data | undefined>
@@ -90,7 +85,7 @@ export type responseInterface<Data, Error> = {
   isValidating: boolean
 }
 export type revalidateType = (
-  revalidateOpts: RevalidateOptionInterface
+  revalidateOpts: RevalidateOptions
 ) => Promise<boolean>
 
 export type actionType<Data, Error> = {
@@ -163,22 +158,40 @@ export type SWRInfiniteResponse<Data = any, Error = any> = responseInterface<
  * @deprecated `CacheInterface` will be renamed to `Cache`.
  */
 export interface CacheInterface {
-  get(key: keyInterface): any
-  set(key: keyInterface, value: any): any
+  get(key: Key): any
+  set(key: Key, value: any): any
   keys(): string[]
-  has(key: keyInterface): boolean
-  delete(key: keyInterface): void
+  has(key: Key): boolean
+  delete(key: Key): void
   clear(): void
-  serializeKey(key: keyInterface): [string, any, string, string]
+  serializeKey(key: Key): [string, any, string, string]
   subscribe(listener: cacheListener): () => void
 }
 export interface Cache {
-  get(key: keyInterface): any
-  set(key: keyInterface, value: any): any
+  get(key: Key): any
+  set(key: Key, value: any): any
   keys(): string[]
-  has(key: keyInterface): boolean
-  delete(key: keyInterface): void
+  has(key: Key): boolean
+  delete(key: Key): void
   clear(): void
-  serializeKey(key: keyInterface): [string, any, string, string]
+  serializeKey(key: Key): [string, any, string, string]
   subscribe(listener: cacheListener): () => void
 }
+
+/**
+ * @deprecated `RevalidateOptionInterface` will be renamed to `RevalidateOptions`.
+ */
+export interface RevalidateOptionInterface {
+  retryCount?: number
+  dedupe?: boolean
+}
+export interface RevalidateOptions {
+  retryCount?: number
+  dedupe?: boolean
+}
+
+/**
+ * @deprecated `keyInterface` will be renamed to `Key`.
+ */
+export type keyInterface = keyFunction | keyType
+export type Key = keyFunction | keyType

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,9 +84,6 @@ export type responseInterface<Data, Error> = {
   ) => Promise<Data | undefined>
   isValidating: boolean
 }
-export type revalidateType = (
-  revalidateOpts: RevalidateOptions
-) => Promise<boolean>
 
 export type actionType<Data, Error> = {
   data?: Data
@@ -195,3 +192,13 @@ export interface RevalidateOptions {
  */
 export type keyInterface = keyFunction | keyType
 export type Key = keyFunction | keyType
+
+/**
+ * @deprecated `revalidateType` will be renamed to `Revalidator`.
+ */
+export type revalidateType = (
+  revalidateOpts: RevalidateOptions
+) => Promise<boolean>
+export type Revalidator = (
+  revalidateOpts: RevalidateOptions
+) => Promise<boolean>

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,26 +99,10 @@ export type actionType<Data, Error> = {
   isValidating?: boolean
 }
 
-export interface CacheInterface {
-  get(key: keyInterface): any
-  set(key: keyInterface, value: any): any
-  keys(): string[]
-  has(key: keyInterface): boolean
-  delete(key: keyInterface): void
-  clear(): void
-  serializeKey(key: keyInterface): [string, any, string, string]
-  subscribe(listener: cacheListener): () => void
-}
-
 export type cacheListener = () => void
 
 // Public types
 
-export type SWRConfiguration<
-  Data = any,
-  Error = any,
-  Fn extends fetcherFn<Data> = fetcherFn<Data>
-> = Partial<Configuration<Data, Error, Fn>>
 /**
  * @deprecated `ConfigInterface` will be renamed to `SWRConfiguration`.
  */
@@ -127,15 +111,12 @@ export type ConfigInterface<
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > = Partial<Configuration<Data, Error, Fn>>
-
-export type SWRInfiniteConfiguration<
+export type SWRConfiguration<
   Data = any,
-  Error = any
-> = SWRConfiguration<Data[], Error, fetcherFn<Data[]>> & {
-  initialSize?: number
-  revalidateAll?: boolean
-  persistSize?: boolean
-}
+  Error = any,
+  Fn extends fetcherFn<Data> = fetcherFn<Data>
+> = Partial<Configuration<Data, Error, Fn>>
+
 /**
  * @deprecated `SWRInfiniteConfigInterface` will be renamed to `SWRInfiniteConfiguration`.
  */
@@ -147,16 +128,15 @@ export type SWRInfiniteConfigInterface<
   revalidateAll?: boolean
   persistSize?: boolean
 }
-
-export type SWRInfiniteResponse<Data = any, Error = any> = responseInterface<
-  Data[],
-  Error
-> & {
-  size: number
-  setSize: (
-    size: number | ((size: number) => number)
-  ) => Promise<Data[] | undefined>
+export type SWRInfiniteConfiguration<
+  Data = any,
+  Error = any
+> = SWRConfiguration<Data[], Error, fetcherFn<Data[]>> & {
+  initialSize?: number
+  revalidateAll?: boolean
+  persistSize?: boolean
 }
+
 /**
  * @deprecated `SWRInfiniteResponseInterface` will be renamed to `SWRInfiniteResponse`.
  */
@@ -168,4 +148,37 @@ export type SWRInfiniteResponseInterface<
   setSize: (
     size: number | ((size: number) => number)
   ) => Promise<Data[] | undefined>
+}
+export type SWRInfiniteResponse<Data = any, Error = any> = responseInterface<
+  Data[],
+  Error
+> & {
+  size: number
+  setSize: (
+    size: number | ((size: number) => number)
+  ) => Promise<Data[] | undefined>
+}
+
+/**
+ * @deprecated `CacheInterface` will be renamed to `Cache`.
+ */
+export interface CacheInterface {
+  get(key: keyInterface): any
+  set(key: keyInterface, value: any): any
+  keys(): string[]
+  has(key: keyInterface): boolean
+  delete(key: keyInterface): void
+  clear(): void
+  serializeKey(key: keyInterface): [string, any, string, string]
+  subscribe(listener: cacheListener): () => void
+}
+export interface Cache {
+  get(key: keyInterface): any
+  set(key: keyInterface, value: any): any
+  keys(): string[]
+  has(key: keyInterface): boolean
+  delete(key: keyInterface): void
+  clear(): void
+  serializeKey(key: keyInterface): [string, any, string, string]
+  subscribe(listener: cacheListener): () => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,12 @@
+// Internal types
+
 export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
-export interface ConfigInterface<
+
+export type Configuration<
   Data = any,
   Error = any,
   Fn extends fetcherFn<Data> = fetcherFn<Data>
-> {
+> = {
   errorRetryInterval: number
   errorRetryCount?: number
   loadingTimeout: number
@@ -16,28 +19,24 @@ export interface ConfigInterface<
   revalidateOnMount?: boolean
   revalidateOnReconnect: boolean
   shouldRetryOnError: boolean
-  fetcher: Fn
   suspense: boolean
+  fetcher: Fn
   initialData?: Data
 
   isOnline: () => boolean
   isDocumentVisible: () => boolean
   isPaused: () => boolean
-  onLoadingSlow: (key: string, config: ConfigInterface<Data, Error>) => void
+  onLoadingSlow: (key: string, config: Configuration<Data, Error>) => void
   onSuccess: (
     data: Data,
     key: string,
-    config: ConfigInterface<Data, Error>
+    config: Configuration<Data, Error>
   ) => void
-  onError: (
-    err: Error,
-    key: string,
-    config: ConfigInterface<Data, Error>
-  ) => void
+  onError: (err: Error, key: string, config: Configuration<Data, Error>) => void
   onErrorRetry: (
     err: Error,
     key: string,
-    config: ConfigInterface<Data, Error>,
+    config: Configuration<Data, Error>,
     revalidate: revalidateType,
     revalidateOpts: RevalidateOptionInterface
   ) => void
@@ -112,3 +111,20 @@ export interface CacheInterface {
 }
 
 export type cacheListener = () => void
+
+// Public types
+
+/**
+ * @deprecated `ConfigInterface` will be renamed to `SWRConfiguration`.
+ */
+export type ConfigInterface<
+  Data = any,
+  Error = any,
+  Fn extends fetcherFn<Data> = fetcherFn<Data>
+> = Partial<Configuration<Data, Error, Fn>>
+
+export type SWRConfiguration<
+  Data = any,
+  Error = any,
+  Fn extends fetcherFn<Data> = fetcherFn<Data>
+> = Partial<Configuration<Data, Error, Fn>>

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,11 @@ export type cacheListener = () => void
 
 // Public types
 
+export type SWRConfiguration<
+  Data = any,
+  Error = any,
+  Fn extends fetcherFn<Data> = fetcherFn<Data>
+> = Partial<Configuration<Data, Error, Fn>>
 /**
  * @deprecated `ConfigInterface` will be renamed to `SWRConfiguration`.
  */
@@ -123,8 +128,44 @@ export type ConfigInterface<
   Fn extends fetcherFn<Data> = fetcherFn<Data>
 > = Partial<Configuration<Data, Error, Fn>>
 
-export type SWRConfiguration<
+export type SWRInfiniteConfiguration<
   Data = any,
-  Error = any,
-  Fn extends fetcherFn<Data> = fetcherFn<Data>
-> = Partial<Configuration<Data, Error, Fn>>
+  Error = any
+> = SWRConfiguration<Data[], Error, fetcherFn<Data[]>> & {
+  initialSize?: number
+  revalidateAll?: boolean
+  persistSize?: boolean
+}
+/**
+ * @deprecated `SWRInfiniteConfigInterface` will be renamed to `SWRInfiniteConfiguration`.
+ */
+export type SWRInfiniteConfigInterface<
+  Data = any,
+  Error = any
+> = SWRConfiguration<Data[], Error, fetcherFn<Data[]>> & {
+  initialSize?: number
+  revalidateAll?: boolean
+  persistSize?: boolean
+}
+
+export type SWRInfiniteResponse<Data = any, Error = any> = responseInterface<
+  Data[],
+  Error
+> & {
+  size: number
+  setSize: (
+    size: number | ((size: number) => number)
+  ) => Promise<Data[] | undefined>
+}
+/**
+ * @deprecated `SWRInfiniteResponseInterface` will be renamed to `SWRInfiniteResponse`.
+ */
+export type SWRInfiniteResponseInterface<
+  Data = any,
+  Error = any
+> = responseInterface<Data[], Error> & {
+  size: number
+  setSize: (
+    size: number | ((size: number) => number)
+  ) => Promise<Data[] | undefined>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,11 @@
 // Internal types
 
-export type fetcherFn<Data> = (...args: any) => Data | Promise<Data>
+export type Fetcher<Data> = (...args: any) => Data | Promise<Data>
 
 export type Configuration<
   Data = any,
   Error = any,
-  Fn extends fetcherFn<Data> = fetcherFn<Data>
+  Fn extends Fetcher<Data> = Fetcher<Data>
 > = {
   errorRetryInterval: number
   errorRetryCount?: number
@@ -46,42 +46,40 @@ export type Configuration<
   compare: (a: Data | undefined, b: Data | undefined) => boolean
 }
 
-export type keyType = string | any[] | null
-type keyFunction = () => keyType
+export type ValueKey = string | any[] | null
 
-export type updaterInterface<Data = any, Error = any> = (
+export type Updater<Data = any, Error = any> = (
   shouldRevalidate?: boolean,
   data?: Data,
   error?: Error,
   shouldDedupe?: boolean,
   dedupe?: boolean
 ) => boolean | Promise<boolean>
-export type triggerInterface = (
-  key: Key,
-  shouldRevalidate?: boolean
-) => Promise<any>
-export type mutateCallback<Data = any> = (
+export type Trigger = (key: Key, shouldRevalidate?: boolean) => Promise<any>
+
+type MutatorCallback<Data = any> = (
   currentValue: undefined | Data
 ) => Promise<undefined | Data> | undefined | Data
-export type mutateInterface<Data = any> = (
+
+export type Mutator<Data = any> = (
   key: Key,
-  data?: Data | Promise<Data> | mutateCallback<Data>,
+  data?: Data | Promise<Data> | MutatorCallback<Data>,
   shouldRevalidate?: boolean
 ) => Promise<Data | undefined>
-export type broadcastStateInterface<Data = any, Error = any> = (
+export type Broadcaster<Data = any, Error = any> = (
   key: string,
   data: Data,
   error?: Error,
   isValidating?: boolean
 ) => void
 
-export type actionType<Data, Error> = {
+export type Action<Data, Error> = {
   data?: Data
   error?: Error
   isValidating?: boolean
 }
 
-export type cacheListener = () => void
+export type CacheListener = () => void
 
 // Public types
 
@@ -91,19 +89,19 @@ export type cacheListener = () => void
 export type ConfigInterface<
   Data = any,
   Error = any,
-  Fn extends fetcherFn<Data> = fetcherFn<Data>
+  Fn extends Fetcher<Data> = Fetcher<Data>
 > = Partial<Configuration<Data, Error, Fn>>
 export type SWRConfiguration<
   Data = any,
   Error = any,
-  Fn extends fetcherFn<Data> = fetcherFn<Data>
+  Fn extends Fetcher<Data> = Fetcher<Data>
 > = Partial<Configuration<Data, Error, Fn>>
 
 /**
  * @deprecated `keyInterface` will be renamed to `Key`.
  */
-export type keyInterface = keyFunction | keyType
-export type Key = keyFunction | keyType
+export type keyInterface = ValueKey | (() => ValueKey)
+export type Key = ValueKey | (() => ValueKey)
 
 /**
  * @deprecated `responseInterface` will be renamed to `SWRResponse`.
@@ -113,7 +111,7 @@ export type responseInterface<Data, Error> = {
   error?: Error
   revalidate: () => Promise<boolean>
   mutate: (
-    data?: Data | Promise<Data> | mutateCallback<Data>,
+    data?: Data | Promise<Data> | MutatorCallback<Data>,
     shouldRevalidate?: boolean
   ) => Promise<Data | undefined>
   isValidating: boolean
@@ -123,7 +121,7 @@ export type SWRResponse<Data, Error> = {
   error?: Error
   revalidate: () => Promise<boolean>
   mutate: (
-    data?: Data | Promise<Data> | mutateCallback<Data>,
+    data?: Data | Promise<Data> | MutatorCallback<Data>,
     shouldRevalidate?: boolean
   ) => Promise<Data | undefined>
   isValidating: boolean
@@ -135,7 +133,7 @@ export type SWRResponse<Data, Error> = {
 export type SWRInfiniteConfigInterface<
   Data = any,
   Error = any
-> = SWRConfiguration<Data[], Error, fetcherFn<Data[]>> & {
+> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
   initialSize?: number
   revalidateAll?: boolean
   persistSize?: boolean
@@ -143,7 +141,7 @@ export type SWRInfiniteConfigInterface<
 export type SWRInfiniteConfiguration<
   Data = any,
   Error = any
-> = SWRConfiguration<Data[], Error, fetcherFn<Data[]>> & {
+> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
   initialSize?: number
   revalidateAll?: boolean
   persistSize?: boolean
@@ -204,7 +202,7 @@ export interface CacheInterface {
   delete(key: Key): void
   clear(): void
   serializeKey(key: Key): [string, any, string, string]
-  subscribe(listener: cacheListener): () => void
+  subscribe(listener: CacheListener): () => void
 }
 export interface Cache {
   get(key: Key): any
@@ -214,5 +212,5 @@ export interface Cache {
   delete(key: Key): void
   clear(): void
   serializeKey(key: Key): [string, any, string, string]
-  subscribe(listener: cacheListener): () => void
+  subscribe(listener: CacheListener): () => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export type Configuration<
     err: Error,
     key: string,
     config: Configuration<Data, Error>,
-    revalidate: revalidateType,
+    revalidate: Revalidator,
     revalidateOpts: RevalidateOptions
   ) => void
   registerOnFocus?: (cb: () => void) => void
@@ -74,16 +74,6 @@ export type broadcastStateInterface<Data = any, Error = any> = (
   error?: Error,
   isValidating?: boolean
 ) => void
-export type responseInterface<Data, Error> = {
-  data?: Data
-  error?: Error
-  revalidate: () => Promise<boolean>
-  mutate: (
-    data?: Data | Promise<Data> | mutateCallback<Data>,
-    shouldRevalidate?: boolean
-  ) => Promise<Data | undefined>
-  isValidating: boolean
-}
 
 export type actionType<Data, Error> = {
   data?: Data
@@ -132,16 +122,16 @@ export type SWRInfiniteConfiguration<
 /**
  * @deprecated `SWRInfiniteResponseInterface` will be renamed to `SWRInfiniteResponse`.
  */
-export type SWRInfiniteResponseInterface<
-  Data = any,
-  Error = any
-> = responseInterface<Data[], Error> & {
+export type SWRInfiniteResponseInterface<Data = any, Error = any> = SWRResponse<
+  Data[],
+  Error
+> & {
   size: number
   setSize: (
     size: number | ((size: number) => number)
   ) => Promise<Data[] | undefined>
 }
-export type SWRInfiniteResponse<Data = any, Error = any> = responseInterface<
+export type SWRInfiniteResponse<Data = any, Error = any> = SWRResponse<
   Data[],
   Error
 > & {
@@ -202,3 +192,27 @@ export type revalidateType = (
 export type Revalidator = (
   revalidateOpts: RevalidateOptions
 ) => Promise<boolean>
+
+/**
+ * @deprecated `responseInterface` will be renamed to `SWRResponse`.
+ */
+export type responseInterface<Data, Error> = {
+  data?: Data
+  error?: Error
+  revalidate: () => Promise<boolean>
+  mutate: (
+    data?: Data | Promise<Data> | mutateCallback<Data>,
+    shouldRevalidate?: boolean
+  ) => Promise<Data | undefined>
+  isValidating: boolean
+}
+export type SWRResponse<Data, Error> = {
+  data?: Data
+  error?: Error
+  revalidate: () => Promise<boolean>
+  mutate: (
+    data?: Data | Promise<Data> | mutateCallback<Data>,
+    shouldRevalidate?: boolean
+  ) => Promise<Data | undefined>
+  isValidating: boolean
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export type Configuration<
     key: string,
     config: Configuration<Data, Error>,
     revalidate: Revalidator,
-    revalidateOpts: RevalidateOptions
+    revalidateOpts: RevalidatorOptions
   ) => void
   registerOnFocus?: (cb: () => void) => void
   registerOnReconnect?: (cb: () => void) => void
@@ -100,6 +100,36 @@ export type SWRConfiguration<
 > = Partial<Configuration<Data, Error, Fn>>
 
 /**
+ * @deprecated `keyInterface` will be renamed to `Key`.
+ */
+export type keyInterface = keyFunction | keyType
+export type Key = keyFunction | keyType
+
+/**
+ * @deprecated `responseInterface` will be renamed to `SWRResponse`.
+ */
+export type responseInterface<Data, Error> = {
+  data?: Data
+  error?: Error
+  revalidate: () => Promise<boolean>
+  mutate: (
+    data?: Data | Promise<Data> | mutateCallback<Data>,
+    shouldRevalidate?: boolean
+  ) => Promise<Data | undefined>
+  isValidating: boolean
+}
+export type SWRResponse<Data, Error> = {
+  data?: Data
+  error?: Error
+  revalidate: () => Promise<boolean>
+  mutate: (
+    data?: Data | Promise<Data> | mutateCallback<Data>,
+    shouldRevalidate?: boolean
+  ) => Promise<Data | undefined>
+  isValidating: boolean
+}
+
+/**
  * @deprecated `SWRInfiniteConfigInterface` will be renamed to `SWRInfiniteConfiguration`.
  */
 export type SWRInfiniteConfigInterface<
@@ -142,6 +172,28 @@ export type SWRInfiniteResponse<Data = any, Error = any> = SWRResponse<
 }
 
 /**
+ * @deprecated `RevalidateOptionInterface` will be renamed to `RevalidatorOptions`.
+ */
+export interface RevalidateOptionInterface {
+  retryCount?: number
+  dedupe?: boolean
+}
+export interface RevalidatorOptions {
+  retryCount?: number
+  dedupe?: boolean
+}
+
+/**
+ * @deprecated `revalidateType` will be renamed to `Revalidator`.
+ */
+export type revalidateType = (
+  revalidateOpts: RevalidatorOptions
+) => Promise<boolean>
+export type Revalidator = (
+  revalidateOpts: RevalidatorOptions
+) => Promise<boolean>
+
+/**
  * @deprecated `CacheInterface` will be renamed to `Cache`.
  */
 export interface CacheInterface {
@@ -163,56 +215,4 @@ export interface Cache {
   clear(): void
   serializeKey(key: Key): [string, any, string, string]
   subscribe(listener: cacheListener): () => void
-}
-
-/**
- * @deprecated `RevalidateOptionInterface` will be renamed to `RevalidateOptions`.
- */
-export interface RevalidateOptionInterface {
-  retryCount?: number
-  dedupe?: boolean
-}
-export interface RevalidateOptions {
-  retryCount?: number
-  dedupe?: boolean
-}
-
-/**
- * @deprecated `keyInterface` will be renamed to `Key`.
- */
-export type keyInterface = keyFunction | keyType
-export type Key = keyFunction | keyType
-
-/**
- * @deprecated `revalidateType` will be renamed to `Revalidator`.
- */
-export type revalidateType = (
-  revalidateOpts: RevalidateOptions
-) => Promise<boolean>
-export type Revalidator = (
-  revalidateOpts: RevalidateOptions
-) => Promise<boolean>
-
-/**
- * @deprecated `responseInterface` will be renamed to `SWRResponse`.
- */
-export type responseInterface<Data, Error> = {
-  data?: Data
-  error?: Error
-  revalidate: () => Promise<boolean>
-  mutate: (
-    data?: Data | Promise<Data> | mutateCallback<Data>,
-    shouldRevalidate?: boolean
-  ) => Promise<Data | undefined>
-  isValidating: boolean
-}
-export type SWRResponse<Data, Error> = {
-  data?: Data
-  error?: Error
-  revalidate: () => Promise<boolean>
-  mutate: (
-    data?: Data | Promise<Data> | mutateCallback<Data>,
-    shouldRevalidate?: boolean
-  ) => Promise<Data | undefined>
-  isValidating: boolean
 }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -7,51 +7,33 @@ import useSWR from './use-swr'
 import {
   keyType,
   fetcherFn,
-  SWRConfiguration,
-  responseInterface
+  SWRInfiniteConfiguration,
+  SWRInfiniteResponse
 } from './types'
 
 type KeyLoader<Data = any> = (
   index: number,
   previousPageData: Data | null
 ) => keyType
-type SWRInfiniteConfigInterface<Data = any, Error = any> = SWRConfiguration<
-  Data[],
-  Error,
-  fetcherFn<Data[]>
-> & {
-  initialSize?: number
-  revalidateAll?: boolean
-  persistSize?: boolean
-}
-type SWRInfiniteResponseInterface<Data = any, Error = any> = responseInterface<
-  Data[],
-  Error
-> & {
-  size: number
-  setSize: (
-    size: number | ((size: number) => number)
-  ) => Promise<Data[] | undefined>
-}
 
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>
-): SWRInfiniteResponseInterface<Data, Error>
+): SWRInfiniteResponse<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
-  config?: Partial<SWRInfiniteConfigInterface<Data, Error>>
-): SWRInfiniteResponseInterface<Data, Error>
+  config?: Partial<SWRInfiniteConfiguration<Data, Error>>
+): SWRInfiniteResponse<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
   fn?: fetcherFn<Data>,
-  config?: Partial<SWRInfiniteConfigInterface<Data, Error>>
-): SWRInfiniteResponseInterface<Data, Error>
+  config?: Partial<SWRInfiniteConfiguration<Data, Error>>
+): SWRInfiniteResponse<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
   ...options: any[]
-): SWRInfiniteResponseInterface<Data, Error> {
+): SWRInfiniteResponse<Data, Error> {
   let _fn: fetcherFn<Data> | undefined,
-    _config: Partial<SWRInfiniteConfigInterface<Data, Error>> = {}
+    _config: Partial<SWRInfiniteConfiguration<Data, Error>> = {}
 
   if (options.length > 1) {
     _fn = options[0]
@@ -64,7 +46,7 @@ function useSWRInfinite<Data = any, Error = any>(
     }
   }
 
-  const config: SWRInfiniteConfigInterface<Data, Error> = Object.assign(
+  const config: SWRInfiniteConfiguration<Data, Error> = Object.assign(
     {},
     defaultConfig,
     useContext(SWRConfigContext),
@@ -246,11 +228,7 @@ function useSWRInfinite<Data = any, Error = any>(
       enumerable: true
     }
   })
-  return swrInfinite as SWRInfiniteResponseInterface<Data, Error>
+  return swrInfinite as SWRInfiniteResponse<Data, Error>
 }
 
-export {
-  useSWRInfinite,
-  SWRInfiniteConfigInterface,
-  SWRInfiniteResponseInterface
-}
+export { useSWRInfinite }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -5,8 +5,8 @@ import SWRConfigContext from './swr-config-context'
 import useSWR from './use-swr'
 
 import {
-  keyType,
-  fetcherFn,
+  ValueKey,
+  Fetcher,
   SWRInfiniteConfiguration,
   SWRInfiniteResponse
 } from './types'
@@ -14,7 +14,7 @@ import {
 type KeyLoader<Data = any> = (
   index: number,
   previousPageData: Data | null
-) => keyType
+) => ValueKey
 
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>
@@ -25,14 +25,14 @@ function useSWRInfinite<Data = any, Error = any>(
 ): SWRInfiniteResponse<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
-  fn?: fetcherFn<Data>,
+  fn?: Fetcher<Data>,
   config?: Partial<SWRInfiniteConfiguration<Data, Error>>
 ): SWRInfiniteResponse<Data, Error>
 function useSWRInfinite<Data = any, Error = any>(
   getKey: KeyLoader<Data>,
   ...options: any[]
 ): SWRInfiniteResponse<Data, Error> {
-  let _fn: fetcherFn<Data> | undefined,
+  let _fn: Fetcher<Data> | undefined,
     _config: Partial<SWRInfiniteConfiguration<Data, Error>> = {}
 
   if (options.length > 1) {

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -4,13 +4,18 @@ import defaultConfig, { cache } from './config'
 import SWRConfigContext from './swr-config-context'
 import useSWR from './use-swr'
 
-import { keyType, fetcherFn, ConfigInterface, responseInterface } from './types'
+import {
+  keyType,
+  fetcherFn,
+  SWRConfiguration,
+  responseInterface
+} from './types'
 
 type KeyLoader<Data = any> = (
   index: number,
   previousPageData: Data | null
 ) => keyType
-type SWRInfiniteConfigInterface<Data = any, Error = any> = ConfigInterface<
+type SWRInfiniteConfigInterface<Data = any, Error = any> = SWRConfiguration<
   Data[],
   Error,
   fetcherFn<Data[]>

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -19,7 +19,7 @@ import {
   fetcherFn,
   Key,
   mutateInterface,
-  responseInterface,
+  SWRResponse,
   RevalidateOptions,
   triggerInterface,
   updaterInterface
@@ -213,24 +213,22 @@ const mutate: mutateInterface = async (
   return data
 }
 
-function useSWR<Data = any, Error = any>(
-  key: Key
-): responseInterface<Data, Error>
+function useSWR<Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: Key,
   config?: SWRConfiguration<Data, Error>
-): responseInterface<Data, Error>
+): SWRResponse<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: Key,
   // `null` is used for a hack to manage shared state with SWR
   // https://github.com/vercel/swr/pull/918
   fn?: fetcherFn<Data> | null,
   config?: SWRConfiguration<Data, Error>
-): responseInterface<Data, Error>
+): SWRResponse<Data, Error>
 function useSWR<Data = any, Error = any>(
   _key: Key,
   ...options: any[]
-): responseInterface<Data, Error> {
+): SWRResponse<Data, Error> {
   let _fn: fetcherFn<Data> | undefined,
     _config: SWRConfiguration<Data, Error> = {}
   if (options.length > 1) {
@@ -346,7 +344,7 @@ function useSWR<Data = any, Error = any>(
     [key]
   )
 
-  const boundMutate: responseInterface<Data, Error>['mutate'] = useCallback(
+  const boundMutate: SWRResponse<Data, Error>['mutate'] = useCallback(
     (data, shouldRevalidate) => {
       return mutate(keyRef.current, data, shouldRevalidate)
     },
@@ -769,7 +767,7 @@ function useSWR<Data = any, Error = any>(
     // revalidate will be deprecated in the 1.x release
     // because mutate() covers the same use case of revalidate().
     // This remains only for backward compatibility
-    const state = { revalidate, mutate: boundMutate } as responseInterface<
+    const state = { revalidate, mutate: boundMutate } as SWRResponse<
       Data,
       Error
     >

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -20,7 +20,7 @@ import {
   Key,
   mutateInterface,
   SWRResponse,
-  RevalidateOptions,
+  RevalidatorOptions,
   triggerInterface,
   updaterInterface
 } from './types'
@@ -375,7 +375,7 @@ function useSWR<Data = any, Error = any>(
 
   // start a revalidation
   const revalidate = useCallback(
-    async (revalidateOpts: RevalidateOptions = {}): Promise<boolean> => {
+    async (revalidateOpts: RevalidatorOptions = {}): Promise<boolean> => {
       if (!key || !fn) return false
       if (unmountedRef.current) return false
       if (configRef.current.isPaused()) return false

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -14,7 +14,8 @@ import SWRConfigContext from './swr-config-context'
 import {
   actionType,
   broadcastStateInterface,
-  ConfigInterface,
+  Configuration,
+  SWRConfiguration,
   fetcherFn,
   keyInterface,
   mutateInterface,
@@ -217,21 +218,21 @@ function useSWR<Data = any, Error = any>(
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: keyInterface,
-  config?: Partial<ConfigInterface<Data, Error>>
+  config?: SWRConfiguration<Data, Error>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
   key: keyInterface,
   // `null` is used for a hack to manage shared state with SWR
   // https://github.com/vercel/swr/pull/918
   fn?: fetcherFn<Data> | null,
-  config?: Partial<ConfigInterface<Data, Error>>
+  config?: SWRConfiguration<Data, Error>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
   _key: keyInterface,
   ...options: any[]
 ): responseInterface<Data, Error> {
   let _fn: fetcherFn<Data> | undefined,
-    _config: Partial<ConfigInterface<Data, Error>> = {}
+    _config: SWRConfiguration<Data, Error> = {}
   if (options.length > 1) {
     _fn = options[0]
     _config = options[1]
@@ -249,12 +250,12 @@ function useSWR<Data = any, Error = any>(
   // `keyErr` is the cache key for error objects
   const [key, fnArgs, keyErr, keyValidating] = cache.serializeKey(_key)
 
-  const config: ConfigInterface<Data, Error> = Object.assign(
+  const config = Object.assign(
     {},
     defaultConfig,
     useContext(SWRConfigContext),
     _config
-  )
+  ) as Configuration<Data, Error>
 
   const configRef = useRef(config)
   useIsomorphicLayoutEffect(() => {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -17,10 +17,10 @@ import {
   Configuration,
   SWRConfiguration,
   fetcherFn,
-  keyInterface,
+  Key,
   mutateInterface,
   responseInterface,
-  RevalidateOptionInterface,
+  RevalidateOptions,
   triggerInterface,
   updaterInterface
 } from './types'
@@ -214,21 +214,21 @@ const mutate: mutateInterface = async (
 }
 
 function useSWR<Data = any, Error = any>(
-  key: keyInterface
+  key: Key
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
-  key: keyInterface,
+  key: Key,
   config?: SWRConfiguration<Data, Error>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
-  key: keyInterface,
+  key: Key,
   // `null` is used for a hack to manage shared state with SWR
   // https://github.com/vercel/swr/pull/918
   fn?: fetcherFn<Data> | null,
   config?: SWRConfiguration<Data, Error>
 ): responseInterface<Data, Error>
 function useSWR<Data = any, Error = any>(
-  _key: keyInterface,
+  _key: Key,
   ...options: any[]
 ): responseInterface<Data, Error> {
   let _fn: fetcherFn<Data> | undefined,
@@ -377,9 +377,7 @@ function useSWR<Data = any, Error = any>(
 
   // start a revalidation
   const revalidate = useCallback(
-    async (
-      revalidateOpts: RevalidateOptionInterface = {}
-    ): Promise<boolean> => {
+    async (revalidateOpts: RevalidateOptions = {}): Promise<boolean> => {
       if (!key || !fn) return false
       if (unmountedRef.current) return false
       if (configRef.current.isPaused()) return false


### PR DESCRIPTION
This PR does 2 things:
1. The exported type `ConfigInterface` was changed in #946, which might be breaking. **However it's not released as stable yet**. This PR fixes it.
2. Renames some types to be more consistent. Also marks the old ones as deprecated. 

For 1, the cause is that properties in `ConfigInterface` are no longer optional. And if a user creates a custom hook the type might be broken:

```ts
import useSWR, { ConfigInterface } from 'swr'

function useData (opts: ConfigInterface) {
  return useSWR('/api', opts)
}

useData({}) // ← error because all fields are required
```

For 2, updated types are:

| Current | New |
|:----|:---|
| `keyInterface` | `Key` |
| `ConfigInterface` | `SWRConfiguration` |
| `responseInterface` | `SWRResponse` |
| `SWRInfiniteConfigInterface` | `SWRInfiniteConfiguration` |
| `SWRInfiniteResponseInterface` | `SWRInfiniteResponse` |
| `revalidateType` | `Revalidator` |
| `RevalidateOptionInterface` | `RevalidatorOptions` |
| `CacheInterface` | `Cache` |

The deprecated ones will be kept until 1.0.