### PR TITLE
Micro optimizations

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,7 @@
 import { Cache as CacheType, Key, CacheListener } from './types'
 import hash from './libs/hash'
 
-export default class Cache implements CacheInterface {
+export default class Cache implements CacheType {
   private cache: Map<string, any>
   private subs: CacheListener[]
 

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -2,42 +2,42 @@ import { CacheInterface, keyInterface, cacheListener } from './types'
 import hash from './libs/hash'
 
 export default class Cache implements CacheInterface {
-  private __cache: Map<string, any>
-  private __listeners: cacheListener[]
+  private cache: Map<string, any>
+  private subs: cacheListener[]
 
   constructor(initialData: any = {}) {
-    this.__cache = new Map(Object.entries(initialData))
-    this.__listeners = []
+    this.cache = new Map(Object.entries(initialData))
+    this.subs = []
   }
 
   get(key: keyInterface): any {
     const [_key] = this.serializeKey(key)
-    return this.__cache.get(_key)
+    return this.cache.get(_key)
   }
 
   set(key: keyInterface, value: any): any {
     const [_key] = this.serializeKey(key)
-    this.__cache.set(_key, value)
+    this.cache.set(_key, value)
     this.notify()
   }
 
   keys() {
-    return Array.from(this.__cache.keys())
+    return Array.from(this.cache.keys())
   }
 
   has(key: keyInterface) {
     const [_key] = this.serializeKey(key)
-    return this.__cache.has(_key)
+    return this.cache.has(_key)
   }
 
   clear() {
-    this.__cache.clear()
+    this.cache.clear()
     this.notify()
   }
 
   delete(key: keyInterface) {
     const [_key] = this.serializeKey(key)
-    this.__cache.delete(_key)
+    this.cache.delete(_key)
     this.notify()
   }
 
@@ -74,22 +74,22 @@ export default class Cache implements CacheInterface {
     }
 
     let isSubscribed = true
-    this.__listeners.push(listener)
+    this.subs.push(listener)
 
     return () => {
       if (!isSubscribed) return
       isSubscribed = false
-      const index = this.__listeners.indexOf(listener)
+      const index = this.subs.indexOf(listener)
       if (index > -1) {
-        this.__listeners[index] = this.__listeners[this.__listeners.length - 1]
-        this.__listeners.length--
+        this.subs[index] = this.subs[this.subs.length - 1]
+        this.subs.length--
       }
     }
   }
 
   // Notify Cache subscribers about a change in the cache
   private notify() {
-    for (let listener of this.__listeners) {
+    for (let listener of this.subs) {
       listener()
     }
   }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -89,14 +89,14 @@ function useSWRInfinite<Data = any, Error = any>(
   // here we get the key of the fetcher context cache
   let contextCacheKey: string | null = null
   if (firstPageKey) {
-    contextCacheKey = 'context@' + firstPageKey
+    contextCacheKey = 'ctx@' + firstPageKey
   }
 
   // page count is cached as well, so when navigating the list can be restored
   let pageCountCacheKey: string | null = null
   let cachedPageSize
   if (firstPageKey) {
-    pageCountCacheKey = 'size@' + firstPageKey
+    pageCountCacheKey = 'len@' + firstPageKey
     cachedPageSize = cache.get(pageCountCacheKey)
   }
   const pageCountRef = useRef<number>(cachedPageSize || initialSize)
@@ -120,10 +120,10 @@ function useSWRInfinite<Data = any, Error = any>(
 
   // actual swr of all pages
   const swr = useSWR<Data[], Error>(
-    firstPageKey ? ['many', firstPageKey] : null,
+    firstPageKey ? ['inf', firstPageKey] : null,
     async () => {
       // get the revalidate context
-      const { originalData, force } = cache.get(contextCacheKey) || {}
+      const { data: originalData, force } = cache.get(contextCacheKey) || {}
 
       // return an array of page data
       const data: Data[] = []
@@ -189,7 +189,7 @@ function useSWRInfinite<Data = any, Error = any>(
       if (shouldRevalidate && typeof data !== 'undefined') {
         // we only revalidate the pages that are changed
         const originalData = dataRef.current
-        cache.set(contextCacheKey, { originalData, force: false })
+        cache.set(contextCacheKey, { data: originalData, force: false })
       } else if (shouldRevalidate) {
         // calling `mutate()`, we revalidate all pages
         cache.set(contextCacheKey, { force: true })

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -83,7 +83,7 @@ function useSWRInfinite<Data = any, Error = any>(
     // not ready
   }
 
-  const [, rerender] = useState<boolean>(false)
+  const rerender = useState({})[1]
 
   // we use cache to pass extra info (context) to fetcher so it can be globally shared
   // here we get the key of the fetcher context cache
@@ -212,7 +212,7 @@ function useSWRInfinite<Data = any, Error = any>(
         pageCountRef.current = arg
       }
       cache.set(pageCountCacheKey, pageCountRef.current)
-      rerender(v => !v)
+      rerender({})
       return mutate(v => v)
     },
     [mutate, pageCountCacheKey]

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -300,7 +300,7 @@ function useSWR<Data = any, Error = any>(
   // display the data label in the React DevTools next to SWR hooks
   useDebugValue(stateRef.current.data)
 
-  const [, rerender] = useState(null)
+  const rerender = useState({})[1]
   let dispatch = useCallback(
     (payload: actionType<Data, Error>) => {
       let shouldUpdateState = false

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -352,8 +352,7 @@ function useSWR<Data = any, Error = any>(
     []
   )
 
-  const addRevalidator = (revalidators, callback) => {
-    if (!callback) return
+  const addRevalidator = (revalidators: object, callback: () => void) => {
     if (!revalidators[key]) {
       revalidators[key] = [callback]
     } else {

--- a/test/use-swr-configs.test.tsx
+++ b/test/use-swr-configs.test.tsx
@@ -6,7 +6,7 @@ import { sleep } from './utils'
 describe('useSWR - configs', () => {
   it('should read the config fallback from the context', async () => {
     let value = 0
-    const INTERVAL = 10
+    const INTERVAL = 50
     const fetcher = () => value++
 
     function Section() {


### PR DESCRIPTION
Make the code cleaner and more consistent:
- use the `useState({})[1]` pattern for re-rendering the component
- make the internal property names shorter in `Cache`
- make the key prefixes in useSWRInfinite 3 chars (`ctx@`, `inf@`, `len@`), and internal cache property name shorter
- make `addRevalidator` return the ubsubscriber

Closes #896.