### PR TITLE
Allow passing undefined as the config

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -22,11 +22,14 @@ function useSWRInfinite<Data = any, Error = any>(
   ...args:
     | readonly [KeyLoader<Data>]
     | readonly [KeyLoader<Data>, Fetcher<Data>]
-    | readonly [KeyLoader<Data>, SWRInfiniteConfiguration<Data, Error>]
+    | readonly [
+        KeyLoader<Data>,
+        SWRInfiniteConfiguration<Data, Error> | undefined
+      ]
     | readonly [
         KeyLoader<Data>,
         Fetcher<Data>,
-        SWRInfiniteConfiguration<Data, Error>
+        SWRInfiniteConfiguration<Data, Error> | undefined
       ]
 ): SWRInfiniteResponse<Data, Error> {
   const getKey = args[0]

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -210,8 +210,12 @@ function useSWR<Data = any, Error = any>(
   ...args:
     | readonly [Key]
     | readonly [Key, Fetcher<Data> | null]
-    | readonly [Key, SWRConfiguration<Data, Error>]
-    | readonly [Key, Fetcher<Data> | null, SWRConfiguration<Data, Error>]
+    | readonly [Key, SWRConfiguration<Data, Error> | undefined]
+    | readonly [
+        Key,
+        Fetcher<Data> | null,
+        SWRConfiguration<Data, Error> | undefined
+      ]
 ): SWRResponse<Data, Error> {
   const _key = args[0]
   const config = Object.assign(


### PR DESCRIPTION
Currently TS will show an error if you use `undefined` as the config: `useSWR('key', fetcher, undefined)`. It breaks the old behavior, which makes the following use case impossible:

```ts
import useSWR, { SWRConfiguration } from 'swr'

function useData (opts?: SWRConfiguration) {
  useSWR('/api', fetcher, opts) // ⛔️
}

useData({}) // ✅
useData() // ⛔️
```