### PR TITLE
Export default SWR config to allow more flexible extensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export * from './use-swr'
 export { useSWRInfinite } from './use-swr-infinite'
 
 // Cache related, to be replaced by the new APIs
-export { default as defaultSWRConfig, cache } from './config'
+export { cache } from './config'
 
 // Types
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export * from './use-swr'
 export { useSWRInfinite } from './use-swr-infinite'
 
 // Cache related, to be replaced by the new APIs
-export { cache } from './config'
+export { default as defaultSWRConfig, cache } from './config'
 
 // Types
 export {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -584,10 +584,7 @@ function useSWR<Data = any, Error = any>(
     const softRevalidate = () => revalidate({ dedupe: true })
 
     // trigger a revalidation
-    if (
-      isUpdating ||
-      willRevalidateOnMount()
-    ) {
+    if (isUpdating || willRevalidateOnMount()) {
       if (typeof latestKeyedData !== 'undefined' && !IS_SERVER) {
         // delay revalidate if there's cache
         // to not block the rendering
@@ -829,7 +826,12 @@ function useSWR<Data = any, Error = any>(
   return memoizedState
 }
 
-const SWRConfig = SWRConfigContext.Provider
+Object.defineProperty(SWRConfigContext.Provider, 'default', {
+  value: defaultConfig
+})
+const SWRConfig = SWRConfigContext.Provider as typeof SWRConfigContext.Provider & {
+  default: SWRConfiguration
+}
 
 export { trigger, mutate, SWRConfig }
 export default useSWR

--- a/test/use-swr-configs.test.tsx
+++ b/test/use-swr-configs.test.tsx
@@ -2,6 +2,7 @@ import { act, render, screen, fireEvent } from '@testing-library/react'
 import React, { useEffect, useState } from 'react'
 import useSWR, { mutate, SWRConfig } from '../src'
 import { sleep } from './utils'
+import defaultConfig from '../src/config'
 
 describe('useSWR - configs', () => {
   it('should read the config fallback from the context', async () => {
@@ -87,5 +88,9 @@ describe('useSWR - configs', () => {
     screen.getByText('data: 1')
     await act(() => revalidate())
     screen.getByText('data: 1')
+  })
+
+  it('should expose default config as static property on SWRConfig', () => {
+    expect(SWRConfig.default).toBe(defaultConfig)
   })
 })


### PR DESCRIPTION
To allow more flexible customisations and extensions it would be useful to export default config.

Eg. in our case we want to extend `onErrorRetry` but keep the current logic. Now we had to copy-paste the default config to our wrapper instead of calling it.