### PR TITLE
refactor: fix a react-hooks/exhaustive-deps warning

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -211,7 +211,9 @@ function useSWRInfinite<Data = any, Error = any>(
       rerender({})
       return mutate(v => v)
     },
-    [pageSizeCacheKey, resolvePageSize, mutate]
+    // immutability of rerender is guaranteed by React, but react-hooks/exhaustive-deps doesn't recognize it
+    // from `rerender = useState({})[1], so we put rerender here
+    [pageSizeCacheKey, resolvePageSize, mutate, rerender]
   )
 
   // Use getter functions to avoid unnecessary re-renders caused by triggering all the getters of the returned swr object


### PR DESCRIPTION
An ESlint warning of `react-hooks/exhaustive-deps` is caused by https://github.com/vercel/swr/commit/b18414b901d60fbe63232537f298dc847ae20822 because the rule cannot determine `rerender` is always the same reference from `rerender = useState({})[1]`. Previously, this line was `[, rerender] = useState({})` and the rule can determine it is always the same reference.

To fix this, I've added `rerender` into the deps array because I'd like to enable the rule for the `setSize` function.