### PR TITLE
fix: invalid invocation on raf

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -8,7 +8,9 @@ export const IS_SERVER =
 // polyfill for requestAnimationFrame
 export const rAF = IS_SERVER
   ? null
-  : window['requestAnimationFrame'] || (f => setTimeout(f, 1))
+  : window['requestAnimationFrame']
+  ? (f: FrameRequestCallback) => window['requestAnimationFrame'](f)
+  : (f: (...args: any[]) => void) => setTimeout(f, 1)
 
 // React currently throws a warning when using useLayoutEffect on the server.
 // To get around it, we can conditionally useEffect on the server (no-op) and

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -567,7 +567,7 @@ function useSWR<Data = any, Error = any>(
         // delay revalidate if there's cache
         // to not block the rendering
 
-        //@ts-ignore it's safe to use requestAnimationFrame in browser
+        // @ts-ignore it's safe to use requestAnimationFrame in browser
         rAF(softRevalidate)
       } else {
         softRevalidate()


### PR DESCRIPTION
Fixes #1046 #1050

### Minimal repro

```js
a = {
   raf: window.requestAnimationFrame,
   raf_pure: f => window.requestAnimationFrame(f)
}

f = () => console.log(1)
a.raf(f) // Error
// Chrome: Uncaught TypeError: Illegal invocation
// Firefox: Uncaught TypeError: 'requestAnimationFrame' called on an object that does not implement interface Window.

a.raf_pure(f) // log `1` in console
```

Possible root cause:

checked the repro in #1050, the line calling rAF is compiled to `c.rAF(n)`, rAF called on an object `c`, which represents a module. We need to make it pure.