### PR TITLE
Allow setting the generic on mutate()

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -65,11 +65,6 @@ export type MutatorCallback<Data = any> = (
   currentValue: undefined | Data
 ) => Promise<undefined | Data> | undefined | Data
 
-export type Mutator<Data = any> = (
-  key: Key,
-  data?: Data | Promise<Data> | MutatorCallback<Data>,
-  shouldRevalidate?: boolean
-) => Promise<Data | undefined>
 export type Broadcaster<Data = any, Error = any> = (
   key: string,
   data: Data,

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -101,7 +101,7 @@ const broadcastState: Broadcaster = (key, data, error, isValidating) => {
 
 async function mutate<Data = any>(
   _key: Key,
-  _data?: Data | Promise<Data> | MutatorCallback<Data>,
+  _data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
   shouldRevalidate = true
 ): Promise<Data | undefined> {
   const [key, , keyErr] = cache.serializeKey(_key)
@@ -124,7 +124,7 @@ async function mutate<Data = any>(
   if (_data && typeof _data === 'function') {
     // `_data` is a function, call it passing current cache value
     try {
-      _data = _data(cache.get(key))
+      _data = (_data as MutatorCallback<Data>)(cache.get(key))
     } catch (err) {
       // if `_data` function throws an error synchronously, it shouldn't be cached
       _data = undefined
@@ -132,7 +132,7 @@ async function mutate<Data = any>(
     }
   }
 
-  if (_data && typeof _data.then === 'function') {
+  if (_data && typeof (_data as Promise<Data>).then === 'function') {
     // `_data` is a promise
     isAsyncMutation = true
     try {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -103,7 +103,7 @@ async function mutate<Data = any>(
   _key: Key,
   _data?: Data | Promise<Data> | MutatorCallback<Data>,
   shouldRevalidate = true
-) {
+): Promise<Data | undefined> {
   const [key, , keyErr] = cache.serializeKey(_key)
   if (!key) return
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -16,7 +16,7 @@ import {
   Broadcaster,
   Fetcher,
   Key,
-  Mutator,
+  MutatorCallback,
   SWRResponse,
   RevalidatorOptions,
   Trigger,
@@ -99,7 +99,11 @@ const broadcastState: Broadcaster = (key, data, error, isValidating) => {
   }
 }
 
-const mutate: Mutator = async (_key, _data, shouldRevalidate = true) => {
+async function mutate<Data = any>(
+  _key: Key,
+  _data?: Data | Promise<Data> | MutatorCallback<Data>,
+  shouldRevalidate = true
+) {
   const [key, , keyErr] = cache.serializeKey(_key)
   if (!key) return
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -105,7 +105,7 @@ async function mutate<Data = any>(
   shouldRevalidate = true
 ): Promise<Data | undefined> {
   const [key, , keyErr] = cache.serializeKey(_key)
-  if (!key) return
+  if (!key) return Promise.resolve(undefined)
 
   // if there is no new data to update, let's just revalidate the key
   if (typeof _data === 'undefined') return trigger(_key, shouldRevalidate)

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -105,7 +105,7 @@ async function mutate<Data = any>(
   shouldRevalidate = true
 ): Promise<Data | undefined> {
   const [key, , keyErr] = cache.serializeKey(_key)
-  if (!key) return Promise.resolve(undefined)
+  if (!key) return undefined
 
   // if there is no new data to update, let's just revalidate the key
   if (typeof _data === 'undefined') return trigger(_key, shouldRevalidate)


### PR DESCRIPTION
Without this change, it is not possible for users to do `mutate<MyType>(...)`

![image](https://user-images.githubusercontent.com/567105/112512884-b3b6bc00-8d8b-11eb-9f7b-bcc9f8f96b89.png)
