### PR TITLE
Add `--no-sourcemap`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://swr.vercel.app",
   "license": "MIT",
   "scripts": {
-    "build": "bunchee src/index.ts -m",
+    "build": "bunchee src/index.ts -m --no-sourcemap",
     "watch": "bunchee src/index.ts --watch",
     "prepublishOnly": "rm -rf dist && yarn build",
     "types:check": "tsc --noEmit",


### PR DESCRIPTION
We're already using the minified version and I can't think of a specific case that you need to debug the lib itself (with minified code). It's also not enabled in previous versions so let's disable it.