### PR TITLE
Optimistic UI examples comments clearer

### DIFF
--- a/examples/optimistic-ui-immer/pages/index.js
+++ b/examples/optimistic-ui-immer/pages/index.js
@@ -10,15 +10,19 @@ export default () => {
 
   async function handleSubmit(event) {
     event.preventDefault()
-    // call mutate to optimistically update the UI
-    // we use Immer produce to allow us to perform and immutable change
-    // while coding it as a normal mutation of the same object
+    // Call mutate to optimistically update the UI.
+    // We use Immer produce to allow us to perform an immutable change
+    // while coding it as a normal mutation of the same object.
     mutate("/api/data", produce(draftData => {
       draftData.push(text)
     }), false)
-    // then we send the request to the API and let mutate
-    // update the data with the API response
-    // if this fail it will rollback the optimistic update
+    // Then we send the request to the API and let mutate
+    // update the data with the API response.
+    // Our action may fail in the API function, and the response differ
+    // from what was optimistically updated, in that case the UI will be
+    // changed to match the API response.
+    // The fetch could also fail, in that case the UI will
+    // be in an incorrect state until the next successful fetch.
     mutate('/api/data', await fetch('/api/data', {
       method: 'POST',
       body: JSON.stringify({ text })

--- a/examples/optimistic-ui/pages/index.js
+++ b/examples/optimistic-ui/pages/index.js
@@ -9,12 +9,15 @@ export default () => {
 
   async function handleSubmit(event) {
     event.preventDefault()
-    // mutate current data to optimistically update the UI
-    // the fetch below could fail, in that case the UI will
-    // be in an incorrect state
+    // Call mutate to optimistically update the UI.
     mutate('/api/data', [...data, text], false)
-    // then we send the request to the API and let mutate
-    // update the data with the API response
+    // Then we send the request to the API and let mutate
+    // update the data with the API response.
+    // Our action may fail in the API function, and the response differ
+    // from what was optimistically updated, in that case the UI will be
+    // changed to match the API response.
+    // The fetch could also fail, in that case the UI will
+    // be in an incorrect state until the next successful fetch.
     mutate('/api/data', await fetch('/api/data', {
       method: 'POST',
       body: JSON.stringify({ text })


### PR DESCRIPTION
From my understanding the two examples of optimistic UI have the same behavior: they update optimistically, and then send a POST request, and update again according to the backend reply, if it replies.

The comments in the example `index.js` seem misleading (at least it was for me):

For optimistic UI we have [this comment](https://github.com/vercel/swr/blob/master/examples/optimistic-ui/pages/index.js#L13):
```javascript
// the fetch below could fail, in that case the UI will
// be in an incorrect state
```

For optimistic UI with Immer.js we have nothing about possible fetch failure, but we have [this comment](https://github.com/vercel/swr/blob/master/examples/optimistic-ui-immer/pages/index.js#L21):
```javascript
// if this fail it will rollback the optimistic update
```

I think we should add that the request may fail and lead to an incorrect state also for the example with Immer.js. The way it is now makes me think that with the Immer.js example we solve that problem.
