### PR TITLE
test: refactor use-swr-refresh.test.tsx

### DIFF
--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -27,20 +27,21 @@ describe('useSWR - refresh', () => {
       })
       return <div>count: {data}</div>
     }
-    const { container } = render(<Page />)
+
+    render(<Page />)
 
     // hydration
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: "`)
+    screen.getByText('count:')
 
     // mount
     await screen.findByText('count: 0')
 
     await act(() => advanceTimers(200)) // update
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
+    screen.getByText('count: 1')
     await act(() => advanceTimers(50)) // no update
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
+    screen.getByText('count: 1')
     await act(() => advanceTimers(150)) // update
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
+    screen.getByText('count: 2')
   })
 
   it('should dedupe requests combined with intervals', async () => {
@@ -54,24 +55,24 @@ describe('useSWR - refresh', () => {
       return <div>count: {data}</div>
     }
 
-    const { container } = render(<Page />)
+    render(<Page />)
 
     // hydration
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: "`)
+    screen.getByText('count:')
 
     // mount
-    // await screen.findByText('count: 0')
+    await screen.findByText('count: 0')
 
     await act(() => advanceTimers(100)) // no update (deduped)
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 0"`)
+    screen.getByText('count: 0')
     await act(() => advanceTimers(400)) // exceed dudupingInterval
     await act(() => advanceTimers(100)) // update
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
+    screen.getByText('count: 1')
     await act(() => advanceTimers(100)) // no update (deduped)
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
+    screen.getByText('count: 1')
     await act(() => advanceTimers(400)) // exceed dudupingInterval
     await act(() => advanceTimers(100)) // update
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
+    screen.getByText('count: 2')
   })
 
   it('should update data upon interval changes', async () => {
@@ -88,46 +89,47 @@ describe('useSWR - refresh', () => {
         </div>
       )
     }
-    const { container } = render(<Page />)
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: "`)
+
+    render(<Page />)
+    screen.getByText('count:')
 
     // mount
     await screen.findByText('count: 0')
 
     await act(() => advanceTimers(100))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
+    screen.getByText('count: 1')
     await act(() => advanceTimers(50))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 1"`)
+    screen.getByText('count: 1')
     await act(() => advanceTimers(50))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
-    fireEvent.click(container.firstElementChild)
+    screen.getByText('count: 2')
+    fireEvent.click(screen.getByText('count: 2'))
 
     await act(() => advanceTimers(100))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 2"`)
+    screen.getByText('count: 2')
 
     await act(() => advanceTimers(50))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 3"`)
+    screen.getByText('count: 3')
 
     await act(() => advanceTimers(150))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
-    fireEvent.click(container.firstElementChild)
+    screen.getByText('count: 4')
+    fireEvent.click(screen.getByText('count: 4'))
     await act(() => {
       // it will clear 150ms timer and setup a new 200ms timer
       return advanceTimers(150)
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 4"`)
+    screen.getByText('count: 4')
     await act(() => advanceTimers(50))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
-    fireEvent.click(container.firstElementChild)
+    screen.getByText('count: 5')
+    fireEvent.click(screen.getByText('count: 5'))
     await act(() => {
       // it will clear 200ms timer and stop
       return advanceTimers(50)
     })
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
+    screen.getByText('count: 5')
     await act(() => advanceTimers(50))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"count: 5"`)
+    screen.getByText('count: 5')
   })
 
   it('should update data upon interval changes -- changes happened during revalidate', async () => {
@@ -153,68 +155,49 @@ describe('useSWR - refresh', () => {
         </div>
       )
     }
-    const { container } = render(<Page />)
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count:  0"`
-    )
+
+    render(<Page />)
+    screen.getByText('count: 0')
 
     await screen.findByText('count: 0 1')
 
     await act(() => advanceTimers(100))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 1 2"`
-    )
+    screen.getByText('count: 1 2')
 
     await act(() => advanceTimers(100))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 1 2"`
-    )
+    screen.getByText('count: 1 2')
 
     await act(() => advanceTimers(100))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 1 2"`
-    )
+    screen.getByText('count: 1 2')
 
     await act(() => advanceTimers(100))
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 1 2"`
-    )
+    screen.getByText('count: 1 2')
 
-    fireEvent.click(container.firstElementChild)
+    fireEvent.click(screen.getByText('count: 1 2'))
 
     await act(() => {
       // it will setup a new 100ms timer
       return advanceTimers(50)
     })
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 1 0"`
-    )
+    screen.getByText('count: 1 0')
 
     await act(() => advanceTimers(50))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 2 1"`
-    )
+    screen.getByText('count: 2 1')
 
     await act(() => advanceTimers(100))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 3 2"`
-    )
+    screen.getByText('count: 3 2')
 
     await act(() => advanceTimers(100))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 3 2"`
-    )
+    screen.getByText('count: 3 2')
 
     await act(() => advanceTimers(100))
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(
-      `"count: 3 2"`
-    )
+    screen.getByText('count: 3 2')
   })
 
   it('should allow use custom compare method', async () => {
@@ -243,9 +226,9 @@ describe('useSWR - refresh', () => {
       return <button onClick={() => change()}>{data.timestamp}</button>
     }
 
-    const { container } = render(<Page />)
+    render(<Page />)
 
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"loading"`)
+    screen.getByText('loading')
 
     await screen.findByText('1')
     expect(fetcher).toBeCalledTimes(1)
@@ -254,7 +237,7 @@ describe('useSWR - refresh', () => {
       version: '1.0'
     })
 
-    fireEvent.click(container.firstElementChild)
+    fireEvent.click(screen.getByText('1'))
     await act(() => advanceTimers(1))
     expect(fetcher).toBeCalledTimes(2)
     expect(fetcher).toReturnWith({
@@ -264,7 +247,7 @@ describe('useSWR - refresh', () => {
 
     const cachedData = cache.get(key)
     expect(cachedData.timestamp.toString()).toEqual('1')
-    expect(container.firstChild.textContent).toMatchInlineSnapshot(`"1"`)
+    screen.getByText('1')
   })
 
   it('should not let the previous interval timer to set new timer if key changes too fast', async () => {
@@ -284,7 +267,8 @@ describe('useSWR - refresh', () => {
         >{`click me ${data}`}</button>
       )
     }
-    const { container } = render(<Page />)
+
+    render(<Page />)
 
     // initial revalidate
     await act(() => advanceTimers(200))
@@ -302,7 +286,7 @@ describe('useSWR - refresh', () => {
     expect(fetcherWithToken).toHaveBeenLastCalledWith('0')
     // change the key during revalidation
     // The second refresh will not start a new timer
-    fireEvent.click(container.firstElementChild)
+    fireEvent.click(screen.getByText('click me 0'))
 
     // first refresh with new key 1
     await act(() => advanceTimers(100))
@@ -337,7 +321,8 @@ describe('useSWR - refresh', () => {
         >{`click me ${data}`}</button>
       )
     }
-    const { container } = render(<Page />)
+
+    render(<Page />)
 
     // initial revalidate
     await act(() => advanceTimers(100))
@@ -358,7 +343,7 @@ describe('useSWR - refresh', () => {
     expect(fetcherWithToken).toHaveBeenLastCalledWith('0-hash')
     // change the key during revalidation
     // The second refresh will not start a new timer
-    fireEvent.click(container.firstElementChild)
+    fireEvent.click(screen.getByText('click me 0-hash'))
 
     // first refresh with new key 1
     await act(() => advanceTimers(50))

--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -3,19 +3,17 @@ import React, { useState } from 'react'
 import useSWR, { cache } from '../src'
 import { sleep } from './utils'
 
+// This has to be an async function to wait a microtask to flush updates
 const advanceTimers = async (ms: number) => jest.advanceTimersByTime(ms)
 
-// This test heavily depends on timers, and it takes long time and makes tests flaky.
-// So we use fake timers Jest provides
+// This test heavily depends on setInterval/setTimeout timers, which makes tests slower and flaky.
+// So we use Jest's fake timers
 describe('useSWR - refresh', () => {
-  beforeAll(() => {
+  beforeEach(() => {
     jest.useFakeTimers()
   })
-  afterAll(() => {
-    jest.useRealTimers()
-  })
   afterEach(() => {
-    jest.clearAllTimers()
+    jest.useRealTimers()
   })
   it('should rerender automatically on interval', async () => {
     let count = 0
@@ -65,12 +63,12 @@ describe('useSWR - refresh', () => {
 
     await act(() => advanceTimers(100)) // no update (deduped)
     screen.getByText('count: 0')
-    await act(() => advanceTimers(400)) // exceed dudupingInterval
+    await act(() => advanceTimers(400)) // reach dudupingInterval
     await act(() => advanceTimers(100)) // update
     screen.getByText('count: 1')
     await act(() => advanceTimers(100)) // no update (deduped)
     screen.getByText('count: 1')
-    await act(() => advanceTimers(400)) // exceed dudupingInterval
+    await act(() => advanceTimers(400)) // reach dudupingInterval
     await act(() => advanceTimers(100)) // update
     screen.getByText('count: 2')
   })


### PR DESCRIPTION
This is a follow-up PR of #933.
I've refactored use-swr-refresh.test.tsx.

The test file is the slowest test in `vercel/swr` because it has many tests depend on setTimeout/setInterval timers.
Reducing the interval of timers makes tests flaky, so I've used Jest's fake timers to reduce the total test time.

- Before

```
➜  yarn test                                                                                                                                                                                                                 
yarn run v1.22.10
$ jest
 PASS  test/use-swr-config-callbacks.test.tsx
 PASS  test/use-swr-concurrent-mode.test.tsx
 PASS  test/use-swr-revalidate.test.tsx
 PASS  test/use-swr-key.test.tsx
 PASS  test/use-swr-configs.test.tsx
 PASS  test/use-swr-focus.test.tsx
 PASS  test/use-swr-loading.test.tsx
 PASS  test/use-swr-offline.test.tsx
 PASS  test/use-swr-context-config.test.tsx
 PASS  test/use-swr-infinite.test.tsx
 PASS  test/use-swr-suspense.test.tsx
 PASS  test/use-swr-cache.test.tsx
 PASS  test/use-swr-integration.test.tsx
 PASS  test/use-swr-local-mutation.test.tsx
 PASS  test/use-swr-error.test.tsx
 PASS  test/use-swr-refresh.test.tsx (6.37s)

Test Suites: 16 passed, 16 total
Tests:       110 passed, 110 total
Snapshots:   55 passed, 55 total
Time:        8.228s
Ran all test suites.
✨  Done in 9.83s.
```

- After

```
➜  yarn test
yarn run v1.22.10
$ jest
 PASS  test/use-swr-refresh.test.tsx
 PASS  test/use-swr-config-callbacks.test.tsx
 PASS  test/use-swr-concurrent-mode.test.tsx
 PASS  test/use-swr-configs.test.tsx
 PASS  test/use-swr-loading.test.tsx
 PASS  test/use-swr-revalidate.test.tsx
 PASS  test/use-swr-key.test.tsx
 PASS  test/use-swr-context-config.test.tsx
 PASS  test/use-swr-cache.test.tsx
 PASS  test/use-swr-focus.test.tsx
 PASS  test/use-swr-offline.test.tsx
 PASS  test/use-swr-suspense.test.tsx
 PASS  test/use-swr-infinite.test.tsx
 PASS  test/use-swr-integration.test.tsx
 PASS  test/use-swr-error.test.tsx
 PASS  test/use-swr-local-mutation.test.tsx

Test Suites: 16 passed, 16 total
Tests:       110 passed, 110 total
Snapshots:   23 passed, 23 total
Time:        5.803s
Ran all test suites.
✨  Done in 7.29s.
```




