### PR TITLE
Fix setting `null` cache in `useSWRInfinite`

### DIFF
--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -72,18 +72,22 @@ function useSWRInfinite<Data = any, Error = any>(
   // keep the last page size to restore it with the persistSize option
   const lastPageSizeRef = useRef<number>(resolvePageSize())
 
-  // every time the key changes, we reset the page size if it's not persisted
+  // When the page key changes, we reset the page size if it's not persisted
   useIsomorphicLayoutEffect(() => {
     if (!didMountRef.current) {
       didMountRef.current = true
       return
     }
-    // If the key has been changed, we keep the current page size if persistSize is enabled
-    cache.set(
-      pageSizeCacheKey,
-      persistSize ? lastPageSizeRef.current : initialSize
-    )
-    // initialSize isn't allowed to change during the lifecycle
+
+    if (firstPageKey) {
+      // If the key has been changed, we keep the current page size if persistSize is enabled
+      cache.set(
+        pageSizeCacheKey,
+        persistSize ? lastPageSizeRef.current : initialSize
+      )
+    }
+
+    // `initialSize` isn't allowed to change during the lifecycle
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [firstPageKey])
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -150,7 +150,7 @@ async function mutate<Data = any>(
   // if there's a race we don't update cache or broadcast change, just return the data
   if (shouldAbort()) return data
 
-  if (data !== 'undefined') {
+  if (data !== undefined) {
     // update cached data
     cache.set(key, data)
   }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -150,7 +150,7 @@ async function mutate<Data = any>(
   // if there's a race we don't update cache or broadcast change, just return the data
   if (shouldAbort()) return data
 
-  if (typeof data !== 'undefined') {
+  if (data !== 'undefined') {
     // update cached data
     cache.set(key, data)
   }

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -434,6 +434,7 @@ describe('useSWR - local mutation', () => {
     const [keyData, , keyErr] = cache.serializeKey(key)
     let cacheError = cache.get(keyErr)
     expect(cacheError.message).toMatchInlineSnapshot(`"${message}"`)
+
     // if mutate throws an error synchronously, the cache shouldn't be updated
     expect(cache.get(keyData)).toBe(value)
 


### PR DESCRIPTION
We call `cache.set(pageSizeCacheKey, persistSize ? lastPageSizeRef.current : initialSize)` inside `useSWRInfinite` whenever the `firstPageKey` changes, but the key can still be `null`. In that case we are setting `cache.set(null, 1)` which should be avoided.