### PR TITLE
Replace deprecated types with latest types in axios-typescript example

### DIFF
--- a/examples/axios-typescript/libs/useRequest.ts
+++ b/examples/axios-typescript/libs/useRequest.ts
@@ -1,11 +1,11 @@
-import useSWR, { ConfigInterface, responseInterface } from 'swr'
+import useSWR, { SWRConfiguration, SWRResponse } from 'swr'
 import axios, { AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios'
 
 export type GetRequest = AxiosRequestConfig | null
 
 interface Return<Data, Error>
   extends Pick<
-    responseInterface<AxiosResponse<Data>, AxiosError<Error>>,
+    SWRResponse<AxiosResponse<Data>, AxiosError<Error>>,
     'isValidating' | 'revalidate' | 'error' | 'mutate'
   > {
   data: Data | undefined
@@ -14,7 +14,7 @@ interface Return<Data, Error>
 
 export interface Config<Data = unknown, Error = unknown>
   extends Omit<
-    ConfigInterface<AxiosResponse<Data>, AxiosError<Error>>,
+    SWRConfiguration<AxiosResponse<Data>, AxiosError<Error>>,
     'initialData'
   > {
   initialData?: Data


### PR DESCRIPTION
# Problem
My VSCode shows warnings that `responseInterface`, `ConfigInterface` are deprecated which are used in axios-typescript example. I noticed that they have `@deprecated` annotations in type definition file and were described they will be renamed to `SWRResponse`, `SWRConfiguration` each other. 

<img width="1196" alt="Screen Shot 2021-04-18 at 2 00 36 PM" src="https://user-images.githubusercontent.com/31213226/115135009-2136cf00-a050-11eb-803f-ddd11e0c6d9f.png">

# Solution
So I replaced them with latest types(`SWRResponse`, `SWRConfiguration`) already existing.


