### PR TITLE
slow connection mode when `navigator.connection.saveData` is enabled

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,9 @@ const slowConnection =
   // @ts-ignore
   navigator['connection'] &&
   // @ts-ignore
-  ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1
+  (['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1 ||
+    // @ts-ignore
+    navigator['connection'].saveData)
 
 // config
 const defaultConfig = {


### PR DESCRIPTION
Use slow connection mode when `navigator.connection.saveData` is enabled

## issue
https://github.com/vercel/swr/issues/1122