### PR TITLE
enhance: support exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "React Hooks library for remote data fetching",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.js"
+    }
+  },
   "react-native": "./dist/index.esm.js",
   "types": "./dist/types/index.d.ts",
   "files": [


### PR DESCRIPTION
 Adopt [exports sugar](https://nodejs.org/api/packages.html#packages_exports_sugar), to make subpath imports like `swr/infinite` easier in long run.

parsing `exports` field is supported in webpack5.