### PR TITLE
enhance: add $ prefix for non-major keys

### DIFF
--- a/src/libs/hash.ts
+++ b/src/libs/hash.ts
@@ -32,7 +32,7 @@ export default function hash(args: any[]): string {
         _hash = table.get(args[i])
       }
     }
-    key += '@' + _hash
+    key += '$' + _hash
   }
   return key
 }

--- a/src/libs/serialize.ts
+++ b/src/libs/serialize.ts
@@ -21,8 +21,8 @@ export function serialize(key: Key): [string, any, string, string] {
     key = String(key || '')
   }
 
-  const errorKey = key ? '$err@' + key : ''
-  const isValidatingKey = key ? '$req@' + key : ''
+  const errorKey = key ? '$err$' + key : ''
+  const isValidatingKey = key ? '$req$' + key : ''
 
   return [key, args, errorKey, isValidatingKey]
 }

--- a/src/libs/serialize.ts
+++ b/src/libs/serialize.ts
@@ -21,8 +21,8 @@ export function serialize(key: Key): [string, any, string, string] {
     key = String(key || '')
   }
 
-  const errorKey = key ? 'err@' + key : ''
-  const isValidatingKey = key ? 'req@' + key : ''
+  const errorKey = key ? '$err@' + key : ''
+  const isValidatingKey = key ? '$req@' + key : ''
 
   return [key, args, errorKey, isValidatingKey]
 }

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -100,7 +100,7 @@ function useSWRInfinite<Data = any, Error = any>(
 
   // actual swr of all pages
   const swr = useSWR<Data[], Error>(
-    firstPageKey ? ['$inf', firstPageKey] : null,
+    firstPageKey ? 'inf@' + firstPageKey : null,
     async () => {
       // get the revalidate context
       const { data: originalData, force } = cache.get(contextCacheKey) || {}

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -41,13 +41,13 @@ function useSWRInfiniteHandler<Data = any, Error = any>(
   // here we get the key of the fetcher context cache
   let contextCacheKey: string | null = null
   if (firstPageKey) {
-    contextCacheKey = '$ctx@' + firstPageKey
+    contextCacheKey = '$ctx$' + firstPageKey
   }
 
   // page size is also cached to share the page data between hooks having the same key
   let pageSizeCacheKey: string | null = null
   if (firstPageKey) {
-    pageSizeCacheKey = '$len@' + firstPageKey
+    pageSizeCacheKey = '$len$' + firstPageKey
   }
   const didMountRef = useRef<boolean>(false)
 
@@ -85,7 +85,7 @@ function useSWRInfiniteHandler<Data = any, Error = any>(
 
   // actual swr of all pages
   const swr = useSWRHandler<Data[], Error>(
-    firstPageKey ? '$inf@' + firstPageKey : null,
+    firstPageKey ? '$inf$' + firstPageKey : null,
     async () => {
       // get the revalidate context
       const { data: originalData, force } = cache.get(contextCacheKey) || {}

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -56,13 +56,13 @@ function useSWRInfinite<Data = any, Error = any>(
   // here we get the key of the fetcher context cache
   let contextCacheKey: string | null = null
   if (firstPageKey) {
-    contextCacheKey = 'ctx@' + firstPageKey
+    contextCacheKey = '$ctx@' + firstPageKey
   }
 
   // page size is also cached to share the page data between hooks having the same key
   let pageSizeCacheKey: string | null = null
   if (firstPageKey) {
-    pageSizeCacheKey = 'len@' + firstPageKey
+    pageSizeCacheKey = '$len@' + firstPageKey
   }
   const didMountRef = useRef<boolean>(false)
 
@@ -100,7 +100,7 @@ function useSWRInfinite<Data = any, Error = any>(
 
   // actual swr of all pages
   const swr = useSWR<Data[], Error>(
-    firstPageKey ? ['inf', firstPageKey] : null,
+    firstPageKey ? ['$inf', firstPageKey] : null,
     async () => {
       // get the revalidate context
       const { data: originalData, force } = cache.get(contextCacheKey) || {}

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -100,7 +100,7 @@ function useSWRInfinite<Data = any, Error = any>(
 
   // actual swr of all pages
   const swr = useSWR<Data[], Error>(
-    firstPageKey ? 'inf@' + firstPageKey : null,
+    firstPageKey ? '$inf@' + firstPageKey : null,
     async () => {
       // get the revalidate context
       const { data: originalData, force } = cache.get(contextCacheKey) || {}


### PR DESCRIPTION
specialize keys for `error` and `isValidating`, and some non major keys in swr infinite, to identify them easier later if developers want to play tricks with keys or filter them from cache provider.

Resolves #242 

e.g.

### access all keys

```js
const provider = new Map()
const { cache, mutate } = createCache(provider)

// ...
const serializedKeys = Array.from(provider.keys()).filter(k => !k.startsWith('$'))
```

### access pending requests

```js
const validatingKeys = serializedKeys.filter(key => key.startsWith('$req$'))
```