### PR TITLE
fix: autocomplete suggestions example

### DIFF
--- a/examples/autocomplete-suggestions/package.json
+++ b/examples/autocomplete-suggestions/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@reach/combobox": "0.5.3",
+    "@reach/combobox": "0.15.1",
     "isomorphic-unfetch": "3.0.0",
     "next": "9.3.3",
     "react": "16.11.0",


### PR DESCRIPTION
Fixes #1129 
The issue is caused by `@reach/combobox`, so I've updated the version to fix it.