### PR TITLE
[RFC] feat: Use a `status` enum to label the current stage of a SWR hook

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,7 @@ export interface SWRResponse<Data, Error> {
   revalidate: () => Promise<boolean>
   mutate: KeyedMutator<Data>
   isValidating: boolean
+  status: 'loading' | 'validating' | 'error' | 'stale'
 }
 
 export type KeyLoader<Data = any> =

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -447,7 +447,6 @@ function useSWR<Data = any, Error = any>(
 
         if (stateRef.current.error !== err) {
           // we keep the stale data
-          // cache.set(keyValidating, false)
           setState({
             isValidating: false,
             error: err

--- a/test/use-swr-status.test.tsx
+++ b/test/use-swr-status.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import useSWR, { createCache, SWRConfig } from '../src'
 import { createKey } from './utils'

--- a/test/use-swr-status.test.tsx
+++ b/test/use-swr-status.test.tsx
@@ -1,0 +1,282 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+import useSWR, { createCache, SWRConfig } from '../src'
+import { createKey } from './utils'
+
+describe('useSWR - status', () => {
+  it('should update `status` when initial and revalidate requests are successful', async () => {
+    const fetcher = _key => new Promise(resolve => resolve('data'))
+    const key = createKey()
+
+    function Section() {
+      const { status, mutate } = useSWR(key, fetcher)
+
+      return (
+        <div onClick={() => mutate()} data-testid="status">
+          {status}
+        </div>
+      )
+    }
+
+    const customCache = new Map()
+    const { cache } = createCache(customCache)
+
+    render(
+      <SWRConfig value={{ cache }}>
+        <Section />
+      </SWRConfig>
+    )
+
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    await screen.findByText('stale')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('stale')
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('status'))
+    })
+
+    expect(screen.getByText('validating')).toBeInTheDocument()
+
+    await screen.findByText('stale')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('stale')
+  })
+
+  it('should update `status` when request fails but mutate resolves, no retry on error', async () => {
+    let init = false
+
+    const fetcher = _key => {
+      if (init) return new Promise(resolve => resolve('data'))
+      init = true
+
+      return new Promise((_, reject) => reject('reason'))
+    }
+
+    const key = createKey()
+
+    function Section() {
+      const { status, error, mutate, isValidating } = useSWR(key, fetcher)
+
+      return (
+        <div>
+          <div onClick={() => mutate()} data-testid="status">
+            {status}
+          </div>
+          {error && isValidating ? (
+            <span>Healing from error</span>
+          ) : (
+            <span>Gave up</span>
+          )}
+        </div>
+      )
+    }
+
+    const customCache = new Map()
+    const { cache } = createCache(customCache)
+
+    render(
+      <SWRConfig value={{ cache, shouldRetryOnError: false }}>
+        <Section />
+      </SWRConfig>
+    )
+
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    await screen.findByText('error')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error')
+
+    expect(screen.getByText('Gave up')).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('status'))
+    })
+
+    expect(screen.getByText('Healing from error')).toBeInTheDocument()
+
+    await screen.findByText('stale')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('stale')
+  })
+
+  it('should update `status` when a request fails but mutate is successful, with retry on error', async () => {
+    let init = false
+
+    const fetcher = _key => {
+      if (init) return new Promise(resolve => resolve('data'))
+      init = true
+
+      return new Promise((_, reject) => reject('reason'))
+    }
+
+    const key = createKey()
+
+    function Section() {
+      const { status, error, mutate, isValidating } = useSWR(key, fetcher)
+
+      return (
+        <div>
+          <div onClick={() => mutate()} data-testid="status">
+            {status}
+          </div>
+          {error && isValidating ? (
+            <span>Healing from error</span>
+          ) : (
+            <span>Gave up</span>
+          )}
+        </div>
+      )
+    }
+
+    const customCache = new Map()
+    const { cache } = createCache(customCache)
+
+    render(
+      <SWRConfig value={{ cache }}>
+        <Section />
+      </SWRConfig>
+    )
+
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    await screen.findByText('error')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error')
+
+    expect(screen.getByText('Healing from error')).toBeInTheDocument()
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('status'))
+    })
+
+    expect(screen.getByText('Healing from error')).toBeInTheDocument()
+
+    await screen.findByText('stale')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('stale')
+  })
+
+  it('should update `status` when a request always fails, no mutate and with retry on error', async () => {
+    const fetcher = _key => {
+      return new Promise((_, reject) => reject('reason'))
+    }
+
+    const key = createKey()
+
+    function Section() {
+      const { status, error, isValidating } = useSWR(key, fetcher)
+
+      return (
+        <div>
+          <div data-testid="status">{status}</div>
+          {error && isValidating ? (
+            <span>Healing from error</span>
+          ) : (
+            <span>Gave up</span>
+          )}
+        </div>
+      )
+    }
+
+    const customCache = new Map()
+    const { cache } = createCache(customCache)
+
+    render(
+      <SWRConfig
+        value={{
+          cache,
+          errorRetryInterval: 20,
+          errorRetryCount: 3
+        }}
+      >
+        <Section />
+      </SWRConfig>
+    )
+
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    await screen.findByText('error')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error')
+
+    expect(screen.getByText('Healing from error')).toBeInTheDocument()
+
+    await screen.findByText('Gave up')
+
+    expect(screen.getByText('Gave up')).toBeInTheDocument()
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error')
+  })
+
+  it('should update `status` when a request fails, fails to retry 3 times, and then mutate succeeds', async () => {
+    const initial = 1
+    const retries = 3
+    let count = 0
+    const fetcher = _key => {
+      if (count === retries + initial)
+        return new Promise(resolve => resolve('data'))
+      count += 1
+      return new Promise((_, reject) => reject('reason'))
+    }
+
+    const key = createKey()
+
+    function Section() {
+      const { status, error, mutate, isValidating } = useSWR(key, fetcher)
+
+      return (
+        <div>
+          <div onClick={() => mutate()} data-testid="status">
+            {status}
+          </div>
+          {error && isValidating ? (
+            <span>Healing from error</span>
+          ) : (
+            <span>Gave up</span>
+          )}
+        </div>
+      )
+    }
+
+    const customCache = new Map()
+    const { cache } = createCache(customCache)
+
+    render(
+      <SWRConfig
+        value={{
+          cache,
+          errorRetryInterval: 20,
+          errorRetryCount: retries
+        }}
+      >
+        <Section />
+      </SWRConfig>
+    )
+
+    expect(screen.getByText('loading')).toBeInTheDocument()
+
+    await screen.findByText('error')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error')
+
+    expect(screen.getByText('Healing from error')).toBeInTheDocument()
+
+    await screen.findByText('Gave up')
+
+    expect(screen.getByText('Gave up')).toBeInTheDocument()
+
+    expect(screen.getByTestId('status')).toHaveTextContent('error')
+
+    act(() => {
+      fireEvent.click(screen.getByTestId('status'))
+    })
+
+    expect(screen.getByText('Healing from error')).toBeInTheDocument()
+
+    await screen.findByText('stale')
+
+    expect(screen.getByTestId('status')).toHaveTextContent('stale')
+  })
+})


### PR DESCRIPTION
Hi!

I've been using this library, and I've collected some feedback from colleagues or people I show this hook to. 

One persistent subject is that, often developers want to derive the `status` of the hook, that is, is it loading? is it validating? is there a difference between them at all? is there any data, etc. Refer to: https://github.com/vercel/swr/discussions/563

I understand that we should open up discussions for these subjects first, but in this case it seemed best to talk over the code, because of the change itself and because I am short on bandwidth as of now.

I'll create a discussion thread and link both. Hopefully it doesn't create confusion.

At the core of this PR, we derive a new key called `status` which can be `loading`, `stale`, `error` or `validating`.

In addition, I noticed that `isValidating` doesn't really settle on error cases. This might introduce breaking changes for users.

I included some tests which helpfully help understanding the subject matter of the feature.

Last but not least, more documentation is needed. 

- [ ] Documentation
- [ ] Analyze possible breaking changes
- [ ] More units tests
- [ ] Infinite SWR
