### PR TITLE
Fix: Make SWR compatible with React Native again (window.addEventListener.bind fails)

### DIFF
--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -12,7 +12,7 @@ const isOnline = () => online
 
 // For node and React Native, `window.addEventListener` doesn't exist.
 const addWindowEventListener =
-  typeof window !== 'undefined' ? window.addEventListener.bind(window) : null
+  typeof window !== 'undefined' && typeof window.addEventListener !== 'undefined' ? window.addEventListener.bind(window) : null
 const addDocumentEventListener =
   typeof document !== 'undefined'
     ? document.addEventListener.bind(document)


### PR DESCRIPTION
In React Native environments, window refers to `global` object but `window.addEventListener` does not exit, so we need to check window.addEventListener exists too in addition to `window` existence to allow running in React Native environments.

ref. https://stackoverflow.com/questions/49911424/what-does-the-variable-window-represent-in-react-native

This incompatibility with RN was accidentally introduced in this PR.
https://github.com/vercel/swr/commit/b38d1bd74d4afc3ae4f43e732b573f5dfd89211d#diff-8e1a842791533fc5b3bd3a489a491864e056b3ddd867b208e566d05319175860L27

