### PR TITLE
chore: bump typescript to use ts-expect-error instead of ts-ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react-dom-experimental": "npm:react-dom@experimental",
     "react-experimental": "npm:react@experimental",
     "ts-jest": "25.5.1",
-    "typescript": "3.7.7"
+    "typescript": "3.9.10"
   },
   "peerDependencies": {
     "react": "^16.11.0 || ^17.0.0"

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,7 +26,7 @@ export const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
 // slow connection (<= 70Kbps)
 export const slowConnection =
   !IS_SERVER &&
-  // @ts-expect-error
+  // @ts-ignore
   navigator['connection'] &&
-  // @ts-expect-error
+  // @ts-ignore
   ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1

--- a/src/env.ts
+++ b/src/env.ts
@@ -19,12 +19,14 @@ export const rAF = __requestAnimationFrame
 // useLayoutEffect in the browser.
 export const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
 
+// This assignment is to extend the Navigator type to use effectiveType
+const __navigator: Navigator & {
+  connection?: { effectiveType: string }
+} = navigator
 // client side: need to adjust the config
 // based on the browser status
 // slow connection (<= 70Kbps)
 export const slowConnection =
   !IS_SERVER &&
-  // @ts-ignore
-  navigator['connection'] &&
-  // @ts-ignore
-  ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1
+  typeof __navigator.connection !== 'undefined' &&
+  ['slow-2g', '2g'].indexOf(__navigator['connection'].effectiveType) !== -1

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,7 +2,7 @@ import { useEffect, useLayoutEffect } from 'react'
 
 export const IS_SERVER =
   typeof window === 'undefined' ||
-  // @ts-ignore
+  // @ts-expect-error
   !!(typeof Deno !== 'undefined' && Deno.version && Deno.version.deno)
 
 const __requestAnimationFrame = !IS_SERVER
@@ -26,7 +26,7 @@ export const useIsomorphicLayoutEffect = IS_SERVER ? useEffect : useLayoutEffect
 // slow connection (<= 70Kbps)
 export const slowConnection =
   !IS_SERVER &&
-  // @ts-ignore
+  // @ts-expect-error
   navigator['connection'] &&
-  // @ts-ignore
+  // @ts-expect-error
   ['slow-2g', '2g'].indexOf(navigator['connection'].effectiveType) !== -1

--- a/src/env.ts
+++ b/src/env.ts
@@ -10,9 +10,7 @@ const __requestAnimationFrame = !IS_SERVER
   : null
 
 // polyfill for requestAnimationFrame
-export const rAF = IS_SERVER
-  ? null
-  : __requestAnimationFrame
+export const rAF = __requestAnimationFrame
   ? (f: FrameRequestCallback) => __requestAnimationFrame(f)
   : (f: (...args: any[]) => void) => setTimeout(f, 1)
 

--- a/src/libs/web-preset.ts
+++ b/src/libs/web-preset.ts
@@ -12,7 +12,10 @@ const isOnline = () => online
 
 // For node and React Native, `window.addEventListener` doesn't exist.
 const addWindowEventListener =
-  typeof window !== 'undefined' && typeof window.addEventListener !== 'undefined' ? window.addEventListener.bind(window) : null
+  typeof window !== 'undefined' &&
+  typeof window.addEventListener !== 'undefined'
+    ? window.addEventListener.bind(window)
+    : null
 const addDocumentEventListener =
   typeof document !== 'undefined'
     ? document.addEventListener.bind(document)

--- a/src/use-swr-infinite.ts
+++ b/src/use-swr-infinite.ts
@@ -1,4 +1,3 @@
-// TODO: use @ts-expect-error
 import { useRef, useState, useCallback } from 'react'
 
 import defaultConfig from './config'

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -521,7 +521,6 @@ export function useSWRHandler<Data = any, Error = any>(
       } else {
         // Delay the revalidate if we have data to return so we won't block
         // rendering.
-        // @ts-ignore it's safe to use requestAnimationFrame in browser
         rAF(softRevalidate)
       }
     }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -521,7 +521,7 @@ export function useSWRHandler<Data = any, Error = any>(
       } else {
         // Delay the revalidate if we have data to return so we won't block
         // rendering.
-        // @ts-ignore it's safe to use requestAnimationFrame in browser
+        // @ts-expect-error it's safe to use requestAnimationFrame in browser
         rAF(softRevalidate)
       }
     }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -521,7 +521,7 @@ export function useSWRHandler<Data = any, Error = any>(
       } else {
         // Delay the revalidate if we have data to return so we won't block
         // rendering.
-        // @ts-expect-error it's safe to use requestAnimationFrame in browser
+        // @ts-ignore it's safe to use requestAnimationFrame in browser
         rAF(softRevalidate)
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6582,10 +6582,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@3.7.7:
-  version "3.7.7"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz#c931733e2ec10dda56b855b379cc488a72a81199"
-  integrity sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==
+typescript@3.9.10:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^3.9.6:
   version "3.9.9"


### PR DESCRIPTION
This PR bumps typescript to 3.9.10 so that we can use `ts-expect-error` instead of `ts-ignore`. 
I've tried to bump typescript to the latest version, but the build with `bunchee` was failed. To fix this, I would have to update some dependencies that `bunchee` has and I'll work on it later.