### PR TITLE
chore: fix to run the build script multiple times

### DIFF
--- a/immutable/tsconfig.json
+++ b/immutable/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "..",
   },
-  "include": [".", "../src"]
+  "include": [".", "../src"],
+  "exclude": ["./dist"]
 }

--- a/infinite/tsconfig.json
+++ b/infinite/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "./dist",
     "rootDir": "..",
   },
-  "include": [".", "../src"]
+  "include": [".", "../src"],
+  "exclude": ["./dist"]
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "build:core": "bunchee src/index.ts -m --no-sourcemap",
     "build:infinite": "bunchee index.ts --cwd infinite -m --no-sourcemap",
     "build:immutable": "bunchee index.ts --cwd immutable -m --no-sourcemap",
-    "prepublishOnly": "rm -rf dist && yarn build",
+    "prepublishOnly": "rm -rf dist infinite/dist immutable/dist && yarn build",
     "types:check": "tsc --noEmit",
     "format": "prettier --write \"{src,infinite,immutable,test,examples}/**/*.{ts,tsx}\"",
     "lint": "eslint \"{src,infinite,immutable,test,examples}/**/*.{ts,tsx}\"",


### PR DESCRIPTION
Currently, `yarn build` is failed when the `dist/` directories already exist, so I've added `dist/` directories into the `exclude` setting to ignore them. I've also remove them on the `prepublishOnly` script.