### PR TITLE
chore: run tests without doing the build

### DIFF
--- a/immutable/index.ts
+++ b/immutable/index.ts
@@ -1,5 +1,4 @@
-// @ts-ignore
-import useSWR from 'swr'
+import useSWR from '../src/use-swr'
 
 import { withMiddleware } from '../src/utils/with-middleware'
 import { Middleware, SWRHook } from '../src/types'

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -3,8 +3,7 @@
 
 import { useRef, useState, useCallback } from 'react'
 
-// @ts-ignore
-import useSWR from 'swr'
+import useSWR from '../src/use-swr'
 
 import defaultConfig from '../src/utils/config'
 import { useIsomorphicLayoutEffect } from '../src/utils/env'

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,6 @@ module.exports = {
   testRegex: '/test/.*\\.test\\.tsx$',
   modulePathIgnorePatterns: ['<rootDir>/examples/'],
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
-  moduleNameMapper: {
-    swr: '<rootDir>/dist/index.js'
-  },
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.test.json'

--- a/test/use-swr-immutable.test.tsx
+++ b/test/use-swr-immutable.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, act, fireEvent } from '@testing-library/react'
 import React, { useState } from 'react'
-import useSWR from '../src'
-import useSWRImmutable from '../immutable'
+import useSWR from '../src/use-swr'
+import useSWRImmutable from '../immutable/index'
 import { sleep, createKey } from './utils'
 
 const waitForNextTick = () => act(() => sleep(1))

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { render, fireEvent, act, screen } from '@testing-library/react'
-import { mutate } from '../src'
-import useSWRInfinite from '../infinite'
+import { mutate } from '../src/use-swr'
+import useSWRInfinite from '../infinite/index'
 import { sleep, createResponse } from './utils'
 
 describe('useSWRInfinite', () => {


### PR DESCRIPTION
After #992, we have to run a build script to run tests because now tests use files in `dist/` instead of TS files.
I guess that the change is related to start using the exports filed in `package.json`.

This is a bit error-prone, so I'd like to use TS files for unit testing. Does it make sense?