### PR TITLE
fix: ignore .d.ts in dist/ for ESLint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,2 @@
-dist/**/*
-esm/**/*
+dist/
 node_modules
-playground


### PR DESCRIPTION
I've had the following error while running `yarn lint`, which is caused by checking .d.ts files in `dist/`. So I've ignored them.

```
  0:0  error  Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
The file does not match your project config: immutable/dist/src/index.d.ts.
The file must be included in at least one of the projects provided
```

I've also removed unnecessary ignored targets.
