### PR TITLE
chore: add watch scripts for sub packages to build them

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
   "license": "MIT",
   "scripts": {
     "build": "yarn build:core && yarn build:infinite && yarn build:immutable",
-    "watch": "bunchee src/index.ts --watch",
+    "watch": "concurrently \"yarn watch:core\" \"yarn watch:infinite\" \"yarn watch:immutable\"",
+    "watch:core": "bunchee src/index.ts --watch",
+    "watch:infinite": "bunchee index.ts --cwd infinite --watch",
+    "watch:immutable": "bunchee index.ts --cwd immutable --watch",
     "build:core": "bunchee src/index.ts -m --no-sourcemap",
     "build:infinite": "bunchee index.ts --cwd infinite -m --no-sourcemap",
     "build:immutable": "bunchee index.ts --cwd immutable -m --no-sourcemap",


### PR DESCRIPTION
~This is an alternative of #1256 
Currently, we have to build each packages to run tests, which is a bit cumbersome,  and I've added npm-scripts to watch and build each package.~

~With this PR, we don't have to run a build script manually for unit testing.~

I've reopened this because I think this is useful to use local builds to run an application.