### PR TITLE
Fix typo of type SWRHookWithMiddleware

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -73,13 +73,13 @@ export interface Preset {
 }
 
 // Middlewares guarantee that a SWRHook receives a key, fetcher, and config as the argument
-type SWRHookWithdMiddleware = <Data = any, Error = any>(
+type SWRHookWithMiddleware = <Data = any, Error = any>(
   key: Key,
   fetcher: Fetcher<Data> | null,
   config: SWRConfiguration<Data, Error>
 ) => SWRResponse<Data, Error>
 
-export type Middleware = (useSWRNext: SWRHook) => SWRHookWithdMiddleware
+export type Middleware = (useSWRNext: SWRHook) => SWRHookWithMiddleware
 
 export type ValueKey = string | any[] | null
 


### PR DESCRIPTION
Fix: `SWRHookWithdMiddleware` -> `SWRHookWithMiddleware`