### PR TITLE
Move infinite types to swr/infinite and deprecate old ones

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -238,3 +238,4 @@ type SWRInfiniteHook = <Data = any, Error = any>(
 ) => SWRInfiniteResponse<Data, Error>
 
 export default withMiddleware(useSWR, infinite) as SWRInfiniteHook
+export { SWRInfiniteConfiguration, SWRInfiniteResponse }

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -2,22 +2,19 @@
 // hook where `key` and return type are not like the normal `useSWR` types.
 
 import { useRef, useState, useCallback } from 'react'
-import useSWR, { SWRConfig } from 'swr'
-
+import useSWR, {
+  SWRConfig,
+  KeyLoader,
+  Fetcher,
+  SWRHook,
+  MutatorCallback,
+  Middleware
+} from 'swr'
 import { useIsomorphicLayoutEffect } from '../src/utils/env'
 import { serialize } from '../src/utils/serialize'
 import { isUndefined, UNDEFINED } from '../src/utils/helper'
 import { withMiddleware } from '../src/utils/with-middleware'
-
-import {
-  KeyLoader,
-  Fetcher,
-  SWRHook,
-  SWRInfiniteConfiguration,
-  SWRInfiniteResponse,
-  MutatorCallback,
-  Middleware
-} from 'swr'
+import { SWRInfiniteConfiguration, SWRInfiniteResponse } from './types'
 
 export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
   getKey: KeyLoader<Data>,

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,0 +1,18 @@
+import { SWRConfiguration, Fetcher, SWRResponse } from 'swr'
+
+export type SWRInfiniteConfiguration<
+  Data = any,
+  Error = any
+> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
+  initialSize?: number
+  revalidateAll?: boolean
+  persistSize?: boolean
+}
+
+export interface SWRInfiniteResponse<Data = any, Error = any>
+  extends SWRResponse<Data[], Error> {
+  size: number
+  setSize: (
+    size: number | ((_size: number) => number)
+  ) => Promise<Data[] | undefined>
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ export default useSWR
 // Types
 export {
   SWRConfiguration,
+  SWRInfiniteConfiguration,
+  SWRInfiniteResponse,
   Revalidator,
   RevalidatorOptions,
   Key,
@@ -20,6 +22,8 @@ export {
   Middleware,
   // Legacy, for backwards compatibility
   ConfigInterface,
+  SWRInfiniteConfigInterface,
+  SWRInfiniteResponseInterface,
   revalidateType,
   RevalidateOptionInterface,
   keyInterface,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,6 @@ export default useSWR
 // Types
 export {
   SWRConfiguration,
-  SWRInfiniteConfiguration,
-  SWRInfiniteResponse,
   Revalidator,
   RevalidatorOptions,
   Key,
@@ -22,8 +20,6 @@ export {
   Middleware,
   // Legacy, for backwards compatibility
   ConfigInterface,
-  SWRInfiniteConfigInterface,
-  SWRInfiniteResponseInterface,
   revalidateType,
   RevalidateOptionInterface,
   keyInterface,

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,52 @@ export type KeyLoader<Data = any> =
   | null
 
 /**
+ * @deprecated `SWRInfiniteConfigInterface` will be renamed to `SWRInfiniteConfiguration`.
+ */
+export type SWRInfiniteConfigInterface<
+  Data = any,
+  Error = any
+> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
+  initialSize?: number
+  revalidateAll?: boolean
+  persistSize?: boolean
+}
+/**
+ * @deprecated `SWRInfiniteConfiguration` will be moved to `swr/infinite`.
+ */
+export type SWRInfiniteConfiguration<
+  Data = any,
+  Error = any
+> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
+  initialSize?: number
+  revalidateAll?: boolean
+  persistSize?: boolean
+}
+
+/**
+ * @deprecated `SWRInfiniteResponseInterface` will be renamed to `SWRInfiniteResponse` in `swr/infinite`.
+ */
+export type SWRInfiniteResponseInterface<Data = any, Error = any> = SWRResponse<
+  Data[],
+  Error
+> & {
+  size: number
+  setSize: (
+    size: number | ((_size: number) => number)
+  ) => Promise<Data[] | undefined>
+}
+/**
+ * @deprecated `SWRInfiniteResponse` will be moved to `swr/infinite`.
+ */
+export interface SWRInfiniteResponse<Data = any, Error = any>
+  extends SWRResponse<Data[], Error> {
+  size: number
+  setSize: (
+    size: number | ((_size: number) => number)
+  ) => Promise<Data[] | undefined>
+}
+
+/**
  * @deprecated `RevalidateOptionInterface` will be renamed to `RevalidatorOptions`.
  */
 export interface RevalidateOptionInterface {

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,46 +183,6 @@ export type KeyLoader<Data = any> =
   | null
 
 /**
- * @deprecated `SWRInfiniteConfigInterface` will be renamed to `SWRInfiniteConfiguration`.
- */
-export type SWRInfiniteConfigInterface<
-  Data = any,
-  Error = any
-> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
-  initialSize?: number
-  revalidateAll?: boolean
-  persistSize?: boolean
-}
-export type SWRInfiniteConfiguration<
-  Data = any,
-  Error = any
-> = SWRConfiguration<Data[], Error, Fetcher<Data[]>> & {
-  initialSize?: number
-  revalidateAll?: boolean
-  persistSize?: boolean
-}
-
-/**
- * @deprecated `SWRInfiniteResponseInterface` will be renamed to `SWRInfiniteResponse`.
- */
-export type SWRInfiniteResponseInterface<Data = any, Error = any> = SWRResponse<
-  Data[],
-  Error
-> & {
-  size: number
-  setSize: (
-    size: number | ((_size: number) => number)
-  ) => Promise<Data[] | undefined>
-}
-export interface SWRInfiniteResponse<Data = any, Error = any>
-  extends SWRResponse<Data[], Error> {
-  size: number
-  setSize: (
-    size: number | ((_size: number) => number)
-  ) => Promise<Data[] | undefined>
-}
-
-/**
  * @deprecated `RevalidateOptionInterface` will be renamed to `RevalidatorOptions`.
  */
 export interface RevalidateOptionInterface {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -1,6 +1,4 @@
-// TODO: use @ts-expect-error
 import { useCallback, useRef, useDebugValue } from 'react'
-
 import defaultConfig from './utils/config'
 import { wrapCache } from './utils/cache'
 import { IS_SERVER, rAF, useIsomorphicLayoutEffect } from './utils/env'


### PR DESCRIPTION
```diff
- import { SWRInfiniteConfiguration, SWRInfiniteResponse } from 'swr'
+ import { SWRInfiniteConfiguration, SWRInfiniteResponse } from 'swr/infinite'
```