### PR TITLE
Refine createCache

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,13 +49,16 @@ export interface Configuration<
 
   isOnline: () => boolean
   isDocumentVisible: () => boolean
-  setupOnFocus: (cb: () => void) => () => void
-  setupOnReconnect: (cb: () => void) => () => void
 
   /**
    * @deprecated `revalidateOnMount` will be removed. Please considering using the `revalidateWhenStale` option.
    */
   revalidateOnMount?: boolean
+}
+
+export type Preset = {
+  setupOnFocus: (cb: () => void) => () => void
+  setupOnReconnect: (cb: () => void) => () => void
 }
 
 export type SWRHook = <Data = any, Error = any>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,8 @@ export interface Configuration<
 
   isOnline: () => boolean
   isDocumentVisible: () => boolean
-  registerOnFocus: (cb: () => void) => void
-  registerOnReconnect: (cb: () => void) => void
+  attachOnFocus: (cb: () => void) => () => void
+  attachOnReconnect: (cb: () => void) => () => void
 
   /**
    * @deprecated `revalidateOnMount` will be removed. Please considering using the `revalidateWhenStale` option.

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,8 +49,8 @@ export interface Configuration<
 
   isOnline: () => boolean
   isDocumentVisible: () => boolean
-  attachOnFocus: (cb: () => void) => () => void
-  attachOnReconnect: (cb: () => void) => () => void
+  setupOnFocus: (cb: () => void) => () => void
+  setupOnReconnect: (cb: () => void) => () => void
 
   /**
    * @deprecated `revalidateOnMount` will be removed. Please considering using the `revalidateWhenStale` option.

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,7 +56,7 @@ export interface Configuration<
   revalidateOnMount?: boolean
 }
 
-export type Preset = {
+export type Provider = {
   setupOnFocus: (cb: () => void) => () => void
   setupOnReconnect: (cb: () => void) => () => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,9 +56,9 @@ export interface Configuration<
   revalidateOnMount?: boolean
 }
 
-export type Provider = {
-  setupOnFocus: (cb: () => void) => () => void
-  setupOnReconnect: (cb: () => void) => () => void
+export type ProviderOptions = {
+  setupOnFocus: (cb: () => void) => void
+  setupOnReconnect: (cb: () => void) => void
 }
 
 export type SWRHook = <Data = any, Error = any>(

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useDebugValue } from 'react'
 import defaultConfig from './utils/config'
+import { provider as defaultProvider } from './utils/web-preset'
 import { wrapCache } from './utils/cache'
 import { IS_SERVER, rAF, useIsomorphicLayoutEffect } from './utils/env'
 import { serialize } from './utils/serialize'
@@ -21,7 +22,7 @@ import {
   Cache,
   ScopedMutator,
   SWRHook,
-  Preset
+  Provider
 } from './types'
 
 type Revalidator = (...args: any[]) => void
@@ -46,12 +47,9 @@ const getGlobalState = (cache: Cache) => {
   ]
 }
 
-function setupGlobalEvents(cache: Cache, options: Partial<Preset> = {}) {
+function setupGlobalEvents(cache: Cache, _provider: Partial<Provider> = {}) {
   if (IS_SERVER) return
-
-  const setupOnFocus = options.setupOnFocus || defaultConfig.setupOnFocus
-  const setupOnReconnect =
-    options.setupOnReconnect || defaultConfig.setupOnReconnect
+  const provider = { ..._provider, ...defaultProvider } as Provider
   const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = getGlobalState(cache)
   const revalidate = (revalidators: Record<string, Revalidator[]>) => {
     for (const key in revalidators) {
@@ -60,8 +58,8 @@ function setupGlobalEvents(cache: Cache, options: Partial<Preset> = {}) {
   }
   const onFocus = () => revalidate(FOCUS_REVALIDATORS)
   const onReconnect = () => revalidate(RECONNECT_REVALIDATORS)
-  setupOnFocus(onFocus)
-  setupOnReconnect(onReconnect)
+  provider.setupOnFocus(onFocus)
+  provider.setupOnReconnect(onReconnect)
 }
 
 // Setup DOM events listeners for `focus` and `reconnect` actions

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -696,7 +696,7 @@ export const mutate = internalMutate.bind(
 
 export function createCache<Data>(
   provider: Cache,
-  options?: ProviderOptions
+  options?: Partial<ProviderOptions>
 ): {
   cache: Cache
   mutate: ScopedMutator<Data>

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -58,8 +58,8 @@ function attachGlobalEvents(config: Configuration) {
   }
   const onFocus = () => revalidate(FOCUS_REVALIDATORS)
   const onReconnect = () => revalidate(RECONNECT_REVALIDATORS)
-  const dettachOnFoucs = config.attachOnFocus(onFocus)
-  const dettachOnReconnect = config.attachOnReconnect(onReconnect)
+  const dettachOnFoucs = config.setupOnFocus(onFocus)
+  const dettachOnReconnect = config.setupOnReconnect(onReconnect)
 
   return () => {
     dettachOnFoucs()

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -45,7 +45,7 @@ const getGlobalState = (cache: Cache) => {
   ]
 }
 
-function attachGlobalEvents(config: Configuration) {
+function setupGlobalEvents(config: Configuration) {
   const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = getGlobalState(
     config.cache
   )
@@ -58,17 +58,17 @@ function attachGlobalEvents(config: Configuration) {
   }
   const onFocus = () => revalidate(FOCUS_REVALIDATORS)
   const onReconnect = () => revalidate(RECONNECT_REVALIDATORS)
-  const dettachOnFoucs = config.setupOnFocus(onFocus)
-  const dettachOnReconnect = config.setupOnReconnect(onReconnect)
+  const teardownOnFoucs = config.setupOnFocus(onFocus)
+  const teardownOnReconnect = config.setupOnReconnect(onReconnect)
 
   return () => {
-    dettachOnFoucs()
-    dettachOnReconnect()
+    teardownOnFoucs()
+    teardownOnReconnect()
   }
 }
 
 // Setup DOM events listeners for `focus` and `reconnect` actions
-if (!IS_SERVER) attachGlobalEvents(defaultConfig)
+if (!IS_SERVER) setupGlobalEvents(defaultConfig)
 
 const broadcastState: Broadcaster = (
   cache: Cache,
@@ -498,7 +498,7 @@ export function useSWRHandler<Data = any, Error = any>(
   })
 
   useIsomorphicLayoutEffect(() => {
-    return attachGlobalEvents(configRef.current)
+    return setupGlobalEvents(configRef.current)
   }, [configRef.current.cache])
 
   // After mounted or key changed.

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -49,17 +49,16 @@ const getGlobalState = (cache: Cache) => {
 
 function setupGlobalEvents(cache: Cache, _provider: Partial<Provider> = {}) {
   if (IS_SERVER) return
-  const provider = { ..._provider, ...defaultProvider } as Provider
+  const provider = { ...defaultProvider, ..._provider }
   const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = getGlobalState(cache)
   const revalidate = (revalidators: Record<string, Revalidator[]>) => {
     for (const key in revalidators) {
       if (revalidators[key][0]) revalidators[key][0]()
     }
   }
-  const onFocus = () => revalidate(FOCUS_REVALIDATORS)
-  const onReconnect = () => revalidate(RECONNECT_REVALIDATORS)
-  provider.setupOnFocus(onFocus)
-  provider.setupOnReconnect(onReconnect)
+
+  provider.setupOnFocus(() => revalidate(FOCUS_REVALIDATORS))
+  provider.setupOnReconnect(() => revalidate(RECONNECT_REVALIDATORS))
 }
 
 // Setup DOM events listeners for `focus` and `reconnect` actions

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -22,7 +22,7 @@ import {
   Cache,
   ScopedMutator,
   SWRHook,
-  Provider
+  ProviderOptions
 } from './types'
 
 type Revalidator = (...args: any[]) => void
@@ -47,9 +47,9 @@ const getGlobalState = (cache: Cache) => {
   ]
 }
 
-function setupGlobalEvents(cache: Cache, _provider: Partial<Provider> = {}) {
+function setupGlobalEvents(cache: Cache, _opts: Partial<ProviderOptions> = {}) {
   if (IS_SERVER) return
-  const provider = { ...defaultProvider, ..._provider }
+  const opts = { ...defaultProvider, ..._opts }
   const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = getGlobalState(cache)
   const revalidate = (revalidators: Record<string, Revalidator[]>) => {
     for (const key in revalidators) {
@@ -57,8 +57,8 @@ function setupGlobalEvents(cache: Cache, _provider: Partial<Provider> = {}) {
     }
   }
 
-  provider.setupOnFocus(() => revalidate(FOCUS_REVALIDATORS))
-  provider.setupOnReconnect(() => revalidate(RECONNECT_REVALIDATORS))
+  opts.setupOnFocus(() => revalidate(FOCUS_REVALIDATORS))
+  opts.setupOnReconnect(() => revalidate(RECONNECT_REVALIDATORS))
 }
 
 // Setup DOM events listeners for `focus` and `reconnect` actions
@@ -695,13 +695,14 @@ export const mutate = internalMutate.bind(
 ) as ScopedMutator
 
 export function createCache<Data>(
-  provider: Cache
+  provider: Cache,
+  options?: ProviderOptions
 ): {
   cache: Cache
   mutate: ScopedMutator<Data>
 } {
   const cache = wrapCache<Data>(provider)
-  setupGlobalEvents(cache)
+  setupGlobalEvents(cache, options)
   return {
     cache,
     mutate: internalMutate.bind(null, cache) as ScopedMutator<Data>

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -3,7 +3,12 @@ import { dequal } from 'dequal/lite'
 import { wrapCache } from './cache'
 import webPreset from './web-preset'
 import { slowConnection } from './env'
-import { Configuration, RevalidatorOptions, Revalidator } from '../types'
+import {
+  Configuration,
+  RevalidatorOptions,
+  Revalidator,
+  Preset
+} from '../types'
 import { UNDEFINED } from './helper'
 
 const fetcher = (url: string) => fetch(url).then(res => res.json())
@@ -36,7 +41,7 @@ function onErrorRetry(
 }
 
 // Default config
-const defaultConfig: Configuration = {
+const defaultConfig: Configuration & Preset = {
   // events
   onLoadingSlow: noop,
   onSuccess: noop,

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,14 +1,9 @@
 import { dequal } from 'dequal/lite'
 
 import { wrapCache } from './cache'
-import webPreset from './web-preset'
+import { preset } from './web-preset'
 import { slowConnection } from './env'
-import {
-  Configuration,
-  RevalidatorOptions,
-  Revalidator,
-  Preset
-} from '../types'
+import { Configuration, RevalidatorOptions, Revalidator } from '../types'
 import { UNDEFINED } from './helper'
 
 const fetcher = (url: string) => fetch(url).then(res => res.json())
@@ -22,7 +17,7 @@ function onErrorRetry(
   revalidate: Revalidator,
   opts: Required<RevalidatorOptions>
 ): void {
-  if (!webPreset.isDocumentVisible()) {
+  if (!preset.isDocumentVisible()) {
     // If it's hidden, stop. It will auto revalidate when refocusing.
     return
   }
@@ -41,7 +36,7 @@ function onErrorRetry(
 }
 
 // Default config
-const defaultConfig: Configuration & Preset = {
+const defaultConfig: Configuration = {
   // events
   onLoadingSlow: noop,
   onSuccess: noop,
@@ -66,8 +61,8 @@ const defaultConfig: Configuration & Preset = {
   isPaused: () => false,
   cache: wrapCache(new Map()),
 
-  // presets
-  ...webPreset
+  // use web preset by default
+  ...preset
 } as const
 
 export default defaultConfig

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -1,3 +1,4 @@
+import { Provider } from '../types'
 import { isUndefined } from './helper'
 
 /**
@@ -63,9 +64,12 @@ const setupOnReconnect = (cb: () => void) => {
   }
 }
 
-export default {
+export const preset = {
   isOnline,
-  isDocumentVisible,
+  isDocumentVisible
+} as const
+
+export const provider: Provider = {
   setupOnFocus,
   setupOnReconnect
-} as const
+}

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -34,7 +34,7 @@ const isDocumentVisible = () => {
   return true
 }
 
-const attachOnFocus = (cb: () => void) => {
+const setupOnFocus = (cb: () => void) => {
   // focus revalidate
   documentEventListener(add)('visibilitychange', cb)
   windowEventListener(add)('focus', cb)
@@ -44,7 +44,7 @@ const attachOnFocus = (cb: () => void) => {
   }
 }
 
-const attachOnReconnect = (cb: () => void) => {
+const setupOnReconnect = (cb: () => void) => {
   const onOnline = () => {
     online = true
     cb()
@@ -66,6 +66,6 @@ const attachOnReconnect = (cb: () => void) => {
 export default {
   isOnline,
   isDocumentVisible,
-  attachOnFocus,
-  attachOnReconnect
+  setupOnFocus,
+  setupOnReconnect
 } as const

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -46,7 +46,8 @@ const attachOnFocus = (cb: () => void) => {
 
 const attachOnReconnect = (cb: () => void) => {
   const onOnline = () => {
-    ;(online = true) && cb()
+    online = true
+    cb()
   }
   const onOffline = () => {
     online = false

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -10,16 +10,14 @@ import { isUndefined } from './helper'
  */
 let online = true
 const isOnline = () => online
-const noop = () => {}
-const ADD = 'addEventListener'
-
 const hasWindow = typeof window !== 'undefined'
 const hasDocument = typeof document !== 'undefined'
+const add = 'addEventListener'
+function noop() {}
 
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
-const onWindowEvent =
-  hasWindow && !isUndefined(window[ADD]) ? window[ADD].bind(window) : noop
-const onDocumentEvent = hasDocument ? document[ADD].bind(document) : noop
+const onWindowEvent = hasWindow && window[add] ? window[add] : noop
+const onDocumentEvent = hasDocument ? document[add] : noop
 
 const isDocumentVisible = () => {
   const visibilityState = hasDocument && document.visibilityState

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -206,7 +206,7 @@ describe('useSWR - focus', () => {
     const { cache } = createCache(new Map())
 
     function Page() {
-      const { data } = useSWR('revalidaOnFocus + cache', () => value++, {
+      const { data } = useSWR('revalidateOnFocus + cache', () => value++, {
         cache,
         revalidateOnFocus: true,
         dedupingInterval: 0
@@ -214,16 +214,12 @@ describe('useSWR - focus', () => {
       return <div>data: {data}</div>
     }
 
+    // reuse default test case
     render(<Page />)
-    // hydration
     screen.getByText('data:')
-    // mount
     await screen.findByText('data: 0')
-
     await waitForNextTick()
-    // trigger revalidation
     await focusWindow()
-
     await screen.findByText('data: 1')
   })
 })

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -1,13 +1,9 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import React, { useState } from 'react'
 import useSWR, { createCache } from 'swr'
-import { sleep } from './utils'
+import { sleep, nextTick as waitForNextTick, focusOn } from './utils'
 
-const waitForNextTick = () => act(() => sleep(1))
-const focusWindow = () =>
-  act(async () => {
-    fireEvent.focus(window)
-  })
+const focusWindow = () => focusOn(window)
 
 describe('useSWR - focus', () => {
   it('should revalidate on focus by default', async () => {

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -57,7 +57,8 @@ describe('useSWR - focus', () => {
     // should not be revalidated
     screen.getByText('data: 0')
   })
-  it('revalidateOnFocus shoule be stateful', async () => {
+
+  it('revalidateOnFocus should be stateful', async () => {
     let value = 0
 
     function Page() {

--- a/test/use-swr-immutable.test.tsx
+++ b/test/use-swr-immutable.test.tsx
@@ -2,13 +2,9 @@ import { render, screen, act, fireEvent } from '@testing-library/react'
 import React, { useState } from 'react'
 import useSWR from 'swr'
 import useSWRImmutable from 'swr/immutable'
-import { sleep, createKey } from './utils'
+import { sleep, createKey, nextTick as waitForNextTick, focusOn } from './utils'
 
-const waitForNextTick = () => act(() => sleep(1))
-const focusWindow = () =>
-  act(async () => {
-    fireEvent.focus(window)
-  })
+const focusWindow = () => focusOn(window)
 
 describe('useSWR - immutable', () => {
   it('should revalidate on mount', async () => {

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -1,9 +1,7 @@
 import { act, render, screen, fireEvent } from '@testing-library/react'
 import React, { useState, useEffect } from 'react'
 import useSWR from 'swr'
-import { createResponse, sleep } from './utils'
-
-const waitForNextTick = () => act(() => sleep(1))
+import { createResponse, sleep, nextTick as waitForNextTick } from './utils'
 
 describe('useSWR', () => {
   it('should return `undefined` on hydration then return data', async () => {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -2,9 +2,7 @@ import { act, render, screen, fireEvent } from '@testing-library/react'
 import React, { useEffect, useState } from 'react'
 import useSWR, { mutate, createCache, SWRConfig } from 'swr'
 import { serialize } from '../src/utils/serialize'
-import { createResponse, sleep } from './utils'
-
-const waitForNextTick = () => act(() => sleep(1))
+import { createResponse, sleep, nextTick as waitForNextTick } from './utils'
 
 describe('useSWR - local mutation', () => {
   it('should trigger revalidation programmatically', async () => {

--- a/test/use-swr-offline.test.tsx
+++ b/test/use-swr-offline.test.tsx
@@ -1,13 +1,9 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import React from 'react'
 import useSWR from 'swr'
-import { sleep } from './utils'
+import { nextTick as waitForNextTick, focusOn } from './utils'
 
-const waitForNextTick = () => act(() => sleep(1))
-const focusWindow = () =>
-  act(async () => {
-    fireEvent.focus(window)
-  })
+const focusWindow = () => focusOn(window)
 const dispatchWindowEvent = event =>
   act(async () => {
     window.dispatchEvent(new Event(event))

--- a/test/use-swr-revalidate.test.tsx
+++ b/test/use-swr-revalidate.test.tsx
@@ -1,9 +1,7 @@
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import useSWR from 'swr'
-import { createResponse, sleep } from './utils'
-
-const waitForNextTick = () => act(() => sleep(1))
+import { createResponse, sleep, nextTick as waitForNextTick } from './utils'
 
 describe('useSWR - revalidate', () => {
   it('should rerender after triggering revalidation', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,3 +1,5 @@
+import { act, fireEvent } from '@testing-library/react'
+
 export function sleep(time: number) {
   return new Promise(resolve => setTimeout(resolve, time))
 }
@@ -15,5 +17,12 @@ export const createResponse = <T = any>(
       }
     }, delay)
   )
+
+export const nextTick = () => act(() => sleep(1))
+
+export const focusOn = (element: any) =>
+  act(async () => {
+    fireEvent.focus(element)
+  })
 
 export const createKey = () => 'swr-key-' + ~~(Math.random() * 1e7)


### PR DESCRIPTION
Fixes #1275

### Changes

* Only need to `setupOn<Event>` for cache
* Setup global listeners inside `createCache` 

```js
createCache(new Map(), {
  // if you want to override any event that can trigger revalidation, use following options

  // override default behavior of revalidate on focus, it will revalidate on your own `focus` event now
  setupOnFocus(focusRevalidator) {
      customEvent.on('focus', focusRevalidator)
   },

   // override default behavior of revalidate on reconnect, it will revalidate on custom network events now
   setupOnReconnect(reconnectRevalidator) {
     customEvent.on('reconnect', reconnectRevalidator)
   }
})
```


### Fixes

* Fix custom cache is not bound to env like `focus`, `reconnect` events on web
