### PR TITLE
enhance: simplify deno detection

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,9 +1,6 @@
 import { useEffect, useLayoutEffect } from 'react'
 
-export const IS_SERVER =
-  typeof window === 'undefined' ||
-  // @ts-expect-error
-  !!(typeof Deno !== 'undefined' && Deno.version && Deno.version.deno)
+export const IS_SERVER = typeof window === 'undefined' || 'Deno' in window
 
 const __requestAnimationFrame = !IS_SERVER
   ? window['requestAnimationFrame']


### PR DESCRIPTION
For Deno, `window` is `globalThis`, so `Deno === window.Deno === globalThis.Deno`. Ignore the case that user customized their own global variable `window.Deno = xxx`