### PR TITLE
Fix useSWRInfinite doesn't revalidate the first page

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -105,6 +105,7 @@ export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
       const data: Data[] = []
 
       const pageSize = resolvePageSize()
+
       let previousPageData = null
       for (let i = 0; i < pageSize; ++i) {
         const [pageKey, pageArgs] = serialize(
@@ -129,15 +130,11 @@ export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
           revalidateAll ||
           force ||
           isUndefined(pageData) ||
-          (isUndefined(force) && i === 0 && !isUndefined(dataRef.current)) ||
+          (i === 0 && !isUndefined(dataRef.current)) ||
           (originalData && !config.compare(originalData[i], pageData))
 
         if (fn && shouldFetchPage) {
-          if (pageArgs !== null) {
-            pageData = await fn(...pageArgs)
-          } else {
-            pageData = await fn(pageKey)
-          }
+          pageData = await fn(...pageArgs)
           cache.set(pageKey, pageData)
         }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,9 @@ module.exports = {
   modulePathIgnorePatterns: ['<rootDir>/examples/'],
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts'],
   moduleNameMapper: {
-    '^swr$': '<rootDir>/src'
+    '^swr$': '<rootDir>/src',
+    '^swr/infinite$': '<rootDir>/infinite/index.ts',
+    '^swr/immutable$': '<rootDir>/immutable/index.ts'
   },
   globals: {
     'ts-jest': {


### PR DESCRIPTION
By design, we should always revalidate the first page even if `force` is set to `false`.

Closes #908. Also added a test case.