### PR TITLE
Code structure refactoring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - run: yarn install
       - run: yarn types:check
       - run: yarn lint
-      - run: yarn build:core
+      - run: yarn build
       - run: yarn test
         env:
           CI: true

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,7 +169,7 @@ export interface RevalidatorOptions {
 
 export type Revalidator = (
   revalidateOpts?: RevalidatorOptions
-) => Promise<boolean>
+) => Promise<boolean> | void
 
 export interface Cache<Data = any> {
   get(key: Key): Data | null | undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,7 +168,7 @@ export interface RevalidatorOptions {
 }
 
 export type Revalidator = (
-  revalidateOpts: RevalidatorOptions
+  revalidateOpts?: RevalidatorOptions
 ) => Promise<boolean>
 
 export interface Cache<Data = any> {

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -73,14 +73,11 @@ async function internalMutate<Data = any>(
     )
   }
 
-  // update global timestamps
-  MUTATION_TS[key] = ++__timestamp
-  MUTATION_END_TS[key] = 0
-
-  // track timestamps before await asynchronously
-  const beforeMutationTs = MUTATION_TS[key]
-
   let data: any, error: unknown
+
+  // Update global timestamps.
+  const beforeMutationTs = (MUTATION_TS[key] = ++__timestamp)
+  MUTATION_END_TS[key] = 0
 
   if (typeof _data === 'function') {
     // `_data` is a function, call it passing current cache value.

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,6 +1,52 @@
-import { Cache } from '../types'
+import { provider as defaultProvider } from './web-preset'
+import { IS_SERVER } from './env'
+import { UNDEFINED } from './helper'
 
-export function wrapCache<Data = any>(provider: Cache<Data>): Cache {
+import { Cache, Revalidator, Updater, ProviderOptions } from '../types'
+
+// Global state used to deduplicate requests and store listeners
+export const SWRGlobalState = new WeakMap<
+  Cache,
+  [
+    Record<string, Revalidator[]>, // FOCUS_REVALIDATORS
+    Record<string, Revalidator[]>, // RECONNECT_REVALIDATORS
+    Record<string, Updater[]>, // CACHE_REVALIDATORS
+    Record<string, number>, // MUTATION_TS
+    Record<string, number>, // MUTATION_END_TS
+    Record<string, any>, // CONCURRENT_PROMISES
+    Record<string, number> // CONCURRENT_PROMISES_TS
+  ]
+>()
+
+function revalidateAllKeys(revalidators: Record<string, Revalidator[]>) {
+  for (const key in revalidators) {
+    if (revalidators[key][0]) revalidators[key][0]()
+  }
+}
+
+function setupGlobalEvents(cache: Cache, options: ProviderOptions) {
+  const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = SWRGlobalState.get(
+    cache
+  )!
+  options.setupOnFocus(revalidateAllKeys.bind(UNDEFINED, FOCUS_REVALIDATORS))
+  options.setupOnReconnect(
+    revalidateAllKeys.bind(UNDEFINED, RECONNECT_REVALIDATORS)
+  )
+}
+
+export function wrapCache<Data = any>(
+  provider: Cache<Data>,
+  options?: Partial<ProviderOptions>
+): Cache {
+  // Initialize global state for the specific data storage that will be used to
+  // deduplicate requests and store listeners.
+  SWRGlobalState.set(provider, [{}, {}, {}, {}, {}, {}, {}])
+
+  // Setup DOM events listeners for `focus` and `reconnect` actions.
+  if (!IS_SERVER) {
+    setupGlobalEvents(provider, { ...defaultProvider, ...options })
+  }
+
   // We might want to inject an extra layer on top of `provider` in the future,
   // such as key serialization, auto GC, etc.
   // For now, it's just a `Map` interface without any modifications.

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -4,19 +4,18 @@ import { UNDEFINED } from './helper'
 
 import { Cache, Revalidator, Updater, ProviderOptions } from '../types'
 
+export type GlobalState = [
+  Record<string, Revalidator[]>, // FOCUS_REVALIDATORS
+  Record<string, Revalidator[]>, // RECONNECT_REVALIDATORS
+  Record<string, (Revalidator | Updater<any>)[]>, // CACHE_REVALIDATORS
+  Record<string, number>, // MUTATION_TS
+  Record<string, number>, // MUTATION_END_TS
+  Record<string, any>, // CONCURRENT_PROMISES
+  Record<string, number> // CONCURRENT_PROMISES_TS
+]
+
 // Global state used to deduplicate requests and store listeners
-export const SWRGlobalState = new WeakMap<
-  Cache,
-  [
-    Record<string, Revalidator[]>, // FOCUS_REVALIDATORS
-    Record<string, Revalidator[]>, // RECONNECT_REVALIDATORS
-    Record<string, Updater[]>, // CACHE_REVALIDATORS
-    Record<string, number>, // MUTATION_TS
-    Record<string, number>, // MUTATION_END_TS
-    Record<string, any>, // CONCURRENT_PROMISES
-    Record<string, number> // CONCURRENT_PROMISES_TS
-  ]
->()
+export const SWRGlobalState = new WeakMap<Cache, GlobalState>()
 
 function revalidateAllKeys(revalidators: Record<string, Revalidator[]>) {
   for (const key in revalidators) {
@@ -27,7 +26,7 @@ function revalidateAllKeys(revalidators: Record<string, Revalidator[]>) {
 function setupGlobalEvents(cache: Cache, options: ProviderOptions) {
   const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = SWRGlobalState.get(
     cache
-  )!
+  ) as GlobalState
   options.setupOnFocus(revalidateAllKeys.bind(UNDEFINED, FOCUS_REVALIDATORS))
   options.setupOnReconnect(
     revalidateAllKeys.bind(UNDEFINED, RECONNECT_REVALIDATORS)

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -12,11 +12,7 @@ type StateDeps = Record<StateKeys, boolean>
 export default function useStateWithDeps<Data, Error, S = State<Data, Error>>(
   state: S,
   unmountedRef: MutableRefObject<boolean>
-): [
-  MutableRefObject<S>,
-  MutableRefObject<Record<StateKeys, boolean>>,
-  (payload: S) => void
-] {
+): [MutableRefObject<S>, Record<StateKeys, boolean>, (payload: S) => void] {
   const rerender = useState<Record<string, unknown>>({})[1]
   const stateRef = useRef(state)
 
@@ -84,5 +80,5 @@ export default function useStateWithDeps<Data, Error, S = State<Data, Error>>(
     stateRef.current = state
   })
 
-  return [stateRef, stateDependenciesRef, setState]
+  return [stateRef, stateDependenciesRef.current, setState]
 }


### PR DESCRIPTION
The most significant change is to move event setup and global states into the cache wrapper, so the main logic (use-swr.ts) keeps uncoupled.