### PR TITLE
Rename isDocumentVisible to isVisible

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export interface Configuration<
   compare: (a: Data | undefined, b: Data | undefined) => boolean
 
   isOnline: () => boolean
-  isDocumentVisible: () => boolean
+  isVisible: () => boolean
 
   /**
    * @deprecated `revalidateOnMount` will be removed. Please considering using the `revalidateWhenStale` option.

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -484,7 +484,7 @@ export function useSWRHandler<Data = any, Error = any>(
     }
 
     const isActive = () =>
-      configRef.current.isDocumentVisible() && configRef.current.isOnline()
+      configRef.current.isVisible() && configRef.current.isOnline()
 
     // Add event listeners.
     let pending = false
@@ -560,7 +560,7 @@ export function useSWRHandler<Data = any, Error = any>(
     async function tick() {
       if (
         !stateRef.current.error &&
-        (refreshWhenHidden || config.isDocumentVisible()) &&
+        (refreshWhenHidden || config.isVisible()) &&
         (refreshWhenOffline || config.isOnline())
       ) {
         // only revalidate when the page is visible

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,7 +16,7 @@ function onErrorRetry(
   revalidate: Revalidator,
   opts: Required<RevalidatorOptions>
 ): void {
-  if (!preset.isDocumentVisible()) {
+  if (!preset.isVisible()) {
     // If it's hidden, stop. It will auto revalidate when refocusing.
     return
   }

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -19,7 +19,7 @@ function noop() {}
 const onWindowEvent = hasWindow && window[add] ? window[add] : noop
 const onDocumentEvent = hasDocument ? document[add] : noop
 
-const isDocumentVisible = () => {
+const isVisible = () => {
   const visibilityState = hasDocument && document.visibilityState
   if (!isUndefined(visibilityState)) {
     return visibilityState !== 'hidden'
@@ -47,7 +47,7 @@ const setupOnReconnect = (cb: () => void) => {
 
 export const preset = {
   isOnline,
-  isDocumentVisible
+  isVisible
 } as const
 
 export const provider: ProviderOptions = {


### PR DESCRIPTION
To make the option meaning more general, and shorter for convenience, rename `isDocumentVisible` to `isVisible`