### PR TITLE
Fix config being ignored when fetcher is null

### DIFF
--- a/src/utils/normalize-args.ts
+++ b/src/utils/normalize-args.ts
@@ -9,5 +9,5 @@ export function normalize<KeyType = Key, Data = any>(
 ): [KeyType, Fetcher<Data> | null, Partial<SWRConfiguration<Data>>] {
   return typeof args[1] === 'function'
     ? [args[0], args[1], args[2] || {}]
-    : [args[0], null, (typeof args[1] === 'object' ? args[1] : args[2]) || {}]
+    : [args[0], null, (args[1] === null ? args[2] : args[1]) || {}]
 }

--- a/test/unit.test.tsx
+++ b/test/unit.test.tsx
@@ -1,0 +1,26 @@
+import { normalize } from '../src/utils/normalize-args'
+
+describe('Unit tests', () => {
+  it('should normalize arguments correctly', async () => {
+    const fetcher = () => {}
+    const opts = { revalidateOnFocus: false }
+
+    // Only the `key` argument is passed
+    expect(normalize(['key'])).toEqual(['key', null, {}])
+
+    // `key` and `null` as fetcher (no fetcher)
+    expect(normalize(['key', null])).toEqual(['key', null, {}])
+
+    // `key` and `fetcher`
+    expect(normalize(['key', fetcher])).toEqual(['key', fetcher, {}])
+
+    // `key` and `options`
+    expect(normalize(['key', opts])).toEqual(['key', null, opts])
+
+    // `key`, `null` as fetcher, and `options`
+    expect(normalize(['key', null, opts])).toEqual(['key', null, opts])
+
+    // `key`, `fetcher`, and `options`
+    expect(normalize(['key', fetcher, opts])).toEqual(['key', fetcher, opts])
+  })
+})


### PR DESCRIPTION
When `args[1]` is `null`, `typeof args[1]` will still be `"object"` which causes this bug.

Fixes #1274.