### PR TITLE
upgrade bunchee, reduce node_modules size

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@types/react": "16.9.11",
     "@typescript-eslint/eslint-plugin": "4.24.0",
     "@typescript-eslint/parser": "4.24.0",
-    "bunchee": "1.6.2",
+    "bunchee": "1.7.0",
     "concurrently": "6.0.0",
     "eslint": "6.6.0",
     "eslint-config-prettier": "6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,10 +2461,10 @@ builtin-modules@^3.1.0:
   resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz#45d5db99e7ee5e6bc4f362e008bf917ab5049887"
   integrity sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
 
-bunchee@1.6.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/bunchee/-/bunchee-1.6.2.tgz#9c495a133f96ae7f649bf0e161e0825da79a453b"
-  integrity sha512-wmU5r+soOffUf8GxvxbwcRuIJagHnch1xrSpuBxierLUgRx06tPm3hrpTBMFi+8AnvmInZdvEgpgbBVjd3HmvA==
+bunchee@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/bunchee/-/bunchee-1.7.0.tgz#1724103258aa764fa790595c5202921c78e9f6d4"
+  integrity sha512-z26n0icJmLFf0RSYIgPa7nGvSyLitEtMSIA0ZwBAChs3JrOP80ZKPgsP7P6lN3Vwo7/hKUcffZDHv91jOqm4Nw==
   dependencies:
     "@rollup/plugin-babel" "5.2.1"
     "@rollup/plugin-commonjs" "20.0.0"
@@ -2477,8 +2477,6 @@ bunchee@1.6.2:
     rollup-plugin-preserve-shebang "1.0.1"
     rollup-plugin-terser "7.0.2"
     tslib "2.3.0"
-  optionalDependencies:
-    typescript ">= 3.7.0"
 
 cache-base@^1.0.1:
   version "1.0.1"
@@ -2841,9 +2839,9 @@ date-fns@^1.27.2:
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
 date-fns@^2.16.1:
-  version "2.17.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
-  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.23.0.tgz#4e886c941659af0cf7b30fafdd1eaa37e88788a9"
+  integrity sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA==
 
 debug@4:
   version "4.3.1"
@@ -5912,9 +5910,9 @@ rxjs@^6.3.3, rxjs@^6.4.0:
     tslib "^1.9.0"
 
 rxjs@^6.6.3:
-  version "6.6.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
-  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -6637,11 +6635,6 @@ typescript@3.9.10:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
-
-"typescript@>= 3.7.0":
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
typescript is now a peer dep of bunchee, the node modules install size should be reduced around 50+MB. from 415MB to 360MB