### PR TITLE
Local devdelopment with examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ esm
 .vscode
 examples/**/yarn.lock
 package-lock.json
-playground/**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,28 +20,37 @@ If possible, you can add other additional context like how this feature can be i
 
 ## Open a PR for Bugfix or Feature
 
-### Local Development
+### Local Development with Examples
 
-To develop SWR locally, you can use the Vite SWR playground to play with the source code inside the browser. You can follow these steps:
+To run SWR locally, you can start it with any example in `examples` folder. You need to setup the example and run command in the root directory for overriding SWR and its dependencies to local assets.
 
-```bash
-yarn install
-yarn register
+First of all, build SWR assets
+
+```sh
+# or `yarn watch`
 yarn build
-yarn prepare:vite
-yarn dev:vite
 ```
 
-To test SSR related features, you need to use the Next.js SWR playground instead:
+Install dependency of the target example, for instance `examples/basic`:
 
-```bash
-yarn install
-yarn register
-yarn build
-yarn prepare:next
-yarn dev:next
+```sh
+cd examples/basic && yarn
 ```
 
+After setup, back to the root directory and run:
+
+```sh
+# by default it will run next dev for the example
+yarn dev-next basic
+```
+
+All examples are built with Next.js, so Next.js commands are all supported:
+
+```sh
+# if you want to build and start
+yarn dev-next basic build
+yarn dev-next basic start
+```
 ## Update Documentation
 
 To update the [SWR Documentation](https://swr.vercel.app), you can contribute to the [website repository](https://github.com/vercel/swr-site). 

--- a/examples/infinite/package.json
+++ b/examples/infinite/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "dependencies": {
     "isomorphic-unfetch": "3.0.0",
-    "next": "10.0.6",
+    "next": "latest",
     "react": "17.0.1",
     "react-dom": "17.0.1",
-    "swr": "latest"
+    "swr": "beta"
   },
   "scripts": {
     "dev": "next",

--- a/package.json
+++ b/package.json
@@ -51,10 +51,7 @@
     "lint:fix": "eslint \"{src,infinite,immutable,test,examples}/**/*.{ts,tsx}\" --fix",
     "test": "jest",
     "register": "yarn link && cd node_modules/react && yarn link",
-    "prepare:vite": "git clone https://github.com/promer94/vite-swr playground/vite-swr && cd playground/vite-swr && yarn && yarn link react && yarn link swr",
-    "prepare:next": "git clone https://github.com/promer94/next-swr playground/next-swr && cd playground/next-swr && yarn && yarn link react && yarn link swr",
-    "dev:vite": "concurrently \"yarn watch\" \"cd playground/vite-swr && yarn dev\"",
-    "dev:next": "concurrently \"yarn watch\" \"cd playground/next-swr && yarn dev\""
+    "dev-next": "node scripts/dev-next.js"
   },
   "husky": {
     "hooks": {

--- a/scripts/dev-next.js
+++ b/scripts/dev-next.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const { existsSync } = require('fs')
+const { resolve } = require('path')
+const { execSync } = require('child_process')
+
+const args = process.argv
+const target = args[2]
+const nextCmd = args[3] || 'dev'
+
+function error(message) {
+  console.log(message)
+  process.exit(1)
+}
+
+if (!target) {
+  error(`Example ${target} is not found\n`)
+}
+
+const examplesDir = resolve(__dirname, '../examples')
+const exampleDir = resolve(examplesDir, target)
+
+const nextBin = resolve(exampleDir, 'node_modules/.bin/next')
+if (!existsSync(nextBin)) {
+  error(`Please run "yarn install" inside ${target} example directory\n`)
+}
+
+const requireHookPath = resolve(__dirname, 'require-hook.js')
+const devCmd = `cd ${exampleDir} && node -r ${requireHookPath} ${nextBin} ${nextCmd}`
+
+console.log(`Running ${devCmd}`)
+
+execSync(devCmd, { stdio: 'inherit' })

--- a/scripts/require-hook.js
+++ b/scripts/require-hook.js
@@ -1,0 +1,20 @@
+const { resolve } = require('path')
+const mod = require('module')
+
+const rootDir = resolve(__dirname, '..')
+const nodeModulesDir = resolve(rootDir, 'node_modules')
+
+const hookPropertyMap = new Map([
+  ['swr', resolve(rootDir, 'dist/index.js')],
+  ['swr/infinite', resolve(rootDir, 'infinite/dist/index.js')],
+  ['swr/immutable', resolve(rootDir, 'immutable/dist/index.js')],
+  ['react', resolve(nodeModulesDir, 'react')],
+  ['react-dom', resolve(nodeModulesDir, 'react-dom')],
+])
+
+const resolveFilename = mod._resolveFilename
+mod._resolveFilename = function (request, ...args) {
+  const hookResolved = hookPropertyMap.get(request)
+  if (hookResolved) request = hookResolved
+  return resolveFilename.call(mod, request, ...args)
+}


### PR DESCRIPTION
The local development commands now fails to run for me. cc @promer94 

### Changes
Figure out another way to develop swr with local existing examples, checkout the readme change.
In short, you can run `yarn dev-next <example name>` to run it with next.js. No extra dependencies required.
