### PR TITLE
Export `unstable_serialize` from SWR

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -110,7 +110,7 @@ export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
 
       let previousPageData = null
       for (let i = 0; i < pageSize; ++i) {
-        const [pageKey, pageArgs] = serialize(
+        const [pageKey, pageArgs] = serializeKey(
           getKey ? getKey(i, previousPageData) : null
         )
 

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -11,7 +11,7 @@ import useSWR, {
   Middleware
 } from 'swr'
 import { useIsomorphicLayoutEffect } from '../src/utils/env'
-import { serialize } from '../src/utils/serialize'
+import { serialize as serializeKey } from '../src/utils/serialize'
 import { isUndefined, UNDEFINED } from '../src/utils/helper'
 import { withMiddleware } from '../src/utils/with-middleware'
 import { SWRInfiniteConfiguration, SWRInfiniteResponse } from './types'
@@ -19,10 +19,10 @@ import { SWRInfiniteConfiguration, SWRInfiniteResponse } from './types'
 const INFINITE_PREFIX = '$inf$'
 
 const getFirstPageKey = (getKey: KeyLoader<any>) => {
-  return serialize(getKey ? getKey(0, null) : null)[0]
+  return serializeKey(getKey ? getKey(0, null) : null)[0]
 }
 
-export const getInfiniteKey = (getKey: KeyLoader<any>) => {
+export const serialize = (getKey: KeyLoader<any>) => {
   return INFINITE_PREFIX + getFirstPageKey(getKey)
 }
 

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -11,7 +11,7 @@ import useSWR, {
   Middleware
 } from 'swr'
 import { useIsomorphicLayoutEffect } from '../src/utils/env'
-import { serialize as serializeKey } from '../src/utils/serialize'
+import { serialize } from '../src/utils/serialize'
 import { isUndefined, UNDEFINED } from '../src/utils/helper'
 import { withMiddleware } from '../src/utils/with-middleware'
 import { SWRInfiniteConfiguration, SWRInfiniteResponse } from './types'
@@ -19,10 +19,10 @@ import { SWRInfiniteConfiguration, SWRInfiniteResponse } from './types'
 const INFINITE_PREFIX = '$inf$'
 
 const getFirstPageKey = (getKey: KeyLoader<any>) => {
-  return serializeKey(getKey ? getKey(0, null) : null)[0]
+  return serialize(getKey ? getKey(0, null) : null)[0]
 }
 
-export const serialize = (getKey: KeyLoader<any>) => {
+export const unstable_serialize = (getKey: KeyLoader<any>) => {
   return INFINITE_PREFIX + getFirstPageKey(getKey)
 }
 
@@ -110,7 +110,7 @@ export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
 
       let previousPageData = null
       for (let i = 0; i < pageSize; ++i) {
-        const [pageKey, pageArgs] = serializeKey(
+        const [pageKey, pageArgs] = serialize(
           getKey ? getKey(i, previousPageData) : null
         )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 // Core APIs
 export { SWRConfig, mutate, createCache } from './use-swr'
+export { serialize } from './utils/serialize'
 
 // useSWR
 import useSWR from './use-swr'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 // Core APIs
-export { SWRConfig, mutate, createCache } from './use-swr'
-export { serialize } from './utils/serialize'
+export { SWRConfig, mutate, createCache, unstable_serialize } from './use-swr'
 
 // useSWR
 import useSWR from './use-swr'

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -650,4 +650,6 @@ export const createCache = <Data = any>(
   }
 }
 
+export const unstable_serialize = (key: Key) => serialize(key)[0]
+
 export default withArgs<SWRHook>(useSWRHandler)

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { render, fireEvent, act, screen } from '@testing-library/react'
 import { mutate, createCache, SWRConfig } from 'swr'
-import useSWRInfinite, { serialize } from 'swr/infinite'
+import useSWRInfinite, { unstable_serialize } from 'swr/infinite'
 import { sleep, createKey, createResponse } from './utils'
 
 describe('useSWRInfinite', () => {
@@ -581,7 +581,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:')
   })
 
-  it('should mutate a cache with `serialize`', async () => {
+  it('should mutate a cache with `unstable_serialize`', async () => {
     let count = 0
     function Page() {
       const { data } = useSWRInfinite<string, string>(
@@ -596,12 +596,14 @@ describe('useSWRInfinite', () => {
 
     await screen.findByText('data:page-test-12-0:1')
 
-    await act(() => mutate(serialize(index => `page-test-12-${index}`)))
+    await act(() =>
+      mutate(unstable_serialize(index => `page-test-12-${index}`))
+    )
     await screen.findByText('data:page-test-12-0:2')
 
     await act(() =>
       mutate(
-        serialize(index => `page-test-12-${index}`),
+        unstable_serialize(index => `page-test-12-${index}`),
         'local-mutation',
         false
       )
@@ -609,7 +611,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:local-mutation')
   })
 
-  it('should mutate a cache with `serialize` based on a current data', async () => {
+  it('should mutate a cache with `unstable_serialize` based on a current data', async () => {
     const getKey = index => [`pagetest-13`, index]
     function Comp() {
       const { data, size, setSize } = useSWRInfinite<string, string>(
@@ -630,7 +632,7 @@ describe('useSWRInfinite', () => {
 
     await act(() =>
       mutate(
-        serialize(getKey),
+        unstable_serialize(getKey),
         data => data.map(value => `(edited)${value}`),
         false
       )
@@ -638,7 +640,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:(edited)page 0, (edited)page 1,')
   })
 
-  it('should be able to use `serialize` with a custom cache', async () => {
+  it('should be able to use `unstable_serialize` with a custom cache', async () => {
     const key = 'page-test-14;'
     const customCache1 = new Map([[key, 'initial-cache']])
     const { cache, mutate: mutateCustomCache } = createCache(customCache1)
@@ -659,11 +661,11 @@ describe('useSWRInfinite', () => {
 
     await screen.findByText('data:initial-cache')
 
-    await act(() => mutateCustomCache(serialize(() => key)))
+    await act(() => mutateCustomCache(unstable_serialize(() => key)))
     await screen.findByText('data:response data')
 
     await act(() =>
-      mutateCustomCache(serialize(() => key), 'local-mutation', false)
+      mutateCustomCache(unstable_serialize(() => key), 'local-mutation', false)
     )
     await screen.findByText('data:local-mutation')
   })

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { render, fireEvent, act, screen } from '@testing-library/react'
 import { mutate, createCache, SWRConfig } from 'swr'
-import useSWRInfinite, { getInfiniteKey } from 'swr/infinite'
+import useSWRInfinite, { serialize } from 'swr/infinite'
 import { sleep, createKey, createResponse } from './utils'
 
 describe('useSWRInfinite', () => {
@@ -581,7 +581,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:')
   })
 
-  it('should mutate a cache with getInfiniteKey', async () => {
+  it('should mutate a cache with `serialize`', async () => {
     let count = 0
     function Page() {
       const { data } = useSWRInfinite<string, string>(
@@ -596,12 +596,12 @@ describe('useSWRInfinite', () => {
 
     await screen.findByText('data:page-test-12-0:1')
 
-    await act(() => mutate(getInfiniteKey(index => `page-test-12-${index}`)))
+    await act(() => mutate(serialize(index => `page-test-12-${index}`)))
     await screen.findByText('data:page-test-12-0:2')
 
     await act(() =>
       mutate(
-        getInfiniteKey(index => `page-test-12-${index}`),
+        serialize(index => `page-test-12-${index}`),
         'local-mutation',
         false
       )
@@ -609,7 +609,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:local-mutation')
   })
 
-  it('should mutate a cache with getInfiniteKey based on a current data', async () => {
+  it('should mutate a cache with `serialize` based on a current data', async () => {
     const getKey = index => [`pagetest-13`, index]
     function Comp() {
       const { data, size, setSize } = useSWRInfinite<string, string>(
@@ -630,7 +630,7 @@ describe('useSWRInfinite', () => {
 
     await act(() =>
       mutate(
-        getInfiniteKey(getKey),
+        serialize(getKey),
         data => data.map(value => `(edited)${value}`),
         false
       )
@@ -638,7 +638,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:(edited)page 0, (edited)page 1,')
   })
 
-  it('should be able to use getInfiniteKey with a custom cache', async () => {
+  it('should be able to use `serialize` with a custom cache', async () => {
     const key = 'page-test-14;'
     const customCache1 = new Map([[key, 'initial-cache']])
     const { cache, mutate: mutateCustomCache } = createCache(customCache1)
@@ -659,11 +659,11 @@ describe('useSWRInfinite', () => {
 
     await screen.findByText('data:initial-cache')
 
-    await act(() => mutateCustomCache(getInfiniteKey(() => key)))
+    await act(() => mutateCustomCache(serialize(() => key)))
     await screen.findByText('data:response data')
 
     await act(() =>
-      mutateCustomCache(getInfiniteKey(() => key), 'local-mutation', false)
+      mutateCustomCache(serialize(() => key), 'local-mutation', false)
     )
     await screen.findByText('data:local-mutation')
   })


### PR DESCRIPTION
SWR handles key serialization so it can just pass a string to the cache provider. This makes all the interfaces simpler. However it makes getting data from the cache (or mutating a specific key) tricky, because the serialization util isn't exposed as an API.

Previously we had #1257 to expose the serialization of the `useSWRInfinite` key. This PR unifies the API name, as well as exposing the `serialize` API of `useSWR`.

Related: #1324, #1257.