### PR TITLE
Improvement: ensure `useSWRInfinite` reuses `useSWR` cache

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -127,13 +127,15 @@ export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
         // - `mutate()` called
         // - the cache is missing
         // - it's the first page and it's not the initial render
-        // - cache has changed
+        // - cache for that page has changed
         const shouldFetchPage =
           revalidateAll ||
           forceRevalidateAll ||
           isUndefined(pageData) ||
           (!i && !isUndefined(dataRef.current)) ||
-          (originalData && !config.compare(originalData[i], pageData))
+          (originalData &&
+            !isUndefined(originalData[i]) &&
+            !config.compare(originalData[i], pageData))
 
         if (fn && shouldFetchPage) {
           pageData = await fn(...pageArgs)

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -726,4 +726,31 @@ describe('useSWRInfinite', () => {
     await act(() => sleep(1))
     expect(renderedData).toEqual(['new'])
   })
+
+  it('should reuse cached value', async () => {
+    const key = createKey()
+    const customCache = new Map([[key + '-1', 'cached value']])
+    const { cache } = createCache(customCache)
+
+    function Page() {
+      const { data, setSize } = useSWRInfinite<string, string>(
+        index => key + '-' + index,
+        () => createResponse('response value')
+      )
+      return (
+        <div onClick={() => setSize(2)}>data:{data ? data.join(',') : ''}</div>
+      )
+    }
+
+    render(
+      <SWRConfig value={{ cache }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    screen.getByText('data:')
+    await screen.findByText('data:response value')
+    fireEvent.click(screen.getByText('data:response value'))
+    await screen.findByText('data:response value,cached value')
+  })
 })

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -727,7 +727,7 @@ describe('useSWRInfinite', () => {
     expect(renderedData).toEqual(['new'])
   })
 
-  it('should reuse cached value', async () => {
+  it('should reuse cached value for new pages', async () => {
     const key = createKey()
     const customCache = new Map([[key + '-1', 'cached value']])
     const { cache } = createCache(customCache)


### PR DESCRIPTION
Currently `useSWRInfinite` will always fetch new pages (when `setSize` is called), even if it's already cached by `useSWR` or something outside of that "pages" cache (an array of pages). With this PR we only re-fetch if the previous cached data of _that page_ has changed. 

Check the test case to see the detailed behavior.