### PR TITLE
Improvement: return stale data then revalidate when setting size of `useSWRInfinite`

### DIFF
--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -754,7 +754,7 @@ describe('useSWRInfinite', () => {
     await screen.findByText('data:response value,cached value')
   })
 
-  it.only('should return cached value ASAP when updating size and revalidate in the background', async () => {
+  it('should return cached value ASAP when updating size and revalidate in the background', async () => {
     const key = createKey()
     const getData = jest.fn(v => v)
 
@@ -790,5 +790,32 @@ describe('useSWRInfinite', () => {
     // Revalidate
     await act(() => sleep(30))
     expect(getData).toHaveBeenCalledTimes(2)
+  })
+
+  it('should block on fetching new uncached pages when updating size', async () => {
+    const key = createKey()
+    const getData = jest.fn(v => v)
+
+    function Page() {
+      const { data, setSize } = useSWRInfinite<string, string>(
+        index => key + '-' + index,
+        () => sleep(30).then(() => getData('response value'))
+      )
+      return (
+        <div onClick={() => setSize(2)}>data:{data ? data.join(',') : ''}</div>
+      )
+    }
+
+    render(<Page />)
+
+    screen.getByText('data:')
+    await screen.findByText('data:response value')
+    expect(getData).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('data:response value'))
+
+    // Fetch new page and revalidate the first page.
+    await screen.findByText('data:response value,response value')
+    expect(getData).toHaveBeenCalledTimes(3)
   })
 })

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -753,4 +753,42 @@ describe('useSWRInfinite', () => {
     fireEvent.click(screen.getByText('data:response value'))
     await screen.findByText('data:response value,cached value')
   })
+
+  it.only('should return cached value ASAP when updating size and revalidate in the background', async () => {
+    const key = createKey()
+    const getData = jest.fn(v => v)
+
+    const customCache = new Map([[key + '-1', 'cached value']])
+    const { cache } = createCache(customCache)
+
+    function Page() {
+      const { data, setSize } = useSWRInfinite<string, string>(
+        index => key + '-' + index,
+        () => sleep(30).then(() => getData('response value'))
+      )
+      return (
+        <div onClick={() => setSize(2)}>data:{data ? data.join(',') : ''}</div>
+      )
+    }
+
+    render(
+      <SWRConfig value={{ cache }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    screen.getByText('data:')
+    await screen.findByText('data:response value')
+    expect(getData).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByText('data:response value'))
+
+    // Returned directly from the cache without blocking
+    await screen.findByText('data:response value,cached value')
+    expect(getData).toHaveBeenCalledTimes(1)
+
+    // Revalidate
+    await act(() => sleep(30))
+    expect(getData).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
Right now `useSWRInfinite` directly revalidates after changing its page size. If that revalidation awaits due to some reason, you can't immediately get the new resized page array even if everything is already in the cache.

This PR changes the behavior to use `mutate` to first return the stale page array with the updated size, and then revalidate in the background.