### PR TITLE
fix: alias swr in next client bundle on dev mode

### DIFF
--- a/scripts/dev-next.js
+++ b/scripts/dev-next.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-const { existsSync } = require('fs')
+const fs = require('fs')
 const { resolve } = require('path')
-const { execSync } = require('child_process')
+const childProcess = require('child_process')
 
 const args = process.argv
 const target = args[2]
@@ -21,13 +21,37 @@ const examplesDir = resolve(__dirname, '../examples')
 const exampleDir = resolve(examplesDir, target)
 
 const nextBin = resolve(exampleDir, 'node_modules/.bin/next')
-if (!existsSync(nextBin)) {
+if (!fs.existsSync(nextBin)) {
   error(`Please run "yarn install" inside ${target} example directory\n`)
 }
 
 const requireHookPath = resolve(__dirname, 'require-hook.js')
-const devCmd = `cd ${exampleDir} && node -r ${requireHookPath} ${nextBin} ${nextCmd}`
+const nextConfigPath = resolve(exampleDir, 'next.config.js')
+const devCmd = `node -r ${requireHookPath} ${nextBin} ${nextCmd}`.split(' ')
 
-console.log(`Running ${devCmd}`)
+if (!fs.existsSync(nextConfigPath)) {
+  fs.symlinkSync(resolve(__dirname, 'next-config.js'), nextConfigPath, 'file')
+}
 
-execSync(devCmd, { stdio: 'inherit' })
+const sub = childProcess.spawn(devCmd.shift(), devCmd, { cwd: exampleDir })
+
+const logStdout = data => process.stdout.write(data.toString())
+const logStderr = data => process.stderr.write(data.toString())
+
+sub.stdout.on('data', logStdout)
+sub.stderr.on('data', logStderr)
+sub.stderr.on('close', () => {
+  sub.stdout.off('data', logStdout)
+  sub.stderr.off('data', logStderr)
+})
+
+const teardown = () => {
+  if (sub.killed) sub.kill('SIGINT')
+  if (fs.existsSync(nextConfigPath)) fs.unlinkSync(nextConfigPath)
+}
+
+process.on('exit', teardown)
+process.on('SIGINT', teardown)
+
+// main
+console.log(`Running ${devCmd.join(' ')}`)

--- a/scripts/next-config.js
+++ b/scripts/next-config.js
@@ -1,0 +1,21 @@
+const { resolve } = require('path')
+
+module.exports = {
+  webpack(config) {
+    const { alias } = config.resolve
+
+    // FIXME: resolving react/jsx-runtime https://github.com/facebook/react/issues/20235
+    alias['react/jsx-dev-runtime'] = require.resolve('react/jsx-dev-runtime.js')
+    alias['react/jsx-runtime'] = require.resolve('react/jsx-runtime.js')
+    
+    alias['swr'] = resolve(__dirname, '../dist/index.js')
+    alias['swr/infinite'] = resolve(__dirname, '../infinite/dist/index.js')
+    alias['swr/immutable'] = resolve(__dirname, '../immutable/dist/index.js')
+
+    alias['react'] = require.resolve('react')
+    alias['react-dom'] = require.resolve('react-dom')
+    alias['react-dom/server'] = require.resolve('react-dom/server')
+
+    return config
+  },
+}


### PR DESCRIPTION
The swr in client bundle is not the one been aliased. reported by @promer94  

Add process to override swr assets by using `next.config.js`:

* run dev command
* create symblink for swr assets overriding
* quit dev command
* unlink custom `next.config.js` and kill dev server
