### PR TITLE
Refactor code structure

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,8 @@
   },
   "rules": {
     "func-names": [2, "as-needed"],
-    "no-shadow": 2,
+    "no-shadow": 0,
+    "@typescript-eslint/no-shadow": 2,
     "@typescript-eslint/explicit-function-return-type": 0,
     "@typescript-eslint/no-use-before-define": 0,
     "@typescript-eslint/ban-ts-ignore": 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,14 +84,6 @@ export type Middleware = (useSWRNext: SWRHook) => SWRHookWithMiddleware
 
 export type ValueKey = string | any[] | null
 
-export type Updater<Data = any, Error = any> = (
-  shouldRevalidate?: boolean,
-  data?: Data,
-  error?: Error,
-  shouldDedupe?: boolean,
-  dedupe?: boolean
-) => boolean | Promise<boolean>
-
 export type MutatorCallback<Data = any> = (
   currentValue?: Data
 ) => Promise<undefined | Data> | undefined | Data
@@ -166,6 +158,27 @@ export interface RevalidatorOptions {
 export type Revalidator = (
   revalidateOpts?: RevalidatorOptions
 ) => Promise<boolean> | void
+
+export const enum RevalidateEvent {
+  FOCUS_EVENT = 0,
+  RECONNECT_EVENT = 1,
+  MUTATE_EVENT = 2
+}
+
+type RevalidateCallbackReturnType = {
+  [RevalidateEvent.FOCUS_EVENT]: void
+  [RevalidateEvent.RECONNECT_EVENT]: void
+  [RevalidateEvent.MUTATE_EVENT]: Promise<boolean>
+}
+export type RevalidateCallback = <K extends RevalidateEvent>(
+  type: K
+) => RevalidateCallbackReturnType[K]
+
+export type StateUpdateCallback<Data = any, Error = any> = (
+  data?: Data,
+  error?: Error,
+  isValidating?: boolean
+) => void
 
 export interface Cache<Data = any> {
   get(key: Key): Data | null | undefined

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -425,10 +425,10 @@ export const useSWRHandler = <Data = any, Error = any>(
   )
 
   // Similar to the global mutate, but bound to the current cache and key.
+  // `cache` isn't allowed to change during the lifecycle.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const boundMutate: SWRResponse<Data, Error>['mutate'] = useCallback(
     internalMutate.bind(UNDEFINED, cache, keyRef.current),
-    // `cache` isn't allowed to change during the lifecycle
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -31,35 +31,33 @@ function revalidateAllKeys(
   }
 }
 
-function setupGlobalEvents(cache: Cache, options: ProviderOptions) {
-  const [EVENT_REVALIDATORS] = SWRGlobalState.get(cache) as GlobalState
-  options.setupOnFocus(
-    revalidateAllKeys.bind(
-      UNDEFINED,
-      EVENT_REVALIDATORS,
-      RevalidateEvent.FOCUS_EVENT
-    )
-  )
-  options.setupOnReconnect(
-    revalidateAllKeys.bind(
-      UNDEFINED,
-      EVENT_REVALIDATORS,
-      RevalidateEvent.RECONNECT_EVENT
-    )
-  )
-}
-
 export function wrapCache<Data = any>(
   provider: Cache<Data>,
   options?: Partial<ProviderOptions>
 ): Cache<Data> {
+  const EVENT_REVALIDATORS = {}
+  const opts = { ...defaultProvider, ...options }
+
   // Initialize global state for the specific data storage that will be used to
   // deduplicate requests and store listeners.
-  SWRGlobalState.set(provider, [{}, {}, {}, {}, {}, {}])
+  SWRGlobalState.set(provider, [EVENT_REVALIDATORS, {}, {}, {}, {}, {}])
 
   // Setup DOM events listeners for `focus` and `reconnect` actions.
   if (!IS_SERVER) {
-    setupGlobalEvents(provider, { ...defaultProvider, ...options })
+    opts.setupOnFocus(
+      revalidateAllKeys.bind(
+        UNDEFINED,
+        EVENT_REVALIDATORS,
+        RevalidateEvent.FOCUS_EVENT
+      )
+    )
+    opts.setupOnReconnect(
+      revalidateAllKeys.bind(
+        UNDEFINED,
+        EVENT_REVALIDATORS,
+        RevalidateEvent.RECONNECT_EVENT
+      )
+    )
   }
 
   // We might want to inject an extra layer on top of `provider` in the future,

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -2,12 +2,17 @@ import { provider as defaultProvider } from './web-preset'
 import { IS_SERVER } from './env'
 import { UNDEFINED } from './helper'
 
-import { Cache, Revalidator, Updater, ProviderOptions } from '../types'
+import {
+  Cache,
+  RevalidateCallback,
+  StateUpdateCallback,
+  ProviderOptions,
+  RevalidateEvent
+} from '../types'
 
 export type GlobalState = [
-  Record<string, Revalidator[]>, // FOCUS_REVALIDATORS
-  Record<string, Revalidator[]>, // RECONNECT_REVALIDATORS
-  Record<string, (Revalidator | Updater<any>)[]>, // CACHE_REVALIDATORS
+  Record<string, RevalidateCallback[]>, // EVENT_REVALIDATORS
+  Record<string, StateUpdateCallback[]>, // STATE_UPDATERS
   Record<string, number>, // MUTATION_TS
   Record<string, number>, // MUTATION_END_TS
   Record<string, any>, // CONCURRENT_PROMISES
@@ -17,19 +22,30 @@ export type GlobalState = [
 // Global state used to deduplicate requests and store listeners
 export const SWRGlobalState = new WeakMap<Cache, GlobalState>()
 
-function revalidateAllKeys(revalidators: Record<string, Revalidator[]>) {
+function revalidateAllKeys(
+  revalidators: Record<string, RevalidateCallback[]>,
+  type: RevalidateEvent
+) {
   for (const key in revalidators) {
-    if (revalidators[key][0]) revalidators[key][0]()
+    if (revalidators[key][0]) revalidators[key][0](type)
   }
 }
 
 function setupGlobalEvents(cache: Cache, options: ProviderOptions) {
-  const [FOCUS_REVALIDATORS, RECONNECT_REVALIDATORS] = SWRGlobalState.get(
-    cache
-  ) as GlobalState
-  options.setupOnFocus(revalidateAllKeys.bind(UNDEFINED, FOCUS_REVALIDATORS))
+  const [EVENT_REVALIDATORS] = SWRGlobalState.get(cache) as GlobalState
+  options.setupOnFocus(
+    revalidateAllKeys.bind(
+      UNDEFINED,
+      EVENT_REVALIDATORS,
+      RevalidateEvent.FOCUS_EVENT
+    )
+  )
   options.setupOnReconnect(
-    revalidateAllKeys.bind(UNDEFINED, RECONNECT_REVALIDATORS)
+    revalidateAllKeys.bind(
+      UNDEFINED,
+      EVENT_REVALIDATORS,
+      RevalidateEvent.RECONNECT_EVENT
+    )
   )
 }
 
@@ -39,7 +55,7 @@ export function wrapCache<Data = any>(
 ): Cache<Data> {
   // Initialize global state for the specific data storage that will be used to
   // deduplicate requests and store listeners.
-  SWRGlobalState.set(provider, [{}, {}, {}, {}, {}, {}, {}])
+  SWRGlobalState.set(provider, [{}, {}, {}, {}, {}, {}])
 
   // Setup DOM events listeners for `focus` and `reconnect` actions.
   if (!IS_SERVER) {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,14 +21,18 @@ function onErrorRetry(
 
   const maxRetryCount = config.errorRetryCount
   const currentRetryCount = opts.retryCount
+
+  // Exponential backoff
+  const timeout =
+    ~~(
+      (Math.random() + 0.5) *
+      (1 << (currentRetryCount < 8 ? currentRetryCount : 8))
+    ) * config.errorRetryInterval
+
   if (maxRetryCount !== UNDEFINED && currentRetryCount > maxRetryCount) {
     return
   }
 
-  // Exponential backoff
-  const timeout =
-    ~~((Math.random() + 0.5) * (1 << Math.min(currentRetryCount, 8))) *
-    config.errorRetryInterval
   setTimeout(revalidate, timeout, opts)
 }
 

--- a/src/utils/subscribe-key.ts
+++ b/src/utils/subscribe-key.ts
@@ -1,11 +1,11 @@
-import { RevalidateCallback, StateUpdateCallback } from '../types'
+type Callback = (...args: any[]) => any
 
 // Add a callback function to a list of keyed callback functions and return
 // the unsubscribe function.
 export const subscribeCallback = (
   key: string,
-  callbacks: Record<string, (RevalidateCallback | StateUpdateCallback)[]>,
-  callback: RevalidateCallback | StateUpdateCallback
+  callbacks: Record<string, Callback[]>,
+  callback: Callback
 ) => {
   const keyedRevalidators = callbacks[key] || (callbacks[key] = [])
   keyedRevalidators.push(callback)

--- a/src/utils/subscribe-key.ts
+++ b/src/utils/subscribe-key.ts
@@ -1,0 +1,22 @@
+import { RevalidateCallback, StateUpdateCallback } from '../types'
+
+// Add a callback function to a list of keyed callback functions and return
+// the unsubscribe function.
+export const subscribeCallback = (
+  key: string,
+  callbacks: Record<string, (RevalidateCallback | StateUpdateCallback)[]>,
+  callback: RevalidateCallback | StateUpdateCallback
+) => {
+  const keyedRevalidators = callbacks[key] || (callbacks[key] = [])
+  keyedRevalidators.push(callback)
+
+  return () => {
+    const index = keyedRevalidators.indexOf(callback)
+
+    if (index >= 0) {
+      // O(1): faster than splice
+      keyedRevalidators[index] = keyedRevalidators[keyedRevalidators.length - 1]
+      keyedRevalidators.pop()
+    }
+  }
+}


### PR DESCRIPTION
- Organize revalidation callbacks into `RevalidateCallback` and `StateUpdateCallback`. The revalidate callback receives internal event (`onfocus`, `onreconnect`, `onmutate`) that might trigger a revalidation to the hook. The state update callback handles hooks' `setState` events. This is the initial step for some future features.
- The new subscribe-key util makes the core leaner.
- Other tweaks.