### PR TITLE
Invert middleware execution order

### DIFF
--- a/src/utils/resolve-args.ts
+++ b/src/utils/resolve-args.ts
@@ -24,7 +24,7 @@ export default function withArgs<SWRType>(hook: any) {
     let next = hook
     const { middlewares } = config
     if (middlewares) {
-      for (let i = 0; i < middlewares.length; i++) {
+      for (let i = middlewares.length; i-- > 0; ) {
         next = middlewares[i](next)
       }
     }


### PR DESCRIPTION
Middleware should be wrapped and executed from the outside to the inside.