### PR TITLE
Rename middlewares option to use

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface PublicConfiguration<
   suspense?: boolean
   initialData?: Data
   fetcher?: Fn
-  middlewares?: Middleware[]
+  use?: Middleware[]
   fallbackValues: { [key: string]: any }
 
   isPaused: () => boolean

--- a/src/utils/config-context.ts
+++ b/src/utils/config-context.ts
@@ -19,7 +19,7 @@ const SWRConfig: FC<{
       provider?: (cache: Readonly<Cache>) => Cache
     }
 }> = ({ children, value }) => {
-  // Extend parent context values and middlewares.
+  // Extend parent context values and middleware.
   const extendedConfig = mergeConfigs(useContext(SWRConfigContext), value)
 
   // Should not use the inherited provider.

--- a/src/utils/merge-config.ts
+++ b/src/utils/merge-config.ts
@@ -10,10 +10,10 @@ export function mergeConfigs(
 
   if (!b) return v
 
-  const { middlewares: m1, fallbackValues: f1 } = a
-  const { middlewares: m2, fallbackValues: f2 } = b
-  if (m1 && m2) {
-    v.middlewares = m1.concat(m2)
+  const { use: u1, fallbackValues: f1 } = a
+  const { use: u2, fallbackValues: f2 } = b
+  if (u1 && u2) {
+    v.use = u1.concat(u2)
   }
   if (f1 && f2) {
     v.fallbackValues = mergeObjects(f1, f2)

--- a/src/utils/resolve-args.ts
+++ b/src/utils/resolve-args.ts
@@ -22,12 +22,12 @@ export default function withArgs<SWRType>(hook: any) {
     // Merge configurations.
     const config = mergeConfigs(fallbackConfig, _config)
 
-    // Apply middlewares.
+    // Apply middleware
     let next = hook
-    const { middlewares } = config
-    if (middlewares) {
-      for (let i = middlewares.length; i-- > 0; ) {
-        next = middlewares[i](next)
+    const { use } = config
+    if (use) {
+      for (let i = use.length; i-- > 0; ) {
+        next = use[i](next)
       }
     }
 

--- a/src/utils/with-middleware.ts
+++ b/src/utils/with-middleware.ts
@@ -15,7 +15,7 @@ export function withMiddleware(
       | readonly [Key, Fetcher<Data> | null, SWRConfiguration | undefined]
   ) => {
     const [key, fn, config] = normalize(args)
-    config.middlewares = (config.middlewares || []).concat(middleware)
+    config.use = (config.use || []).concat(middleware)
     return useSWR<Data, Error>(key, fn, config)
   }
 }

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -124,14 +124,14 @@ describe('useSWR - configs', () => {
           dedupingInterval: 1,
           refreshInterval: 1,
           fallbackValues: { a: 1, b: 1 },
-          middlewares: [middleware1]
+          use: [middleware1]
         }}
       >
         <SWRConfig
           value={{
             dedupingInterval: 2,
             fallbackValues: { a: 2, c: 2 },
-            middlewares: [middleware2]
+            use: [middleware2]
           }}
         >
           <Page />
@@ -142,6 +142,6 @@ describe('useSWR - configs', () => {
     expect(config.dedupingInterval).toEqual(2)
     expect(config.refreshInterval).toEqual(1)
     expect(config.fallbackValues).toEqual({ a: 2, b: 1, c: 2 })
-    expect(config.middlewares).toEqual([middleware1, middleware2])
+    expect(config.use).toEqual([middleware1, middleware2])
   })
 })

--- a/test/use-swr-middlewares.test.tsx
+++ b/test/use-swr-middlewares.test.tsx
@@ -5,8 +5,8 @@ import { withMiddleware } from '../src/utils/with-middleware'
 
 import { createResponse, sleep, createKey } from './utils'
 
-describe('useSWR - middlewares', () => {
-  it('should use middlewares', async () => {
+describe('useSWR - middleware', () => {
+  it('should use middleware', async () => {
     const key = createKey()
     const mockConsoleLog = jest.fn(s => s)
     const loggerMiddleware: Middleware = useSWRNext => (k, fn, config) => {
@@ -15,7 +15,7 @@ describe('useSWR - middlewares', () => {
     }
     function Page() {
       const { data } = useSWR(key, () => createResponse('data'), {
-        middlewares: [loggerMiddleware]
+        use: [loggerMiddleware]
       })
       return <div>hello, {data}</div>
     }
@@ -28,7 +28,7 @@ describe('useSWR - middlewares', () => {
     expect(mockConsoleLog.mock.calls.length).toBe(2)
   })
 
-  it('should pass original keys to middlewares', async () => {
+  it('should pass original keys to middleware', async () => {
     const key = createKey()
     const mockConsoleLog = jest.fn(s => s)
     const loggerMiddleware: Middleware = useSWRNext => (k, fn, config) => {
@@ -37,7 +37,7 @@ describe('useSWR - middlewares', () => {
     }
     function Page() {
       const { data } = useSWR([key, 1, 2, 3], () => createResponse('data'), {
-        middlewares: [loggerMiddleware]
+        use: [loggerMiddleware]
       })
       return <div>hello, {data}</div>
     }
@@ -50,7 +50,7 @@ describe('useSWR - middlewares', () => {
     expect(mockConsoleLog.mock.calls.length).toBe(2)
   })
 
-  it('should support middlewares in context', async () => {
+  it('should support `use` option in context', async () => {
     const key = createKey()
     const mockConsoleLog = jest.fn(s => s)
     const loggerMiddleware: Middleware = useSWRNext => (k, fn, config) => {
@@ -63,7 +63,7 @@ describe('useSWR - middlewares', () => {
     }
 
     render(
-      <SWRConfig value={{ middlewares: [loggerMiddleware] }}>
+      <SWRConfig value={{ use: [loggerMiddleware] }}>
         <Page />
       </SWRConfig>
     )
@@ -73,7 +73,7 @@ describe('useSWR - middlewares', () => {
     expect(mockConsoleLog.mock.calls.length).toBe(2)
   })
 
-  it('should support extending middlewares via context and per-hook config', async () => {
+  it('should support extending middleware via context and per-hook config', async () => {
     const key = createKey()
     const mockConsoleLog = jest.fn((_, s) => s)
     const createLoggerMiddleware = (id: number): Middleware => useSWRNext => (
@@ -86,14 +86,14 @@ describe('useSWR - middlewares', () => {
     }
     function Page() {
       const { data } = useSWR(key, () => createResponse('data'), {
-        middlewares: [createLoggerMiddleware(0)]
+        use: [createLoggerMiddleware(0)]
       })
       return <div>hello, {data}</div>
     }
 
     render(
-      <SWRConfig value={{ middlewares: [createLoggerMiddleware(2)] }}>
-        <SWRConfig value={{ middlewares: [createLoggerMiddleware(1)] }}>
+      <SWRConfig value={{ use: [createLoggerMiddleware(2)] }}>
+        <SWRConfig value={{ use: [createLoggerMiddleware(1)] }}>
           <Page />
         </SWRConfig>
       </SWRConfig>
@@ -133,13 +133,13 @@ describe('useSWR - middlewares', () => {
 
     function Page() {
       const { data } = customSWRHook(key, () => createResponse('data'), {
-        middlewares: [createLoggerMiddleware(1)]
+        use: [createLoggerMiddleware(1)]
       })
       return <div>hello, {data}</div>
     }
 
     render(
-      <SWRConfig value={{ middlewares: [createLoggerMiddleware(2)] }}>
+      <SWRConfig value={{ use: [createLoggerMiddleware(2)] }}>
         <Page />
       </SWRConfig>
     )
@@ -161,7 +161,7 @@ describe('useSWR - middlewares', () => {
     ])
   })
 
-  it('should support react hooks inside middlewares', async () => {
+  it('should support react hooks inside middleware', async () => {
     const key = createKey()
     const lazyMiddleware: Middleware = useSWRNext => (k, fn, config) => {
       const dataRef = useRef(undefined)
@@ -185,7 +185,7 @@ describe('useSWR - middlewares', () => {
     }
 
     render(
-      <SWRConfig value={{ middlewares: [lazyMiddleware] }}>
+      <SWRConfig value={{ use: [lazyMiddleware] }}>
         <Page />
       </SWRConfig>
     )
@@ -199,7 +199,7 @@ describe('useSWR - middlewares', () => {
     screen.getByText(`data:${key}-1`) // 1, time=350
   })
 
-  it('should pass modified keys to the next middlewares and useSWR', async () => {
+  it('should pass modified keys to the next middleware and useSWR', async () => {
     const key = createKey()
     const createDecoratingKeyMiddleware = (
       c: string
@@ -209,7 +209,7 @@ describe('useSWR - middlewares', () => {
 
     function Page() {
       const { data } = useSWR(key, k => createResponse(k), {
-        middlewares: [
+        use: [
           createDecoratingKeyMiddleware('!'),
           createDecoratingKeyMiddleware('#')
         ]


### PR DESCRIPTION
middleware can be singular or plural. rename it to `use` as short and clear. (Aother popular library like expressjs choosed `router.use()` api)