### PR TITLE
Replace Object.defineProperties with getter 

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -231,23 +231,20 @@ export const infinite = ((<Data, Error>(useSWRNext: SWRHook) => (
 
   // Use getter functions to avoid unnecessary re-renders caused by triggering
   // all the getters of the returned swr object.
-  return Object.defineProperties(
-    { size: resolvePageSize(), setSize, mutate },
-    {
-      error: {
-        get: () => swr.error,
-        enumerable: true
-      },
-      data: {
-        get: () => swr.data,
-        enumerable: true
-      },
-      isValidating: {
-        get: () => swr.isValidating,
-        enumerable: true
-      }
+  return {
+    size: resolvePageSize(),
+    setSize,
+    mutate,
+    get error() {
+      return swr.error
+    },
+    get data() {
+      return swr.data
+    },
+    get isValidating() {
+      return swr.isValidating
     }
-  ) as SWRInfiniteResponse<Data, Error>
+  } as SWRInfiniteResponse<Data, Error>
 }) as unknown) as Middleware
 
 type SWRInfiniteHook = <Data = any, Error = any>(

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -12,12 +12,11 @@ let online = true
 const isOnline = () => online
 const hasWindow = typeof window !== 'undefined'
 const hasDocument = typeof document !== 'undefined'
-const ADD_EVENT_LISTENER = 'addEventListener'
 
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
 const onWindowEvent =
-  hasWindow && window[ADD_EVENT_LISTENER] ? window[ADD_EVENT_LISTENER] : noop
-const onDocumentEvent = hasDocument ? document[ADD_EVENT_LISTENER] : noop
+  hasWindow && window.addEventListener ? window.addEventListener : noop
+const onDocumentEvent = hasDocument ? document.addEventListener : noop
 
 const isVisible = () => {
   const visibilityState = hasDocument && document.visibilityState

--- a/test/use-swr-loading.test.tsx
+++ b/test/use-swr-loading.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from '@testing-library/react'
 import React from 'react'
 import useSWR from 'swr'
-import { createResponse, sleep } from './utils'
+import { createResponse, createKey, sleep } from './utils'
 
 describe('useSWR - loading', () => {
   it('should return loading state', async () => {
@@ -68,5 +68,24 @@ describe('useSWR - loading', () => {
     // it doesn't re-render, but fetch was triggered
     expect(renderCount).toEqual(1)
     expect(dataLoaded).toEqual(true)
+  })
+
+  it('should return enumberable object', async () => {
+    // If the returned object is enumberable, we can use the spread operator
+    // to deconstruct all the keys.
+
+    function Page() {
+      const swr = useSWR(createKey())
+      return (
+        <div>
+          {Object.keys({ ...swr })
+            .sort()
+            .join(',')}
+        </div>
+      )
+    }
+
+    render(<Page />)
+    screen.getByText('data,error,isValidating,mutate')
   })
 })


### PR DESCRIPTION
Change `Object.defineProperties` to object getter. Also added a test to ensure object properties are enumerable.