### PR TITLE
use void 0 for undefined

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,6 +1,5 @@
 // `undefined` can possibly be replaced by something else.
-export const UNDEFINED: undefined = ({} as any)[0]
-export const isUndefined = (v: any): v is undefined => v === UNDEFINED
+export const isUndefined = (v: any): v is undefined => v === void 0
 export const isFunction = (v: any): v is Function => typeof v === 'function'
 export const noop = () => {}
 export const mergeObjects = (a: any, b: any) => Object.assign({}, a, b)


### PR DESCRIPTION
related: https://github.com/vercel/swr/pull/1150/files#diff-a9f5a8b144cf49d7b58fc30f932087e24c4c11d1e741d7d1c8be1a2f6d81fe71R2

`src/utils/helper.ts` claims that `undefined` could be replaced by something else so it has to be avoided.
It's correct if it runs in sloppy mode, but the current implementation `({})[0]` can still be replaced to something else.

```js
({})[0] // undefined

Object.prototype[0] = 'something else'

({})[0] // "something else"
```

It seems `({})[0]` is not the best approach to avoid it, this PR uses `void 0` instead