### PR TITLE
Rename revalidateWhenStale to revalidateIfStale

### DIFF
--- a/immutable/index.ts
+++ b/immutable/index.ts
@@ -4,7 +4,7 @@ import { withMiddleware } from '../src/utils/with-middleware'
 export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
   // Always override all revalidate options.
   config.revalidateOnFocus = false
-  config.revalidateWhenStale = false
+  config.revalidateIfStale = false
   config.revalidateOnReconnect = false
   return useSWRNext(key, fetcher, config)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export interface PublicConfiguration<
   revalidateOnFocus: boolean
   revalidateOnReconnect: boolean
   revalidateOnMount?: boolean
-  revalidateWhenStale: boolean
+  revalidateIfStale: boolean
   shouldRetryOnError: boolean
   suspense?: boolean
   fallbackData?: Data

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -81,14 +81,14 @@ export const useSWRHandler = <Data = any, Error = any>(
   // A revalidation must be triggered when mounted if:
   // - `revalidateOnMount` is explicitly set to `true`.
   // - Suspense mode and there's stale data for the initial render.
-  // - Not suspense mode and there is no fallback data and `revalidateWhenStale` is enabled.
-  // - `revalidateWhenStale` is enabled but `data` is not defined.
+  // - Not suspense mode and there is no fallback data and `revalidateIfStale` is enabled.
+  // - `revalidateIfStale` is enabled but `data` is not defined.
   const shouldRevalidateOnMount = () => {
     if (!isUndefined(revalidateOnMount)) return revalidateOnMount
 
     return suspense
       ? !initialMountedRef.current && !isUndefined(data)
-      : isUndefined(data) || config.revalidateWhenStale
+      : isUndefined(data) || config.revalidateIfStale
   }
 
   // Resolve the current validating state.

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -59,7 +59,7 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     // switches
     revalidateOnFocus: true,
     revalidateOnReconnect: true,
-    revalidateWhenStale: true,
+    revalidateIfStale: true,
     shouldRetryOnError: true,
 
     // timeouts

--- a/test/use-swr-immutable.test.tsx
+++ b/test/use-swr-immutable.test.tsx
@@ -50,13 +50,13 @@ describe('useSWR - immutable', () => {
     await screen.findByText('data: 1')
   })
 
-  it('should not revalidate on mount when `revalidateWhenStale` is enabled', async () => {
+  it('should not revalidate on mount when `revalidateIfStale` is enabled', async () => {
     let value = 0
     const key = createKey()
     const useData = () =>
       useSWR(key, () => value++, {
         dedupingInterval: 0,
-        revalidateWhenStale: false
+        revalidateIfStale: false
       })
 
     function Component() {


### PR DESCRIPTION
Both have the same meaning, but "if" is close to the HTTP cache control naming conventions ("only-if-cached", "stale-if-error").