### PR TITLE
enhance: safe undefined variable generation

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,5 +1,5 @@
 // `undefined` can possibly be replaced by something else.
-export const UNDEFINED: undefined = ({} as any)[0]
+export const UNDEFINED: undefined = (NaN as any)[0]
 export const isUndefined = (v: any): v is undefined => v === UNDEFINED
 export const isFunction = (v: any): v is Function => typeof v === 'function'
 export const noop = () => {}


### PR DESCRIPTION
Problem raised by #1372 that `{}[0]` might generate incorrect undefined value when object is overridden globally somewhere.

Change to special variable `NaN` to replace `{}` since `NaN` is not equal to each other. Properties are not assignable to it.

```
> NaN[0]
undefined
> NaN[0] = 1
1
> NaN[0]
undefined
```

Only 1 byte increase