### PR TITLE
[Beta] Fix bound mutate not using latest key

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -307,9 +307,10 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   // Similar to the global mutate, but bound to the current cache and key.
   // `cache` isn't allowed to change during the lifecycle.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   const boundMutate: SWRResponse<Data, Error>['mutate'] = useCallback(
-    internalMutate.bind(UNDEFINED, cache, keyRef.current),
+    (newData, shouldRevalidate) =>
+      internalMutate(cache, keyRef.current, newData, shouldRevalidate),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -723,4 +723,33 @@ describe('useSWR - local mutation', () => {
     render(<Page />)
     screen.getByText('false')
   })
+
+  it('bound mutate should always use the latest key', async () => {
+    const key = createKey()
+    const fetcher = jest.fn(() => 'data')
+    function Page() {
+      const [ready, setReady] = useState(false)
+      const { mutate: boundMutate } = useSWR(ready ? key : null, fetcher)
+      return (
+        <div>
+          <button onClick={() => setReady(true)}>set ready</button>
+          <button onClick={() => boundMutate()}>mutate</button>
+        </div>
+      )
+    }
+    render(<Page />)
+    screen.getByText('set ready')
+
+    expect(fetcher).toBeCalledTimes(0)
+
+    // it should trigger the fetch
+    fireEvent.click(screen.getByText('set ready'))
+    await act(() => sleep(10))
+    expect(fetcher).toBeCalledTimes(1)
+
+    // it should trigger the fetch again
+    fireEvent.click(screen.getByText('mutate'))
+    await act(() => sleep(10))
+    expect(fetcher).toBeCalledTimes(2)
+  })
 })


### PR DESCRIPTION
This was my mistake (wanted to optimize the code), obviously the inlined `useCallback` will not create a closure to reference to the latest key ref. This PR reverts it back to the current (0.x) implementation and adds a test for it.