### PR TITLE
chore: remove isomorphic-unfetch from examples

### DIFF
--- a/examples/api-hooks/libs/fetch.js
+++ b/examples/api-hooks/libs/fetch.js
@@ -1,6 +1,4 @@
-import fetch from 'isomorphic-unfetch'
-
-export default async function (...args) {
+export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()
 }

--- a/examples/api-hooks/package.json
+++ b/examples/api-hooks/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/api-hooks/pages/api/data.js
+++ b/examples/api-hooks/pages/api/data.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const projects = [
   'facebook/flipper', 'vuejs/vuepress', 'rust-lang/rust', 'zeit/next.js'
 ]
@@ -14,7 +12,7 @@ export default (req, res) => {
           res.json(data)
         }, 2000)
       })
-    
+
     return
   }
   setTimeout(() => {

--- a/examples/autocomplete-suggestions/libs/fetcher.js
+++ b/examples/autocomplete-suggestions/libs/fetcher.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/autocomplete-suggestions/package.json
+++ b/examples/autocomplete-suggestions/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "dependencies": {
     "@reach/combobox": "0.16.1",
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/basic-typescript/libs/fetch.ts
+++ b/examples/basic-typescript/libs/fetch.ts
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher<JSON = any>(
   input: RequestInfo,
   init?: RequestInit

--- a/examples/basic-typescript/package.json
+++ b/examples/basic-typescript/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/basic-typescript/pages/api/data.js
+++ b/examples/basic-typescript/pages/api/data.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const projects = [
   'facebook/flipper',
   'vuejs/vuepress',

--- a/examples/basic/libs/fetch.js
+++ b/examples/basic/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/basic/pages/api/data.js
+++ b/examples/basic/pages/api/data.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const projects = [
   'facebook/flipper', 'vuejs/vuepress', 'rust-lang/rust', 'zeit/next.js'
 ]

--- a/examples/focus-revalidate/libs/fetch.js
+++ b/examples/focus-revalidate/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/focus-revalidate/package.json
+++ b/examples/focus-revalidate/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/global-fetcher/libs/fetch.js
+++ b/examples/global-fetcher/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/global-fetcher/package.json
+++ b/examples/global-fetcher/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/global-fetcher/pages/api/data.js
+++ b/examples/global-fetcher/pages/api/data.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const projects = [
   'facebook/flipper', 'vuejs/vuepress', 'rust-lang/rust', 'zeit/next.js'
 ]

--- a/examples/infinite-scroll/libs/fetch.js
+++ b/examples/infinite-scroll/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/infinite-scroll/package.json
+++ b/examples/infinite-scroll/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/infinite/libs/fetch.js
+++ b/examples/infinite/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/infinite/package.json
+++ b/examples/infinite/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/optimistic-ui-immer/libs/fetch.js
+++ b/examples/optimistic-ui-immer/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/optimistic-ui-immer/package.json
+++ b/examples/optimistic-ui-immer/package.json
@@ -5,7 +5,6 @@
   "license": "MIT",
   "dependencies": {
     "immer": "9.0.5",
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/optimistic-ui/libs/fetch.js
+++ b/examples/optimistic-ui/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/optimistic-ui/package.json
+++ b/examples/optimistic-ui/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/prefetch-preload/libs/fetch.js
+++ b/examples/prefetch-preload/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/prefetch-preload/package.json
+++ b/examples/prefetch-preload/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/prefetch-preload/pages/api/data.js
+++ b/examples/prefetch-preload/pages/api/data.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const projects = [
   'facebook/flipper', 'vuejs/vuepress', 'rust-lang/rust', 'zeit/next.js'
 ]

--- a/examples/refetch-interval/libs/fetch.js
+++ b/examples/refetch-interval/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/refetch-interval/package.json
+++ b/examples/refetch-interval/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/server-render/libs/fetcher.js
+++ b/examples/server-render/libs/fetcher.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/server-render/package.json
+++ b/examples/server-render/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/suspense/libs/fetch.js
+++ b/examples/suspense/libs/fetch.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 export default async function fetcher(...args) {
   const res = await fetch(...args)
   return res.json()

--- a/examples/suspense/package.json
+++ b/examples/suspense/package.json
@@ -4,7 +4,6 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-unfetch": "3.1.0",
     "next": "11.1.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/examples/suspense/pages/api/data.js
+++ b/examples/suspense/pages/api/data.js
@@ -1,5 +1,3 @@
-import fetch from 'isomorphic-unfetch'
-
 const projects = [
   'facebook/flipper',
   'vuejs/vuepress',


### PR DESCRIPTION
I've noticed that Next.js started providing a built-in polyfill of `fetch` since v9.1.7, so `isomorphic-unfetch` is no longer required.
https://nextjs.org/blog/next-9-1-7#new-built-in-polyfills-fetch-url-and-objectassign