### PR TITLE
fix: isValidating when an error occurred

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -254,6 +254,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         }
       } catch (err) {
         cleanupState()
+        cache.set(keyValidating, false)
         if (configRef.current.isPaused()) {
           setState({
             isValidating: false

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -254,4 +254,42 @@ describe('useSWR - error', () => {
     // error won't be cleared during revalidation
     expect(errors).toEqual([null, 'error', 'error'])
   })
+
+  it('should reset isValidating when an error occured synchronously', async () => {
+    function Page() {
+      const { error, isValidating } = useSWR('error-10', () => {
+        throw new Error('error!')
+      })
+      if (error)
+        return (
+          <div>
+            {error.message},{isValidating.toString()}
+          </div>
+        )
+      return <div>hello,{isValidating.toString()}</div>
+    }
+
+    render(<Page />)
+    screen.getByText('error!,false')
+  })
+
+  it('should reset isValidating when an error occured asynchronously', async () => {
+    function Page() {
+      const { error, isValidating } = useSWR('error-11', () =>
+        createResponse(new Error('error!'))
+      )
+      if (error)
+        return (
+          <div>
+            {error.message},{isValidating.toString()}
+          </div>
+        )
+      return <div>hello,{isValidating.toString()}</div>
+    }
+
+    render(<Page />)
+    screen.getByText('hello,true')
+
+    await screen.findByText('error!,false')
+  })
 })


### PR DESCRIPTION
Fixes #1395.
I guess SWR should update the cache value for `isValidating` when an error occurred.
