### PR TITLE
Chore: always use config ref

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -69,6 +69,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   // Refs to keep the key and config.
   const keyRef = useRef(key)
   const configRef = useRef(config)
+  const getConfig = () => configRef.current
 
   // Get the current state that SWR should return.
   const cached = cache.get(key)
@@ -323,8 +324,6 @@ export const useSWRHandler = <Data = any, Error = any>(
   useIsomorphicLayoutEffect(() => {
     configRef.current = config
   })
-
-  const getConfig = () => configRef.current
 
   // After mounted or key changed.
   useIsomorphicLayoutEffect(() => {

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -14,9 +14,8 @@ const hasWindow = typeof window !== 'undefined'
 const hasDocument = typeof document !== 'undefined'
 
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
-const onWindowEvent =
-  hasWindow && window.addEventListener ? window.addEventListener : noop
-const onDocumentEvent = hasDocument ? document.addEventListener : noop
+const onWindowEvent = (hasWindow && window.addEventListener) || noop
+const onDocumentEvent = (hasDocument && document.addEventListener) || noop
 
 const isVisible = () => {
   const visibilityState = hasDocument && document.visibilityState


### PR DESCRIPTION
* use config ref in `execute` function
* shorten generated code (8016 -> 8582)