### PR TITLE
feat: add a warning for invalid arguments with suspense mode

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -78,6 +78,10 @@ export const useSWRHandler = <Data = any, Error = any>(
   const data = isUndefined(cached) ? fallback : cached
   const error = cache.get(keyErr)
 
+  if (suspense && (!key || !fn)) {
+    throw new Error('useSWR requires either key or fetcher with suspense mode')
+  }
+
   // A revalidation must be triggered when mounted if:
   // - `revalidateOnMount` is explicitly set to `true`.
   // - Suspense mode and there's stale data for the initial render.

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -3,16 +3,17 @@ import React, { ReactNode, Suspense, useEffect, useState } from 'react'
 import useSWR, { mutate } from 'swr'
 import { createResponse, sleep } from './utils'
 
-class ErrorBoundary extends React.Component<{ fallback: ReactNode }> {
-  state = { hasError: false }
-  static getDerivedStateFromError() {
+class ErrorBoundary extends React.Component<{ fallback?: ReactNode }> {
+  state = { hasError: false, message: null }
+  static getDerivedStateFromError(error: Error) {
     return {
-      hasError: true
+      hasError: true,
+      message: error.message
     }
   }
   render() {
     if (this.state.hasError) {
-      return this.props.fallback
+      return this.props.fallback || this.state.message
     }
     return this.props.children
   }
@@ -257,5 +258,47 @@ describe('useSWR - suspense', () => {
     await act(() => sleep(50)) // wait a moment to observe unnecessary renders
     expect(startRenderCount).toBe(2) // fallback + data
     expect(renderCount).toBe(1) // data
+  })
+
+  it('should throw an error if key is a falsy value', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    function Page() {
+      const { data } = useSWR(null, () => createResponse('SWR'), {
+        suspense: true
+      })
+      return <div>hello, {data}</div>
+    }
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>fallback</div>}>
+          <Page />
+        </Suspense>
+      </ErrorBoundary>
+    )
+
+    screen.getByText('useSWR requires either key or fetcher with suspense mode')
+  })
+
+  it('should throw an error if fetch is null', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    function Page() {
+      const { data } = useSWR('suspense-11', null, {
+        suspense: true
+      })
+      return <div>hello, {data}</div>
+    }
+    render(
+      <ErrorBoundary>
+        <Suspense fallback={<div>fallback</div>}>
+          <Page />
+        </Suspense>
+      </ErrorBoundary>
+    )
+
+    screen.getByText('useSWR requires either key or fetcher with suspense mode')
   })
 })


### PR DESCRIPTION
Fixes #1359.
I've added a warning for invalid arguments with suspense mode.
The check (`!key || !fn`) is the same validation used in other places.