### PR TITLE
ci: separate size bot job

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,27 @@
+name: Report
+
+on:
+  pull_request:
+
+jobs:
+  pkg-size-report:
+    name: Package Size
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+
+      - name: Package size report
+        uses: pkg-size/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          unchanged-files: hide
+          hide-files: '*.{ts,json,md}'
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js
@@ -19,13 +18,4 @@ jobs:
       - run: yarn install
       - run: yarn types:check
       - run: yarn lint
-      - run: yarn build
       - run: yarn test
-        env:
-          CI: true
-      - name: Package size report
-        uses: pkg-size/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          hide-files: '*.{ts,json,md}'


### PR DESCRIPTION
Previously running report together with test job for speed up, but seems pkg-size action doesn't work on "push to master" phase. So separate it for safety and independence