### PR TITLE
refactor: use TestSWRConfig for error-test

### DIFF
--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,10 +1,12 @@
 import { act, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { SWRConfiguration, SWRConfig } from 'swr'
 
 export function sleep(time: number) {
   return new Promise(resolve => setTimeout(resolve, time))
 }
 
-export const createResponse = <T = any>(
+export const createResponse = <T extends any>(
   response: T,
   { delay } = { delay: 10 }
 ): Promise<T> =>
@@ -26,3 +28,15 @@ export const focusOn = (element: any) =>
   })
 
 export const createKey = () => 'swr-key-' + ~~(Math.random() * 1e7)
+
+export const TestSWRConfig = ({
+  children,
+  value
+}: {
+  children: React.ReactNode
+  value?: SWRConfiguration
+}) => (
+  <SWRConfig value={{ provider: () => new Map(), ...value }}>
+    {children}
+  </SWRConfig>
+)


### PR DESCRIPTION
This is a PR to propose to make unit tests more reliable.
Currently, most of the tests depend on a global cache store, which means that those tests share the same cache. This is fragile because the tests might start failing when we use the same key in between them.

SWR has `createKey` as a utility function for testing to generate a random key, which would solve the problem, but I think running tests on independent environments is important and makes tests more reliable.

To fix this, I've added `<TestSWRConfig />`, which creates its own cache provider, and wrapped target components in it. We don't have to care about duplicating keys while using `<TestSWRConfig />`.
I used the name because I expect to be added more configurations for testing in the component. More explicit names like `<SWRCacheBoundary />` might be better.

What do you think? If this looks good to you, I'll refactor other tests as well.

I've also come up with wrapping the render function that testing-library provides, but I didn't adopt the approach because it's less clear what the function does and introduces additional abstraction. It's also hard to cover tests for concurrent rendering because it doesn't use the `testing-library`'s render function.