### PR TITLE
chore: Export KeyedMutator type from root export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   RevalidatorOptions,
   Key,
   KeyLoader,
+  KeyedMutator,
   SWRResponse,
   Cache,
   SWRHook,


### PR DESCRIPTION
# Why

This is necessary to type the `mutate` method returned by the hook. It is useful when passing it around for example into a custom context.

> NOTE: The deprecated `revalidate` method had a type of `Promise<boolean>`. 

When replacing `mutate` with `revalidate`, we now needed to do this:

```
import type { KeyedMutator } from "swr/dist/types"
...
  revalidateAccount: KeyedMutator<AxiosResponse<User>>
```

With this PR, the above code becomes:

```
import type { KeyedMutator } from "swr"
...
  revalidateAccount: KeyedMutator<AxiosResponse<User>>
```

Which is nicer when working with the other type exported.