### PR TITLE
Fix revalidateIfStale behavior when the key changes

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -400,7 +400,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     }
 
     // Trigger a revalidation.
-    if (keyChanged || shouldRevalidateOnMount()) {
+    if (shouldRevalidateOnMount()) {
       if (isUndefined(data) || IS_SERVER) {
         // Revalidate immediately.
         softRevalidate()


### PR DESCRIPTION
With the added test, currently 4 requests will be made because a SWR hook will always revalidate when the key changes. However the correct behavior should be treating a key change as a "remount", and using the `shouldRevalidateOnMount` condition to decide if a revalidation is necessary.