### PR TITLE
test: add render utilities and remove TestSWRConfig

### DIFF
--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -36,7 +36,7 @@ const _renderWithConfig = (
   const result = render(<SWRConfig value={config}>{element}</SWRConfig>)
   return {
     ...result,
-    // override the rerender method to use the same config
+    // override the rerender method to wrap the element with SWRConfig again
     rerender: (rerenderElement: React.ReactElement) =>
       result.rerender(<SWRConfig value={config}>{rerenderElement}</SWRConfig>)
   }

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -1,6 +1,6 @@
-import { act, fireEvent } from '@testing-library/react'
+import { act, fireEvent, render } from '@testing-library/react'
 import React from 'react'
-import { SWRConfiguration, SWRConfig } from 'swr'
+import { SWRConfig } from 'swr'
 
 export function sleep(time: number) {
   return new Promise(resolve => setTimeout(resolve, time))
@@ -29,14 +29,30 @@ export const focusOn = (element: any) =>
 
 export const createKey = () => 'swr-key-' + ~~(Math.random() * 1e7)
 
-export const TestSWRConfig = ({
-  children,
-  value
-}: {
-  children: React.ReactNode
-  value?: SWRConfiguration
-}) => (
-  <SWRConfig value={{ provider: () => new Map(), ...value }}>
-    {children}
-  </SWRConfig>
-)
+const _renderWithConfig = (
+  element: React.ReactElement,
+  config: Parameters<typeof SWRConfig>[0]['value']
+): ReturnType<typeof render> => {
+  const result = render(<SWRConfig value={config}>{element}</SWRConfig>)
+  return {
+    ...result,
+    // override the rerender method to use the same config
+    rerender: (rerenderElement: React.ReactElement) =>
+      result.rerender(<SWRConfig value={config}>{rerenderElement}</SWRConfig>)
+  }
+}
+
+export const renderWithConfig = (
+  element: React.ReactElement,
+  config?: Parameters<typeof _renderWithConfig>[1]
+): ReturnType<typeof _renderWithConfig> => {
+  const provider = () => new Map()
+  return _renderWithConfig(element, { provider, ...config })
+}
+
+export const renderWithGlobalCache = (
+  element: React.ReactElement,
+  config?: Parameters<typeof _renderWithConfig>[1]
+): ReturnType<typeof _renderWithConfig> => {
+  return _renderWithConfig(element, { ...config })
+}


### PR DESCRIPTION
I've introduced `TestSWRConfig`, which is a wrapper component for unit tests, and applied it to `use-swr-error.test.tsx` to avoid using a global cache shared between each test.

While refactoring other tests using the components, I've realized that this approach has a major flaw.
The downside of the approach is that it's very hard to guarantee all components passed to the `testing-library`'s render function are wrapped by `TestSWRConfig`. I sometimes missed placing the component while refactoring tests.
I might be able to check this mistake statically using ESLint or something, but I think it introduces another complexity.

So I reconsidered the approach and took another approach. The following is what I thought. Feedbacks are welcome!
If it seems to be good, I'll refactor each test as separate PRs to review easily.

You can see all diffs by this refactoring.
https://github.com/vercel/swr/compare/master...koba04:refactor-all-tests?expand=1

## renderWithConfig and renderWIthGlobalCache

I've added `renderWIthConfig` and `renderWithGlobalCache` that render components with `SWRConfig` and replaced the `testing-library`'s render function with it.

```tsx
renderWithConfig(<Page />, { a: "a" })
//  ↓
<SWRConfig value={{ provider: () => new Map(), a: "a" }}>
  <Page />
</SWRConfig>

renderWithGlobalCache(<Page />)
//  ↓
<SWRConfig value={{ a: "a" }}>
  <Page />
</SWRConfig>
```

This allows us to remove importing the `testing-library`'s render function from test files. This leads to finding the usage of the render function easily and can avoid using the render function accidentally.

We can use the `testing-library`'s render function directly when using a global cache. But I think this is better to define `renderWithGlobalCache` because it allows us to find the usage of a global cache easily.

A tricky part is that I've overridden the `rerender` function that `testing-library` returns because I had to render components with `SWRConfig` again.

Actually, we only require `rerender` from the result of the render function, so I think it would be better `renderWithConfig` and `renderWithGlobalCache` only return `rerender`. Actually, there are some tests using `container` from the render function, but I could implement with `screen.getByText`.
What do you think? If that makes sense, I'll change the return value from `renderWIthConfig` and `renderWithGlobalCache`.

## use createKey as much as possible

SWR has `createKey` to generate a random key string as a test utility. In many cases, we don't have to care about the actual key values of `useSWR`, so I think it would be nice to use the function rather than putting string literals like test names.

The purpose of the refactoring is to make tests reliable, simple, and easy to write. I think this refactoring would be the right direction for the purpose.
