### PR TITLE
test: refactor concurrent rendering tests

### DIFF
--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -33,13 +33,10 @@ const _renderWithConfig = (
   element: React.ReactElement,
   config: Parameters<typeof SWRConfig>[0]['value']
 ): ReturnType<typeof render> => {
-  const result = render(<SWRConfig value={config}>{element}</SWRConfig>)
-  return {
-    ...result,
-    // override the rerender method to wrap the element with SWRConfig again
-    rerender: (rerenderElement: React.ReactElement) =>
-      result.rerender(<SWRConfig value={config}>{rerenderElement}</SWRConfig>)
-  }
+  const TestSWRConfig = ({ children }: { children: React.ReactNode }) => (
+    <SWRConfig value={config}>{children}</SWRConfig>
+  )
+  return render(element, { wrapper: TestSWRConfig })
 }
 
 export const renderWithConfig = (


### PR DESCRIPTION
This is a follow-up PR of #1435.
concurrent rendering tests are different from other tests because they render components with `ReactDOM.createRoot`, so I didn't use `renderWithConfig` in `test/utils.tsx`.

I've also noticed that the render function of `testing-library` has the `wrapper` option to wrap a target component. 
https://testing-library.com/docs/react-testing-library/setup#custom-render
With the option, we no longer require to override `rerender` function to wrap a target component with `SWRConfig`. It's less hacky than before, so I've refactored to use it.