### PR TITLE
Revert "feat: add a warning for invalid arguments with suspense mode …

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -79,10 +79,6 @@ export const useSWRHandler = <Data = any, Error = any>(
   const data = isUndefined(cached) ? fallback : cached
   const error = cache.get(keyErr)
 
-  if (suspense && (!key || !fn)) {
-    throw new Error('useSWR requires either key or fetcher with suspense mode')
-  }
-
   // A revalidation must be triggered when mounted if:
   // - `revalidateOnMount` is explicitly set to `true`.
   // - `isPaused()` returns `false`, and:

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -3,17 +3,16 @@ import React, { ReactNode, Suspense, useEffect, useState } from 'react'
 import useSWR, { mutate } from 'swr'
 import { createResponse, sleep } from './utils'
 
-class ErrorBoundary extends React.Component<{ fallback?: ReactNode }> {
-  state = { hasError: false, message: null }
-  static getDerivedStateFromError(error: Error) {
+class ErrorBoundary extends React.Component<{ fallback: ReactNode }> {
+  state = { hasError: false }
+  static getDerivedStateFromError() {
     return {
-      hasError: true,
-      message: error.message
+      hasError: true
     }
   }
   render() {
     if (this.state.hasError) {
-      return this.props.fallback || this.state.message
+      return this.props.fallback
     }
     return this.props.children
   }
@@ -258,47 +257,5 @@ describe('useSWR - suspense', () => {
     await act(() => sleep(50)) // wait a moment to observe unnecessary renders
     expect(startRenderCount).toBe(2) // fallback + data
     expect(renderCount).toBe(1) // data
-  })
-
-  it('should throw an error if key is a falsy value', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    jest.spyOn(console, 'error').mockImplementation(() => {})
-
-    function Page() {
-      const { data } = useSWR(null, () => createResponse('SWR'), {
-        suspense: true
-      })
-      return <div>hello, {data}</div>
-    }
-    render(
-      <ErrorBoundary>
-        <Suspense fallback={<div>fallback</div>}>
-          <Page />
-        </Suspense>
-      </ErrorBoundary>
-    )
-
-    screen.getByText('useSWR requires either key or fetcher with suspense mode')
-  })
-
-  it('should throw an error if fetch is null', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    jest.spyOn(console, 'error').mockImplementation(() => {})
-
-    function Page() {
-      const { data } = useSWR('suspense-11', null, {
-        suspense: true
-      })
-      return <div>hello, {data}</div>
-    }
-    render(
-      <ErrorBoundary>
-        <Suspense fallback={<div>fallback</div>}>
-          <Page />
-        </Suspense>
-      </ErrorBoundary>
-    )
-
-    screen.getByText('useSWR requires either key or fetcher with suspense mode')
   })
 })


### PR DESCRIPTION
Feedback from https://github.com/vercel/swr/pull/1402#issuecomment-918375939.

The PR breaks the behavior with https://swr.vercel.app/docs/suspense#note-with-conditional-fetching.

I've noticed that the comment `useSWR requires either key or fetcher with suspense mode` was wrong 🙏
This should be `useSWR requires the both key and fetcher with suspense mode`.

How does the suspense mode work with a nullish value for key and fetcher? Does SWR allow to return `undefined` as `data`?
ref. #1412, https://github.com/vercel/swr/pull/357#issuecomment-627089889.

I'll add some tests for the behavior as another PR.
