### PR TITLE
fix: Support IE11

### DIFF
--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -12,7 +12,10 @@ let online = true
 const isOnline = () => online
 
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
-const onWindowEvent = (hasWindow && addEventListener) || noop
+const onWindowEvent = hasWindow
+  ? (...args: Parameters<typeof window.addEventListener>) =>
+      window.addEventListener(...args)
+  : noop
 const onDocumentEvent = hasDocument
   ? (...args: Parameters<typeof document.addEventListener>) =>
       document.addEventListener(...args)

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -19,7 +19,7 @@ const onDocumentEvent = hasDocument
   : noop
 const offWindowEvent = (hasWindow && removeEventListener) || noop
 const offDocumentEvent = hasDocument
-  ? (...args: Parameters<typeof document.addEventListener>) =>
+  ? (...args: Parameters<typeof document.removeEventListener>) =>
       document.removeEventListener(...args)
   : noop
 

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -13,9 +13,15 @@ const isOnline = () => online
 
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
 const onWindowEvent = (hasWindow && addEventListener) || noop
-const onDocumentEvent = (hasDocument && document.addEventListener) || noop
+const onDocumentEvent = hasDocument
+  ? (...args: Parameters<typeof document.addEventListener>) =>
+      document.addEventListener(...args)
+  : noop
 const offWindowEvent = (hasWindow && removeEventListener) || noop
-const offDocumentEvent = (hasDocument && document.removeEventListener) || noop
+const offDocumentEvent = hasDocument
+  ? (...args: Parameters<typeof document.addEventListener>) =>
+      document.removeEventListener(...args)
+  : noop
 
 const isVisible = () => {
   const visibilityState = hasDocument && document.visibilityState


### PR DESCRIPTION
Closes #1453

`addEventListener` needs to be called from `document` in IE11. Otherwise you'll run into a `Invalid calling object` error.

I've tested the proposed changes in IE11 and couldn't find any other errors.