### PR TITLE
fix: Add clear method to Cache interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -190,4 +190,5 @@ export interface Cache<Data = any> {
   get(key: Key): Data | null | undefined
   set(key: Key, value: Data): void
   delete(key: Key): void
+  clear(): void
 }


### PR DESCRIPTION
https://swr.vercel.app/docs/advanced/cache#access-to-the-cache