### PR TITLE
ci: multiple dir type checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules
 dist
-esm
 *.log
 *.tgz
 .env
@@ -10,3 +9,4 @@ esm
 .vscode
 examples/**/yarn.lock
 package-lock.json
+tsconfig.tsbuildinfo

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noUnusedParameters": true,
     "strictBindCallApply": true,
     "outDir": "./dist",
-    "rootDir": "src",
+    "rootDir": ".",
     "strict": true,
     "target": "es5",
     "baseUrl": ".",
@@ -24,8 +24,15 @@
     },
     "typeRoots": ["./src/types", "./node_modules/@types"]
   },
-  "include": ["src"],
-  "exclude": ["dist", "node_modules"],
+  "include": [
+    "src", 
+    "immutable", 
+    "infinite"
+  ],
+  "exclude": [
+    "./**/dist",
+    "node_modules"
+  ],
   "watchOptions": {
     "watchFile": "useFsEvents",
     "watchDirectory": "useFsEvents",


### PR DESCRIPTION
Current `types:check` script will skip sub folders like `inifinite` etc. tweaks some ts configuration include sub folders