### PR TITLE
chore: Refine type interfaces

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -18,7 +18,8 @@ import {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   SWRInfiniteHook,
-  InfiniteKeyLoader
+  InfiniteKeyLoader,
+  InfiniteFetcher
 } from './types'
 
 const INFINITE_PREFIX = '$inf$'
@@ -254,4 +255,4 @@ export const infinite = ((<Data, Error, Args extends Arguments>(
 }) as unknown) as Middleware
 
 export default withMiddleware(useSWR, infinite) as SWRInfiniteHook
-export { SWRInfiniteConfiguration, SWRInfiniteResponse }
+export { SWRInfiniteConfiguration, SWRInfiniteResponse, InfiniteFetcher }

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -4,34 +4,37 @@
 import { useRef, useState, useCallback } from 'react'
 import useSWR, {
   SWRConfig,
-  KeyLoader,
   Fetcher,
   SWRHook,
   MutatorCallback,
   Middleware,
-  ValueKey,
-  Result
+  Arguments
 } from 'swr'
 import { useIsomorphicLayoutEffect } from '../src/utils/env'
 import { serialize } from '../src/utils/serialize'
 import { isUndefined, isFunction, UNDEFINED } from '../src/utils/helper'
 import { withMiddleware } from '../src/utils/with-middleware'
-import { SWRInfiniteConfiguration, SWRInfiniteResponse } from './types'
+import {
+  SWRInfiniteConfiguration,
+  SWRInfiniteResponse,
+  SWRInfiniteHook,
+  InfiniteKeyLoader
+} from './types'
 
 const INFINITE_PREFIX = '$inf$'
 
-const getFirstPageKey = (getKey: KeyLoader) => {
+const getFirstPageKey = (getKey: InfiniteKeyLoader) => {
   return serialize(getKey ? getKey(0, null) : null)[0]
 }
 
-export const unstable_serialize = (getKey: KeyLoader) => {
+export const unstable_serialize = (getKey: InfiniteKeyLoader) => {
   return INFINITE_PREFIX + getFirstPageKey(getKey)
 }
 
-export const infinite = ((<Data, Error, Args extends ValueKey>(
+export const infinite = ((<Data, Error, Args extends Arguments>(
   useSWRNext: SWRHook
 ) => (
-  getKey: KeyLoader<Args>,
+  getKey: InfiniteKeyLoader<Args>,
   fn: Fetcher<Data> | null,
   config: typeof SWRConfig.default & SWRInfiniteConfiguration<Data, Error, Args>
 ): SWRInfiniteResponse<Data, Error> => {
@@ -249,38 +252,6 @@ export const infinite = ((<Data, Error, Args extends ValueKey>(
     }
   } as SWRInfiniteResponse<Data, Error>
 }) as unknown) as Middleware
-
-export type InfiniteFetcher<
-  Args extends ValueKey = ValueKey,
-  Data = any
-> = Args extends (readonly [...infer K])
-  ? ((...args: [...K]) => Result<Data>)
-  : Args extends null
-  ? never
-  : Args extends (infer T)
-  ? (...args: [T]) => Result<Data>
-  : never
-
-interface SWRInfiniteHook {
-  <Data = any, Error = any, Args extends ValueKey = ValueKey>(
-    getKey: KeyLoader<Args>
-  ): SWRInfiniteResponse<Data, Error>
-  <Data = any, Error = any, Args extends ValueKey = ValueKey>(
-    getKey: KeyLoader<Args>,
-    fn: InfiniteFetcher<Args, Data> | null
-  ): SWRInfiniteResponse<Data, Error>
-  <Data = any, Error = any, Args extends ValueKey = ValueKey>(
-    getKey: KeyLoader<Args>,
-    config: SWRInfiniteConfiguration<Data, Error, Args> | undefined
-  ): SWRInfiniteResponse<Data, Error>
-  <Data = any, Error = any, Args extends ValueKey = ValueKey>(
-    ...args: [
-      KeyLoader<Args>,
-      InfiniteFetcher<Args, Data> | null,
-      SWRInfiniteConfiguration<Data, Error, Args> | undefined
-    ]
-  ): SWRInfiniteResponse<Data, Error>
-}
 
 export default withMiddleware(useSWR, infinite) as SWRInfiniteHook
 export { SWRInfiniteConfiguration, SWRInfiniteResponse }

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,16 +1,16 @@
 import { SWRConfiguration, SWRResponse, Arguments } from 'swr'
 
-type FetcherReturnValue<Data = unknown> = Data | Promise<Data>
+type FetcherResponse<Data = unknown> = Data | Promise<Data>
 
 export type InfiniteFetcher<
   Args extends Arguments = Arguments,
   Data = any
 > = Args extends (readonly [...infer K])
-  ? ((...args: [...K]) => FetcherReturnValue<Data>)
+  ? ((...args: [...K]) => FetcherResponse<Data>)
   : Args extends null
   ? never
   : Args extends (infer T)
-  ? (...args: [T]) => FetcherReturnValue<Data>
+  ? (...args: [T]) => FetcherResponse<Data>
   : never
 
 export type InfiniteKeyLoader<Args extends Arguments = Arguments> =

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,4 +1,4 @@
-import { SWRConfiguration, Fetcher, SWRResponse, Arguments } from 'swr'
+import { SWRConfiguration, SWRResponse, Arguments } from 'swr'
 
 type FetcherReturnValue<Data = unknown> = Data | Promise<Data>
 
@@ -21,7 +21,7 @@ export type SWRInfiniteConfiguration<
   Data = any,
   Error = any,
   Args extends Arguments = Arguments
-> = SWRConfiguration<Data[], Error, Args, Fetcher<Data[], Args>> & {
+> = SWRConfiguration<Data[], Error, Args> & {
   initialSize?: number
   revalidateAll?: boolean
   persistSize?: boolean

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,9 +1,26 @@
-import { SWRConfiguration, Fetcher, SWRResponse, ValueKey } from 'swr'
+import { SWRConfiguration, Fetcher, SWRResponse, Arguments } from 'swr'
+
+type FetcherReturnValue<Data = unknown> = Data | Promise<Data>
+
+export type InfiniteFetcher<
+  Args extends Arguments = Arguments,
+  Data = any
+> = Args extends (readonly [...infer K])
+  ? ((...args: [...K]) => FetcherReturnValue<Data>)
+  : Args extends null
+  ? never
+  : Args extends (infer T)
+  ? (...args: [T]) => FetcherReturnValue<Data>
+  : never
+
+export type InfiniteKeyLoader<Args extends Arguments = Arguments> =
+  | ((index: number, previousPageData: any | null) => Args)
+  | null
 
 export type SWRInfiniteConfiguration<
   Data = any,
   Error = any,
-  Args extends ValueKey = ValueKey
+  Args extends Arguments = Arguments
 > = SWRConfiguration<Data[], Error, Args, Fetcher<Data[], Args>> & {
   initialSize?: number
   revalidateAll?: boolean
@@ -16,4 +33,27 @@ export interface SWRInfiniteResponse<Data = any, Error = any>
   setSize: (
     size: number | ((_size: number) => number)
   ) => Promise<Data[] | undefined>
+}
+
+export interface SWRInfiniteHook {
+  <Data = any, Error = any, SWRInfiniteArguments extends Arguments = Arguments>(
+    getKey: InfiniteKeyLoader<SWRInfiniteArguments>
+  ): SWRInfiniteResponse<Data, Error>
+  <Data = any, Error = any, SWRInfiniteArguments extends Arguments = Arguments>(
+    getKey: InfiniteKeyLoader<SWRInfiniteArguments>,
+    fetcher: InfiniteFetcher<SWRInfiniteArguments, Data> | null
+  ): SWRInfiniteResponse<Data, Error>
+  <Data = any, Error = any, SWRInfiniteArguments extends Arguments = Arguments>(
+    getKey: InfiniteKeyLoader<SWRInfiniteArguments>,
+    config:
+      | SWRInfiniteConfiguration<Data, Error, SWRInfiniteArguments>
+      | undefined
+  ): SWRInfiniteResponse<Data, Error>
+  <Data = any, Error = any, SWRInfiniteArguments extends Arguments = Arguments>(
+    getKey: InfiniteKeyLoader<SWRInfiniteArguments>,
+    fetcher: InfiniteFetcher<SWRInfiniteArguments, Data> | null,
+    config:
+      | SWRInfiniteConfiguration<Data, Error, SWRInfiniteArguments>
+      | undefined
+  ): SWRInfiniteResponse<Data, Error>
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,6 @@ export {
   Fetcher,
   MutatorCallback,
   Middleware,
-  ValueKey,
-  Result
+  //
+  Arguments
 } from './types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,5 @@ export {
   Fetcher,
   MutatorCallback,
   Middleware,
-  //
   Arguments
 } from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import * as revalidateEvents from './constants/revalidate-events'
 
-export type FetcherReturnValue<Data = unknown> = Data | Promise<Data>
+export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 
 export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
   /**
@@ -8,26 +8,26 @@ export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
    * () => ( [{ foo: string }, { bar: number } ] as const | null )
    */
   SWRKey extends (() => readonly [...infer Args] | null)
-    ? ((...args: [...Args]) => FetcherReturnValue<Data>)
-      /**
-       * [{ foo: string }, { bar: number } ] | null
-       * [{ foo: string }, { bar: number } ] as const | null
-       */
-    : SWRKey extends (readonly [...infer Args])
-    ? ((...args: [...Args]) => FetcherReturnValue<Data>)
-      /**
-       * () => string | null
-       * () => Record<any, any> | null
-       */
-    : SWRKey extends (() => infer Arg | null)
-    ? (...args: [Arg]) => FetcherReturnValue<Data>
-      /**
-       *  string | null | Record<any,any>
-       */
-    : SWRKey extends null
+    ? ((...args: [...Args]) => FetcherResponse<Data>)
+    : /**
+     * [{ foo: string }, { bar: number } ] | null
+     * [{ foo: string }, { bar: number } ] as const | null
+     */
+    SWRKey extends (readonly [...infer Args])
+    ? ((...args: [...Args]) => FetcherResponse<Data>)
+    : /**
+     * () => string | null
+     * () => Record<any, any> | null
+     */
+    SWRKey extends (() => infer Arg | null)
+    ? (...args: [Arg]) => FetcherResponse<Data>
+    : /**
+     *  string | null | Record<any,any>
+     */
+    SWRKey extends null
     ? never
     : SWRKey extends (infer Arg)
-    ? (...args: [Arg]) => FetcherReturnValue<Data>
+    ? (...args: [Arg]) => FetcherResponse<Data>
     : never
 
 // Configuration types that are only used internally, not exposed to the user.
@@ -112,7 +112,7 @@ export interface SWRHook {
   <Data = any, Error = any, SWRKey extends Key = Key>(
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey>,
-    config: SWRConfiguration<Data, Error, SWRKey>
+    config: SWRConfiguration<Data, Error, SWRKey> | undefined
   ): SWRResponse<Data, Error>
   <Data = any, Error = any, SWRKey extends Key = Key>(
     ...args:
@@ -122,7 +122,7 @@ export interface SWRHook {
       | [
           SWRKey,
           Fetcher<Data, Key> | null,
-          SWRConfiguration<Data, Error, SWRKey>
+          SWRConfiguration<Data, Error, SWRKey> | undefined
         ]
   ): SWRResponse<Data, Error>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -128,7 +128,7 @@ export type Middleware = (
   config: SWRConfiguration<Data, Error>
 ) => SWRResponse<Data, Error>
 
-export type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
+type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
 export type Arguments = string | null | ArgumentsTuple | Record<any, any>
 export type Key = Arguments | (() => Arguments)
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -10,7 +10,7 @@ import {
   Cache,
   ScopedMutator,
   RevalidateCallback,
-  ConfigOptions
+  ProviderConfiguration
 } from '../types'
 
 const revalidateAllKeys = (
@@ -24,7 +24,7 @@ const revalidateAllKeys = (
 
 export const initCache = <Data = any>(
   provider: Cache<Data>,
-  options?: Partial<ConfigOptions>
+  options?: Partial<ProviderConfiguration>
 ): [Cache<Data>, ScopedMutator<Data>, () => void] | undefined => {
   // The global state for a specific provider will be used to deduplicate
   // requests and store listeners. As well as a mutate function that bound to

--- a/src/utils/config-context.ts
+++ b/src/utils/config-context.ts
@@ -7,7 +7,7 @@ import { useIsomorphicLayoutEffect } from './env'
 import {
   SWRConfiguration,
   FullConfiguration,
-  ConfigOptions,
+  ProviderConfiguration,
   Cache
 } from '../types'
 
@@ -15,7 +15,7 @@ export const SWRConfigContext = createContext<Partial<FullConfiguration>>({})
 
 const SWRConfig: FC<{
   value?: SWRConfiguration &
-    Partial<ConfigOptions> & {
+    Partial<ProviderConfiguration> & {
       provider?: (cache: Readonly<Cache>) => Cache
     }
 }> = ({ children, value }) => {

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -1,4 +1,4 @@
-import { ConfigOptions } from '../types'
+import { ProviderConfiguration } from '../types'
 import { isUndefined, noop, hasWindow, hasDocument } from './helper'
 
 /**
@@ -62,7 +62,7 @@ export const preset = {
   isVisible
 } as const
 
-export const defaultConfigOptions: ConfigOptions = {
+export const defaultConfigOptions: ProviderConfiguration = {
   initFocus,
   initReconnect
 }


### PR DESCRIPTION
Based on #1477, this PR refines some of the internal and exported type names and interfaces:
- Exported `ValueKey` → `Arguments` for accuracy
- Exported `Result` → removed, as it's a simple `T | Promise<T>` wrapper
- New exported `InfiniteKeyLoader` from `swr/infinite`, we can deprecate `KeyLoader` of `swr` later
- Rename internal type name `Args` to `SWRKey` for accuracy
- Other code refactoring