### PR TITLE
fix: add `clear` method to Cache interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,22 +9,22 @@ export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
    */
   SWRKey extends (() => readonly [...infer Args] | null)
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-    : /**
-     * [{ foo: string }, { bar: number } ] | null
-     * [{ foo: string }, { bar: number } ] as const | null
-     */
-    SWRKey extends (readonly [...infer Args])
+      /**
+       * [{ foo: string }, { bar: number } ] | null
+       * [{ foo: string }, { bar: number } ] as const | null
+       */
+    : SWRKey extends (readonly [...infer Args])
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-    : /**
-     * () => string | null
-     * () => Record<any, any> | null
-     */
-    SWRKey extends (() => infer Arg | null)
+      /**
+       * () => string | null
+       * () => Record<any, any> | null
+       */
+    : SWRKey extends (() => infer Arg | null)
     ? (...args: [Arg]) => FetcherResponse<Data>
-    : /**
-     *  string | null | Record<any,any>
-     */
-    SWRKey extends null
+      /**
+       *  string | null | Record<any,any>
+       */
+    : SWRKey extends null
     ? never
     : SWRKey extends (infer Arg)
     ? (...args: [Arg]) => FetcherResponse<Data>
@@ -235,6 +235,7 @@ export type StateUpdateCallback<Data = any, Error = any> = (
 ) => void
 
 export interface Cache<Data = any> {
+  clear(): void
   get(key: Key): Data | null | undefined
   set(key: Key, value: Data): void
   delete(key: Key): void

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -245,7 +245,8 @@ describe('useSWR - cache provider', () => {
             if (typeof v === 'undefined') return v
             return v + '-extended'
           },
-          delete: k => parentCache_.delete(k)
+          delete: k => parentCache_.delete(k),
+          clear: () => parentCache_.clear()
         }
       }
     })


### PR DESCRIPTION
Refer to issue #1502 