### PR TITLE
fix: Error events should be deduplicated

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -261,8 +261,9 @@ export const useSWRHandler = <Data = any, Error = any>(
           cache.set(keyErr, err)
           newState.error = err as Error
 
-          // Error event and retry logic.
-          if (isCallbackSafe()) {
+          // Error event and retry logic. Only for the actual request, not
+          // deduped ones.
+          if (shouldStartNewRequest && isCallbackSafe()) {
             getConfig().onError(err, key, config)
             if (config.shouldRetryOnError) {
               // When retrying, dedupe is always enabled

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -303,4 +303,29 @@ describe('useSWR - error', () => {
 
     await screen.findByText('error!,false')
   })
+
+  it('should dedupe onError events', async () => {
+    const key = createKey()
+    const errorEvents = []
+    function Foo() {
+      useSWR(key, () => createResponse(new Error('error!'), { delay: 20 }), {
+        onError: e => errorEvents.push(e)
+      })
+      return null
+    }
+    function Page() {
+      return (
+        <>
+          <Foo />
+          <Foo />
+        </>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    await act(() => sleep(30))
+
+    // Since there's only 1 request fired, only 1 error event should be reported.
+    expect(errorEvents.length).toBe(1)
+  })
 })


### PR DESCRIPTION
Currently the `onError` and `onErrorRetry` events are also fired for deduped requests. This behavior should be aligned with the `onSuccess` and `onLoadingSlow` events: https://github.com/vercel/swr/blob/eb55c8c1f446724b022dfb0c18cc004d6a8b9d01/src/use-swr.ts#L193-L202