### PR TITLE
feat: Add new onDiscarded option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,22 +9,22 @@ export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
    */
   SWRKey extends (() => readonly [...infer Args] | null)
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-    : /**
-     * [{ foo: string }, { bar: number } ] | null
-     * [{ foo: string }, { bar: number } ] as const | null
-     */
-    SWRKey extends (readonly [...infer Args])
+      /**
+       * [{ foo: string }, { bar: number } ] | null
+       * [{ foo: string }, { bar: number } ] as const | null
+       */
+    : SWRKey extends (readonly [...infer Args])
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-    : /**
-     * () => string | null
-     * () => Record<any, any> | null
-     */
-    SWRKey extends (() => infer Arg | null)
+      /**
+       * () => string | null
+       * () => Record<any, any> | null
+       */
+    : SWRKey extends (() => infer Arg | null)
     ? (...args: [Arg]) => FetcherResponse<Data>
-    : /**
-     *  string | null | Record<any,any>
-     */
-    SWRKey extends null
+      /**
+       *  string | null | Record<any,any>
+       */
+    : SWRKey extends null
     ? never
     : SWRKey extends (infer Arg)
     ? (...args: [Arg]) => FetcherResponse<Data>
@@ -82,6 +82,7 @@ export interface PublicConfiguration<
     revalidate: Revalidator,
     revalidateOpts: Required<RevalidatorOptions>
   ) => void
+  onDiscarded: (key: string) => void
 
   compare: (a: Data | undefined, b: Data | undefined) => boolean
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -208,6 +208,9 @@ export const useSWRHandler = <Data = any, Error = any>(
         // the request that fired later will always be kept.
         // CONCURRENT_PROMISES_TS[key] maybe be `undefined` or a number
         if (CONCURRENT_PROMISES_TS[key] !== startAt) {
+          if (shouldStartNewRequest) {
+            getConfig().onDiscarded(key)
+          }
           return false
         }
 
@@ -237,6 +240,9 @@ export const useSWRHandler = <Data = any, Error = any>(
             MUTATION_END_TS[key] === 0)
         ) {
           finishRequestAndUpdateState()
+          if (shouldStartNewRequest) {
+            getConfig().onDiscarded(key)
+          }
           return false
         }
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -58,6 +58,7 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     onSuccess: noop,
     onError: noop,
     onErrorRetry,
+    onDiscarded: noop,
 
     // switches
     revalidateOnFocus: true,


### PR DESCRIPTION
This new callback will be triggered when the request result is discarded due to race conditions (in the future, it will also be used as the request cancelation/abortion callback too).