### PR TITLE
fix: Only trigger the success event if not discarded

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -194,11 +194,6 @@ export const useSWRHandler = <Data = any, Error = any>(
           // If the request isn't interrupted, clean it up after the
           // deduplication interval.
           setTimeout(() => cleanupState(startAt), config.dedupingInterval)
-
-          // Trigger the successful callback.
-          if (isCallbackSafe()) {
-            getConfig().onSuccess(newData, key, config)
-          }
         }
 
         // If there're other ongoing request(s), started after the current one,
@@ -256,6 +251,13 @@ export const useSWRHandler = <Data = any, Error = any>(
         // https://github.com/vercel/swr/pull/1058
         if (!compare(cache.get(key), newData)) {
           cache.set(key, newData)
+        }
+
+        if (shouldStartNewRequest) {
+          // Trigger the successful callback.
+          if (isCallbackSafe()) {
+            getConfig().onSuccess(newData, key, config)
+          }
         }
       } catch (err) {
         // @ts-ignore

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -253,8 +253,8 @@ export const useSWRHandler = <Data = any, Error = any>(
           cache.set(key, newData)
         }
 
+        // Trigger the successful callback if it's the original request.
         if (shouldStartNewRequest) {
-          // Trigger the successful callback.
           if (isCallbackSafe()) {
             getConfig().onSuccess(newData, key, config)
           }

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -195,4 +195,37 @@ describe('useSWR - config callbacks', () => {
     // Should have one event recorded.
     expect(discardedEvents).toEqual([key])
   })
+
+  it('should not trigger the onSuccess callback when discarded', async () => {
+    const key = createKey()
+    const discardedEvents = []
+    const successEvents = []
+
+    function Page() {
+      const { mutate } = useSWR(
+        key,
+        () => createResponse('foo', { delay: 50 }),
+        {
+          onDiscarded: k => {
+            discardedEvents.push(k)
+          },
+          onSuccess: d => {
+            successEvents.push(d)
+          }
+        }
+      )
+      return <div onClick={() => mutate('bar', false)}>mutate</div>
+    }
+
+    renderWithConfig(<Page />)
+
+    screen.getByText('mutate')
+    await act(() => sleep(10))
+    fireEvent.click(screen.getByText('mutate'))
+    await act(() => sleep(80))
+
+    // Should have one event recorded.
+    expect(discardedEvents).toEqual([key])
+    expect(successEvents).toEqual([])
+  })
 })


### PR DESCRIPTION
This PR moves the `onSuccess` event callback down, so it will not be called if the request result was discarded due to race conditions.