### PR TITLE
Add revalidateFirstPage option to swr/infinite (#1401)

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -47,7 +47,8 @@ export const infinite = ((<Data, Error, Args extends Arguments>(
     cache,
     initialSize = 1,
     revalidateAll = false,
-    persistSize = false
+    persistSize = false,
+    revalidateFirstPage = true
   } = config
 
   // The serialized key of the first page.
@@ -137,7 +138,7 @@ export const infinite = ((<Data, Error, Args extends Arguments>(
           revalidateAll ||
           forceRevalidateAll ||
           isUndefined(pageData) ||
-          (!i && !isUndefined(dataRef.current)) ||
+          (revalidateFirstPage && !i && !isUndefined(dataRef.current)) ||
           (originalData &&
             !isUndefined(originalData[i]) &&
             !config.compare(originalData[i], pageData))

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -25,6 +25,7 @@ export type SWRInfiniteConfiguration<
   initialSize?: number
   revalidateAll?: boolean
   persistSize?: boolean
+  revalidateFirstPage?: boolean
 }
 
 export interface SWRInfiniteResponse<Data = any, Error = any>


### PR DESCRIPTION
Closes #1401.

It does what it says. By default, `swr/infinite` revalidates the first page even when only the next page is needed. This PR adds a `revalidateFirstPage = false` option to `useSWRInfinite`, that turns off revalidating the first page every time. This is useful when the pagination system does not require to update the first page.

Hope I've done everything right and this gets accepted. :)

