### PR TITLE
fix: change config alteration process in withMiddleware to be immutable

### DIFF
--- a/src/utils/with-middleware.ts
+++ b/src/utils/with-middleware.ts
@@ -15,7 +15,7 @@ export const withMiddleware = (
       | [Key, Fetcher<Data> | null, SWRConfiguration | undefined]
   ) => {
     const [key, fn, config] = normalize(args)
-    config.use = (config.use || []).concat(middleware)
-    return useSWR<Data, Error>(key, fn, config)
+    const middlewares = (config.use || []).concat(middleware)
+    return useSWR<Data, Error>(key, fn, { ...config, use: middlewares })
   }
 }


### PR DESCRIPTION
- Enable users to use shared config objects across useSWR, useSWRInfinite without the React rule of hooks error

closes #1555