### PR TITLE
Tweak types

### DIFF
--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,4 +1,4 @@
-import { SWRConfiguration, SWRResponse, Arguments } from 'swr'
+import { SWRConfiguration, SWRResponse, Arguments, OriginFetcher } from 'swr'
 
 type FetcherResponse<Data = unknown> = Data | Promise<Data>
 
@@ -64,7 +64,7 @@ export interface SWRInfiniteHook {
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>,
-    fetcher: InfiniteFetcher<Arguments, Data> | null
+    fetcher: OriginFetcher<Data> | null
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>,
@@ -72,7 +72,7 @@ export interface SWRInfiniteHook {
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>,
-    fetcher: InfiniteFetcher<Arguments, Data> | null,
+    fetcher: OriginFetcher<Data> | null,
     config: SWRInfiniteConfiguration<Data, Error, Arguments> | undefined
   ): SWRInfiniteResponse<Data, Error>
 }

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,4 +1,4 @@
-import { SWRConfiguration, SWRResponse, Arguments, OriginFetcher } from 'swr'
+import { SWRConfiguration, SWRResponse, Arguments, BareFetcher } from 'swr'
 
 type FetcherResponse<Data = unknown> = Data | Promise<Data>
 
@@ -64,7 +64,7 @@ export interface SWRInfiniteHook {
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>,
-    fetcher: OriginFetcher<Data> | null
+    fetcher: BareFetcher<Data> | null
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>,
@@ -72,7 +72,7 @@ export interface SWRInfiniteHook {
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>,
-    fetcher: OriginFetcher<Data> | null,
+    fetcher: BareFetcher<Data> | null,
     config: SWRInfiniteConfiguration<Data, Error, Arguments> | undefined
   ): SWRInfiniteResponse<Data, Error>
 }

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -9,6 +9,8 @@ export type InfiniteFetcher<
   ? ((...args: [...K]) => FetcherResponse<Data>)
   : Args extends null
   ? never
+  : Args extends false
+  ? never
   : Args extends (infer T)
   ? (...args: [T]) => FetcherResponse<Data>
   : never
@@ -56,5 +58,25 @@ export interface SWRInfiniteHook {
     config:
       | SWRInfiniteConfiguration<Data, Error, SWRInfiniteArguments>
       | undefined
+  ): SWRInfiniteResponse<Data, Error>
+  /**
+   * allow user to use generics like this
+   * useSWR<{foo: string}>(key, fn)
+   */
+  <Data = any, Error = any>(
+    getKey: InfiniteKeyLoader<Arguments>
+  ): SWRInfiniteResponse<Data, Error>
+  <Data = any, Error = any>(
+    getKey: InfiniteKeyLoader<Arguments>,
+    fetcher: InfiniteFetcher<Arguments, Data> | null
+  ): SWRInfiniteResponse<Data, Error>
+  <Data = any, Error = any>(
+    getKey: InfiniteKeyLoader<Arguments>,
+    config: SWRInfiniteConfiguration<Data, Error, Arguments> | undefined
+  ): SWRInfiniteResponse<Data, Error>
+  <Data = any, Error = any>(
+    getKey: InfiniteKeyLoader<Arguments>,
+    fetcher: InfiniteFetcher<Arguments, Data> | null,
+    config: SWRInfiniteConfiguration<Data, Error, Arguments> | undefined
   ): SWRInfiniteResponse<Data, Error>
 }

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -59,10 +59,6 @@ export interface SWRInfiniteHook {
       | SWRInfiniteConfiguration<Data, Error, SWRInfiniteArguments>
       | undefined
   ): SWRInfiniteResponse<Data, Error>
-  /**
-   * allow user to use generics like this
-   * useSWR<{foo: string}>(key, fn)
-   */
   <Data = any, Error = any>(
     getKey: InfiniteKeyLoader<Arguments>
   ): SWRInfiniteResponse<Data, Error>

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {
   SWRResponse,
   Cache,
   SWRHook,
-  OriginFetcher,
+  BareFetcher,
   Fetcher,
   MutatorCallback,
   Middleware,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   SWRResponse,
   Cache,
   SWRHook,
+  OriginFetcher,
   Fetcher,
   MutatorCallback,
   Middleware,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as revalidateEvents from './constants/revalidate-events'
 
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
-export type OriginFetcher<Data = unknown> = (
+export type BareFetcher<Data = unknown> = (
   ...args: any[]
 ) => FetcherResponse<Data>
 export type Fetcher<
@@ -118,7 +118,7 @@ export interface SWRHook {
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
-    fetcher: OriginFetcher<Data> | null
+    fetcher: BareFetcher<Data> | null
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
@@ -126,17 +126,17 @@ export interface SWRHook {
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
-    fetcher: OriginFetcher<Data>,
+    fetcher: BareFetcher<Data>,
     config: SWRConfiguration<Data, Error> | undefined
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     ...args:
       | [Key]
-      | [Key, OriginFetcher<Data> | null]
+      | [Key, BareFetcher<Data> | null]
       | [Key, SWRConfiguration<Data, Error> | undefined]
       | [
           Key,
-          OriginFetcher<Data> | null,
+          BareFetcher<Data> | null,
           SWRConfiguration<Data, Error> | undefined
         ]
   ): SWRResponse<Data, Error>

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,22 +9,22 @@ export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
    */
   SWRKey extends (() => readonly [...infer Args] | null | undefined | false)
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-    : /**
-     * [{ foo: string }, { bar: number }]
-     * [{ foo: string }, { bar: number }] as const
-     */
-    SWRKey extends (readonly [...infer Args])
+      /**
+       * [{ foo: string }, { bar: number }]
+       * [{ foo: string }, { bar: number }] as const
+       */
+    : SWRKey extends (readonly [...infer Args])
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-    : /**
-     * () => string | null | undefined | false
-     * () => Record<any, any> | null | undefined | false
-     */
-    SWRKey extends (() => infer Arg | null | undefined | false)
+      /**
+       * () => string | null | undefined | false
+       * () => Record<any, any> | null | undefined | false
+       */
+    : SWRKey extends (() => infer Arg | null | undefined | false)
     ? (...args: [Arg]) => FetcherResponse<Data>
-    : /**
-     *  string | Record<any,any> | null | undefined | false
-     */
-    SWRKey extends null | undefined | false
+      /**
+       *  string | Record<any,any> | null | undefined | false
+       */
+    : SWRKey extends null | undefined | false
     ? never
     : SWRKey extends (infer Arg)
     ? (...args: [Arg]) => FetcherResponse<Data>
@@ -125,6 +125,31 @@ export interface SWRHook {
           Fetcher<Data, Key> | null,
           SWRConfiguration<Data, Error, SWRKey> | undefined
         ]
+  ): SWRResponse<Data, Error>
+  /**
+   * allow people to use generics like this
+   * useSWR<{foo: string}>(key, fn)
+   */
+  <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
+  <Data = any, Error = any>(
+    key: Key,
+    fetcher: Fetcher<Data> | null
+  ): SWRResponse<Data, Error>
+  <Data = any, Error = any>(
+    key: Key,
+    config: SWRConfiguration<Data, Error> | undefined
+  ): SWRResponse<Data, Error>
+  <Data = any, Error = any>(
+    key: Key,
+    fetcher: Fetcher<Data>,
+    config: SWRConfiguration<Data, Error> | undefined
+  ): SWRResponse<Data, Error>
+  <Data = any, Error = any>(
+    ...args:
+      | [Key]
+      | [Key, Fetcher<Data> | null]
+      | [Key, SWRConfiguration<Data, Error> | undefined]
+      | [Key, Fetcher<Data> | null, SWRConfiguration<Data, Error> | undefined]
   ): SWRResponse<Data, Error>
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,33 +4,20 @@ export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 export type OriginFetcher<Data = unknown> = (
   ...args: any[]
 ) => FetcherResponse<Data>
-export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
-  /**
-   * () => [{ foo: string }, { bar: number }] | null | undefined | false
-   * () => ( [{ foo: string }, { bar: number } ] as const | null | undefined | false )
-   */
-  SWRKey extends (() => readonly [...infer Args] | null | undefined | false)
-    ? ((...args: [...Args]) => FetcherResponse<Data>)
-      /**
-       * [{ foo: string }, { bar: number }]
-       * [{ foo: string }, { bar: number }] as const
-       */
-    : SWRKey extends (readonly [...infer Args])
-    ? ((...args: [...Args]) => FetcherResponse<Data>)
-      /**
-       * () => string | null | undefined | false
-       * () => Record<any, any> | null | undefined | false
-       */
-    : SWRKey extends (() => infer Arg | null | undefined | false)
-    ? (...args: [Arg]) => FetcherResponse<Data>
-      /**
-       *  string | Record<any,any> | null | undefined | false
-       */
-    : SWRKey extends null | undefined | false
-    ? never
-    : SWRKey extends (infer Arg)
-    ? (...args: [Arg]) => FetcherResponse<Data>
-    : never
+export type Fetcher<
+  Data = unknown,
+  SWRKey extends Key = Key
+> = SWRKey extends (() => readonly [...infer Args] | null | undefined | false)
+  ? ((...args: [...Args]) => FetcherResponse<Data>)
+  : SWRKey extends (readonly [...infer Args])
+  ? ((...args: [...Args]) => FetcherResponse<Data>)
+  : SWRKey extends (() => infer Arg | null | undefined | false)
+  ? (...args: [Arg]) => FetcherResponse<Data>
+  : SWRKey extends null | undefined | false
+  ? never
+  : SWRKey extends (infer Arg)
+  ? (...args: [Arg]) => FetcherResponse<Data>
+  : never
 
 // Configuration types that are only used internally, not exposed to the user.
 export interface InternalConfiguration {

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,22 +9,22 @@ export type Fetcher<Data = unknown, SWRKey extends Key = Key> =
    */
   SWRKey extends (() => readonly [...infer Args] | null | undefined | false)
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-      /**
-       * [{ foo: string }, { bar: number }]
-       * [{ foo: string }, { bar: number }] as const
-       */
-    : SWRKey extends (readonly [...infer Args])
+    : /**
+     * [{ foo: string }, { bar: number }]
+     * [{ foo: string }, { bar: number }] as const
+     */
+    SWRKey extends (readonly [...infer Args])
     ? ((...args: [...Args]) => FetcherResponse<Data>)
-      /**
-       * () => string | null | undefined | false
-       * () => Record<any, any> | null | undefined | false
-       */
-    : SWRKey extends (() => infer Arg | null | undefined | false)
+    : /**
+     * () => string | null | undefined | false
+     * () => Record<any, any> | null | undefined | false
+     */
+    SWRKey extends (() => infer Arg | null | undefined | false)
     ? (...args: [Arg]) => FetcherResponse<Data>
-      /**
-       *  string | Record<any,any> | null | undefined | false
-       */
-    : SWRKey extends null | undefined | false
+    : /**
+     *  string | Record<any,any> | null | undefined | false
+     */
+    SWRKey extends null | undefined | false
     ? never
     : SWRKey extends (infer Arg)
     ? (...args: [Arg]) => FetcherResponse<Data>
@@ -126,10 +126,6 @@ export interface SWRHook {
           SWRConfiguration<Data, Error, SWRKey> | undefined
         ]
   ): SWRResponse<Data, Error>
-  /**
-   * allow people to use generics like this
-   * useSWR<{foo: string}>(key, fn)
-   */
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -15,6 +15,11 @@ export function useString() {
     expectType<string>(key)
     return key
   })
+
+  useSWR(truthy() ? '/api/user' : false, key => {
+    expectType<string>(key)
+    return key
+  })
 }
 
 export function useRecord() {
@@ -23,6 +28,10 @@ export function useRecord() {
     return key
   })
   useSWR(truthy() ? { a: '1', b: { c: '3', d: 2 } } : null, key => {
+    expectType<{ a: string; b: { c: string; d: number } }>(key)
+    return key
+  })
+  useSWR(truthy() ? { a: '1', b: { c: '3', d: 2 } } : false, key => {
     expectType<{ a: string; b: { c: string; d: number } }>(key)
     return key
   })
@@ -35,6 +44,13 @@ export function useTuple() {
   })
   useSWR(
     truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : null,
+    (...keys) => {
+      expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
+      return keys
+    }
+  )
+  useSWR(
+    truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : false,
     (...keys) => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
@@ -74,6 +90,23 @@ export function useReadonlyTuple() {
       return keys
     }
   )
+  useSWR(
+    truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
+    (...keys) => {
+      expectType<
+        [
+          {
+            readonly a: '1'
+            readonly b: {
+              readonly c: '3'
+            }
+          },
+          readonly [1231, '888']
+        ]
+      >(keys)
+      return keys
+    }
+  )
 }
 
 export function useReturnString() {
@@ -86,6 +119,14 @@ export function useReturnString() {
   )
   useSWR(
     () => (truthy() ? '/api/user' : null),
+    key => {
+      expectType<string>(key)
+      return key
+    }
+  )
+
+  useSWR(
+    () => (truthy() ? '/api/user' : false),
     key => {
       expectType<string>(key)
       return key
@@ -111,6 +152,15 @@ export function useReturnString() {
       return key
     }
   )
+  useSWRInfinite(
+    (index, previousPageData: string) => {
+      return truthy() ? `${index}${previousPageData}` : false
+    },
+    key => {
+      expectType<string>(key)
+      return key
+    }
+  )
 }
 
 export function useReturnRecord() {
@@ -123,6 +173,14 @@ export function useReturnRecord() {
   )
   useSWR(
     () => (truthy() ? { a: '1', b: { c: '3', d: 2 } } : null),
+    key => {
+      expectType<{ a: string; b: { c: string; d: number } }>(key)
+      return key
+    }
+  )
+
+  useSWR(
+    () => (truthy() ? { a: '1', b: { c: '3', d: 2 } } : false),
     key => {
       expectType<{ a: string; b: { c: string; d: number } }>(key)
       return key
@@ -153,6 +211,20 @@ export function useReturnRecord() {
       return [key]
     }
   )
+
+  useSWRInfinite(
+    index =>
+      truthy()
+        ? {
+            index,
+            endPoint: '/api'
+          }
+        : false,
+    key => {
+      expectType<{ index: number; endPoint: string }>(key)
+      return [key]
+    }
+  )
 }
 
 export function useReturnTuple() {
@@ -171,6 +243,14 @@ export function useReturnTuple() {
     }
   )
 
+  useSWR(
+    () => (truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : false),
+    (...keys) => {
+      expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
+      return keys
+    }
+  )
+
   useSWRInfinite(
     index => [{ a: '1', b: { c: '3', d: index } }, [1231, '888']],
     (...keys) => {
@@ -182,6 +262,15 @@ export function useReturnTuple() {
   useSWRInfinite(
     index =>
       truthy() ? [{ a: '1', b: { c: '3', d: index } }, [1231, '888']] : null,
+    (...keys) => {
+      expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
+      return keys[1]
+    }
+  )
+
+  useSWRInfinite(
+    index =>
+      truthy() ? [{ a: '1', b: { c: '3', d: index } }, [1231, '888']] : false,
     (...keys) => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys[1]
@@ -226,6 +315,25 @@ export function useReturnReadonlyTuple() {
     }
   )
 
+  useSWR(
+    () =>
+      truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
+    (...keys) => {
+      expectType<
+        [
+          {
+            readonly a: '1'
+            readonly b: {
+              readonly c: '3'
+            }
+          },
+          readonly [1231, '888']
+        ]
+      >(keys)
+      return keys
+    }
+  )
+
   useSWRInfinite(
     () => [{ a: '1', b: { c: '3' } }, [1231, '888']] as const,
     (...keys) => {
@@ -246,6 +354,25 @@ export function useReturnReadonlyTuple() {
   useSWRInfinite(
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
+    (...keys) => {
+      expectType<
+        [
+          {
+            readonly a: '1'
+            readonly b: {
+              readonly c: '3'
+            }
+          },
+          readonly [1231, '888']
+        ]
+      >(keys)
+      return keys[1]
+    }
+  )
+
+  useSWRInfinite(
+    () =>
+      truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
     (...keys) => {
       expectType<
         [

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -6,6 +6,11 @@ const expectType: ExpectType = () => {}
 
 const truthy: () => boolean = () => true
 
+export function useDataErrorGeneric() {
+  useSWR<{ id: number }>('/api/', () => ({ id: 123 }))
+  useSWR<string, any>('/api/', (key: string) => key)
+}
+
 export function useString() {
   useSWR('/api/user', key => {
     expectType<string>(key)


### PR DESCRIPTION
* make ```useSWR<{ id: number }>('/api/', (key) => ({ id: 123 }))``` still works as before 
so users dont need to update their current code
* add test case for #1586 
* remove some comments (replace with ts playground link later)