### PR TITLE
fix: supports ssr in ie11(#1657)

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -4,9 +4,8 @@ import { hasWindow } from './helper'
 export const IS_SERVER = !hasWindow() || 'Deno' in window
 
 // Polyfill requestAnimationFrame
-export const rAF =
-  (hasWindow() && window['requestAnimationFrame']) ||
-  ((f: (...args: any[]) => void) => setTimeout(f, 1))
+export const rAF = (f: (...args: any[]) => void) =>
+  hasWindow() ? window['requestAnimationFrame'](f) : setTimeout(f, 1)
 
 // React currently throws a warning when using useLayoutEffect on the server.
 // To get around it, we can conditionally useEffect on the server (no-op) and


### PR DESCRIPTION
Fixes: #1657 

It works fine without the polyfill settings mentioned in the issue above.

Instead of importing the rAF function at the moment of import, the function that meets the condition is imported when necessary.