### PR TITLE
Directly use useReducer for rerender purpose

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -1,7 +1,7 @@
 // We have to several type castings here because `useSWRInfinite` is a special
 // hook where `key` and return type are not like the normal `useSWR` types.
 
-import { useRef, useState, useCallback } from 'react'
+import { useRef, useReducer, useCallback } from 'react'
 import useSWR, {
   SWRConfig,
   SWRHook,
@@ -38,7 +38,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     config: Omit<typeof SWRConfig.default, 'fetcher'> &
       Omit<SWRInfiniteConfiguration<Data, Error>, 'fetcher'>
   ): SWRInfiniteResponse<Data, Error> => {
-    const rerender = useState({})[1]
+    const rerender = useReducer(s => s + 1, 0)[1]
     const didMountRef = useRef<boolean>(false)
     const dataRef = useRef<Data[]>()
 
@@ -240,7 +240,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
         cache.set(pageSizeCacheKey, size)
         lastPageSizeRef.current = size
-        rerender({})
+        rerender()
         return mutate(resolvePagesFromCache(size))
       },
       // `cache` and `rerender` isn't allowed to change during the lifecycle

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -1,4 +1,4 @@
-import { useRef, useCallback, useState, MutableRefObject } from 'react'
+import { useRef, useCallback, useReducer, MutableRefObject } from 'react'
 
 import { useIsomorphicLayoutEffect } from './env'
 import { State } from '../types'
@@ -13,7 +13,7 @@ export const useStateWithDeps = <Data, Error, S = State<Data, Error>>(
   state: S,
   unmountedRef: MutableRefObject<boolean>
 ): [MutableRefObject<S>, Record<StateKeys, boolean>, (payload: S) => void] => {
-  const rerender = useState<Record<string, unknown>>({})[1]
+  const rerender = useReducer(s => s + 1, 0)[1]
   const stateRef = useRef(state)
 
   // If a state property (data, error or isValidating) is accessed by the render
@@ -65,7 +65,7 @@ export const useStateWithDeps = <Data, Error, S = State<Data, Error>>(
       }
 
       if (shouldRerender && !unmountedRef.current) {
-        rerender({})
+        rerender()
       }
     },
     // config.suspense isn't allowed to change during the lifecycle


### PR DESCRIPTION
Since the `useState` hook is a wrapper around the `useReducer` hook, directly using the `useReducer` hook for rerender purposes would save some function calls.