### PR TITLE
feat: refreshInterval as a function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ export interface PublicConfiguration<
   loadingTimeout: number
   focusThrottleInterval: number
   dedupingInterval: number
-  refreshInterval?: number
+  refreshInterval?: number | ((latestData: Data | undefined) => number)
   refreshWhenHidden?: boolean
   refreshWhenOffline?: boolean
   revalidateOnFocus: boolean

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -3,7 +3,13 @@ import { defaultConfig } from './utils/config'
 import { SWRGlobalState, GlobalState } from './utils/global-state'
 import { IS_SERVER, rAF, useIsomorphicLayoutEffect } from './utils/env'
 import { serialize } from './utils/serialize'
-import { isUndefined, UNDEFINED, OBJECT, mergeObjects } from './utils/helper'
+import {
+  isUndefined,
+  UNDEFINED,
+  OBJECT,
+  mergeObjects,
+  isFunction
+} from './utils/helper'
 import ConfigProvider from './utils/config-context'
 import { useStateWithDeps } from './utils/state'
 import { withArgs } from './utils/resolve-args'
@@ -440,11 +446,17 @@ export const useSWRHandler = <Data = any, Error = any>(
     let timer: any
 
     function next() {
+      // Use the passed interval
+      // ...or invoke the function with the updated data to get the interval
+      const interval = isFunction(refreshInterval)
+        ? refreshInterval(data)
+        : refreshInterval
+
       // We only start next interval if `refreshInterval` is not 0, and:
       // - `force` is true, which is the start of polling
       // - or `timer` is not 0, which means the effect wasn't canceled
-      if (refreshInterval && timer !== -1) {
-        timer = setTimeout(execute, refreshInterval)
+      if (interval && timer !== -1) {
+        timer = setTimeout(execute, interval)
       }
     }
 


### PR DESCRIPTION
## Issue
Closes #1683 

## Description

In addition to passing a number, `refreshInterval` can also receive a function that returns a number as an interval. The function has access to the updated data.

Do I need to add anything to the examples folder? I'd like to update the docs as well, but it's in a different repo.

## Test plan

- Function can be passed to `refreshInterval`
- Data passed to `refreshInterval`  is updated data