### PR TITLE
test: add refreshInterval function returns 0

### DIFF
--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -434,4 +434,28 @@ describe('useSWR - refresh', () => {
     await act(() => advanceTimers(1000)) // updated after 3s
     screen.getByText('count: 4')
   })
+
+  it('should disable refresh if function returns 0', async () => {
+    let count = 1
+
+    const key = createKey()
+    function Page() {
+      const { data } = useSWR(key, () => count++, {
+        refreshInterval: () => 0,
+        dedupingInterval: 100
+      })
+      return <div>count: {data}</div>
+    }
+
+    renderWithConfig(<Page />)
+
+    // hydration
+    screen.getByText('count:')
+
+    // mount
+    await screen.findByText('count: 1')
+
+    await act(() => advanceTimers(9999)) // no update
+    screen.getByText('count: 1')
+  })
 })


### PR DESCRIPTION
## Issues
Related to #1690 

## Description
Add test when `refreshInterval` function returns 0 for the interval. The `refreshInterval` should be disable, which is the same as using `refreshInterval` with a number.

I keep it simple because there are tests for updated data and passing function as an interval. Alternatively, I can make the count goes down from 2 to 0 to demo it is working initially before being disabled.