### PR TITLE
fix: Return `undefined` data if key's falsy under suspense mode

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -492,7 +492,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   // If there is `error`, the `error` needs to be thrown to the error boundary.
   // If there is no `error`, the `revalidation` promise needs to be thrown to
   // the suspense boundary.
-  if (suspense && isUndefined(data)) {
+  if (suspense && isUndefined(data) && key) {
     throw isUndefined(error) ? revalidate(WITH_DEDUPE) : error
   }
 

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -1,12 +1,7 @@
 import { act, screen, fireEvent } from '@testing-library/react'
 import React, { useEffect, useState } from 'react'
 import useSWR, { SWRConfig, useSWRConfig, Middleware } from 'swr'
-import {
-  sleep,
-  renderWithConfig,
-  createKey,
-  renderWithGlobalCache
-} from './utils'
+import { renderWithConfig, createKey, renderWithGlobalCache } from './utils'
 
 describe('useSWR - configs', () => {
   it('should read the config fallback from the context', async () => {
@@ -30,8 +25,7 @@ describe('useSWR - configs', () => {
     await screen.findByText('data: 0')
 
     // wait for the refresh interval
-    await act(() => sleep(INTERVAL * 1.5))
-    screen.getByText('data: 1')
+    await screen.findByText('data: 1')
   })
 
   it('should stop revalidations when config.isPaused returns true', async () => {


### PR DESCRIPTION
Attempting to fix #1660 