### PR TITLE
feat: Keep track `updatedAt` as part of the SWR state

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -155,6 +155,7 @@ export type State<Data, Error> = {
   data?: Data
   error?: Error
   isValidating?: boolean
+  updatedAt?: number
 }
 
 export type Mutator<Data = any> = (
@@ -196,6 +197,7 @@ export interface SWRResponse<Data = any, Error = any> {
   data?: Data
   error?: Error
   mutate: KeyedMutator<Data>
+  updatedAt?: number
   isValidating: boolean
 }
 

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -203,6 +203,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         // considered here.
         startAt = CONCURRENT_PROMISES_TS[key]
         newData = await CONCURRENT_PROMISES[key]
+        newState.updatedAt = Date.now()
 
         if (shouldStartNewRequest) {
           // If the request isn't interrupted, clean it up after the
@@ -515,6 +516,10 @@ export const useSWRHandler = <Data = any, Error = any>(
     get isValidating() {
       stateDependencies.isValidating = true
       return isValidating
+    },
+    get updatedAt() {
+      stateDependencies.updatedAt = true
+      return stateRef.current.updatedAt
     }
   } as SWRResponse<Data, Error>
 }

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -23,7 +23,8 @@ export const useStateWithDeps = <Data, Error, S = State<Data, Error>>(
   const stateDependenciesRef = useRef<StateDeps>({
     data: false,
     error: false,
-    isValidating: false
+    isValidating: false,
+    updatedAt: false
   })
 
   /**

--- a/test/use-swr-key.test.tsx
+++ b/test/use-swr-key.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen } from '@testing-library/react'
 import React, { useState, useEffect } from 'react'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { createKey, createResponse, renderWithConfig, sleep } from './utils'
 
 describe('useSWR - key', () => {
@@ -212,5 +212,47 @@ describe('useSWR - key', () => {
 
     // Only 1 request since the keys are the same.
     expect(fetcher).toBeCalledTimes(1)
+  })
+
+  it.only('gracefully handles mutate on non existing keys', async () => {
+    const fetcher = jest.fn(() => 'data')
+    const mutSpy = jest.fn()
+
+    const key = createKey()
+    const mutKey = createKey()
+
+    function Page() {
+      const { mutate } = useSWRConfig()
+      useSWR(key, fetcher)
+
+      return (
+        <div>
+          <span>Hello</span>
+          <button
+            onClick={() =>
+              mutate(
+                mutKey,
+                () => {
+                  mutSpy()
+                  return undefined
+                },
+                false
+              )
+            }
+          >
+            mutate
+          </button>
+        </div>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('Hello')
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(mutSpy).toHaveBeenCalledTimes(1)
+
+    screen.getByText('Hello')
   })
 })

--- a/test/use-swr-loading.test.tsx
+++ b/test/use-swr-loading.test.tsx
@@ -138,7 +138,7 @@ describe('useSWR - loading', () => {
     }
 
     renderWithConfig(<Page />)
-    screen.getByText('data,error,isValidating,mutate')
+    screen.getByText('data,error,isValidating,mutate,updatedAt')
   })
 
   it('should sync loading states', async () => {

--- a/test/use-swr-updated-at.test.tsx
+++ b/test/use-swr-updated-at.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+import React, { useEffect } from 'react'
+import useSWR from 'swr'
+import { createKey, renderWithConfig, sleep } from './utils'
+
+describe('useSWR - updatedAt', () => {
+  it('should be initially undefined', async () => {
+    const key = createKey()
+
+    const fetcher = () => {
+      return 'data'
+    }
+
+    function Page() {
+      const { mutate, updatedAt } = useSWR(key, fetcher, {
+        revalidateOnMount: false
+      })
+
+      return <button onClick={() => mutate()}>data: {updatedAt}</button>
+    }
+
+    renderWithConfig(<Page />)
+
+    screen.getByText('data:')
+  })
+
+  it('should not trigger re-render if not consumed', async () => {
+    const key = createKey()
+
+    const fetcher = () => {
+      return 'data'
+    }
+
+    const renderSpy = jest.fn()
+
+    function Page() {
+      const { mutate } = useSWR(key, fetcher, {
+        revalidateOnMount: false
+      })
+
+      renderSpy()
+
+      return <button onClick={() => mutate()}>data</button>
+    }
+
+    renderWithConfig(<Page />)
+
+    screen.getByText('data')
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(renderSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should eventually reflect the last time the fetcher was called', async () => {
+    const key = createKey()
+
+    let fetcherCallTime: number
+
+    const fetcher = () => {
+      fetcherCallTime = Date.now()
+      return 'data'
+    }
+
+    const updateSpy = jest.fn()
+
+    function Page() {
+      const { mutate, updatedAt } = useSWR(key, fetcher)
+
+      useEffect(() => {
+        updateSpy(updatedAt)
+      }, [updatedAt])
+
+      return <button onClick={() => mutate()}>data</button>
+    }
+
+    renderWithConfig(<Page />)
+
+    screen.getByText('data')
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+
+    expect(updateSpy.mock.calls[0][0]).toBeUndefined()
+
+    await act(async () => {
+      await sleep(0)
+    })
+
+    expect(updateSpy).toHaveBeenCalledTimes(2)
+
+    const updatedAt = updateSpy.mock.calls[1][0]
+    expect(updatedAt).toBeDefined()
+
+    expect(updatedAt).toBeGreaterThanOrEqual(fetcherCallTime)
+  })
+})


### PR DESCRIPTION
Seeding work to keep track of the `updatedAt` time.  #1703 

At the top of my head I can think of a few things to do:

- [  ] Are tests exhaustive enough?
- [  ] Updates to other parts of the SWR API (?)
- [  ] Documentation