### PR TITLE
type(infinite): export SWRInfinteHook and InfiniteKeyLoader from infinite

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -17,23 +17,23 @@ import {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   SWRInfiniteHook,
-  InfiniteKeyLoader,
-  InfiniteFetcher
+  SWRInfiniteKeyLoader,
+  SWRInfiniteFetcher
 } from './types'
 
 const INFINITE_PREFIX = '$inf$'
 
-const getFirstPageKey = (getKey: InfiniteKeyLoader) => {
+const getFirstPageKey = (getKey: SWRInfiniteKeyLoader) => {
   return serialize(getKey ? getKey(0, null) : null)[0]
 }
 
-export const unstable_serialize = (getKey: InfiniteKeyLoader) => {
+export const unstable_serialize = (getKey: SWRInfiniteKeyLoader) => {
   return INFINITE_PREFIX + getFirstPageKey(getKey)
 }
 
 export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
   (
-    getKey: InfiniteKeyLoader,
+    getKey: SWRInfiniteKeyLoader,
     fn: BareFetcher<Data> | null,
     config: Omit<typeof SWRConfig.default, 'fetcher'> &
       Omit<SWRInfiniteConfiguration<Data, Error>, 'fetcher'>
@@ -271,6 +271,6 @@ export {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   SWRInfiniteHook,
-  InfiniteKeyLoader,
-  InfiniteFetcher
+  SWRInfiniteKeyLoader,
+  SWRInfiniteFetcher
 }

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -267,4 +267,10 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
   }) as unknown as Middleware
 
 export default withMiddleware(useSWR, infinite) as SWRInfiniteHook
-export { SWRInfiniteConfiguration, SWRInfiniteResponse, InfiniteFetcher }
+export {
+  SWRInfiniteConfiguration,
+  SWRInfiniteResponse,
+  SWRInfiniteHook,
+  InfiniteKeyLoader,
+  InfiniteFetcher
+}

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -2,9 +2,9 @@ import { SWRConfiguration, SWRResponse, Arguments, BareFetcher } from 'swr'
 
 type FetcherResponse<Data = unknown> = Data | Promise<Data>
 
-export type InfiniteFetcher<
+export type SWRInfiniteFetcher<
   Data = any,
-  KeyLoader extends InfiniteKeyLoader = InfiniteKeyLoader
+  KeyLoader extends SWRInfiniteKeyLoader = SWRInfiniteKeyLoader
 > = KeyLoader extends (...args: any[]) => any
   ? ReturnType<KeyLoader> extends
       | readonly [...infer K]
@@ -17,7 +17,7 @@ export type InfiniteFetcher<
     : never
   : never
 
-export type InfiniteKeyLoader = (
+export type SWRInfiniteKeyLoader = (
   index: number,
   previousPageData: any | null
 ) => Arguments
@@ -25,7 +25,7 @@ export type InfiniteKeyLoader = (
 export interface SWRInfiniteConfiguration<
   Data = any,
   Error = any,
-  Fn extends InfiniteFetcher<Data> = BareFetcher<Data>
+  Fn extends SWRInfiniteFetcher<Data> = BareFetcher<Data>
 > extends SWRConfiguration<Data[], Error> {
   initialSize?: number
   revalidateAll?: boolean
@@ -46,7 +46,7 @@ export interface SWRInfiniteHook {
   <
     Data = any,
     Error = any,
-    KeyLoader extends InfiniteKeyLoader = (
+    KeyLoader extends SWRInfiniteKeyLoader = (
       index: number,
       previousPageData: Data | null
     ) => null
@@ -56,55 +56,63 @@ export interface SWRInfiniteHook {
   <
     Data = any,
     Error = any,
-    KeyLoader extends InfiniteKeyLoader = (
+    KeyLoader extends SWRInfiniteKeyLoader = (
       index: number,
       previousPageData: Data | null
     ) => null
   >(
     getKey: KeyLoader,
-    fetcher: InfiniteFetcher<Data, KeyLoader> | null
+    fetcher: SWRInfiniteFetcher<Data, KeyLoader> | null
   ): SWRInfiniteResponse<Data, Error>
   <
     Data = any,
     Error = any,
-    KeyLoader extends InfiniteKeyLoader = (
+    KeyLoader extends SWRInfiniteKeyLoader = (
       index: number,
       previousPageData: Data | null
     ) => null
   >(
     getKey: KeyLoader,
     config:
-      | SWRInfiniteConfiguration<Data, Error, InfiniteFetcher<Data, KeyLoader>>
+      | SWRInfiniteConfiguration<
+          Data,
+          Error,
+          SWRInfiniteFetcher<Data, KeyLoader>
+        >
       | undefined
   ): SWRInfiniteResponse<Data, Error>
   <
     Data = any,
     Error = any,
-    KeyLoader extends InfiniteKeyLoader = (
+    KeyLoader extends SWRInfiniteKeyLoader = (
       index: number,
       previousPageData: Data | null
     ) => null
   >(
     getKey: KeyLoader,
-    fetcher: InfiniteFetcher<Data, KeyLoader> | null,
+    fetcher: SWRInfiniteFetcher<Data, KeyLoader> | null,
     config:
-      | SWRInfiniteConfiguration<Data, Error, InfiniteFetcher<Data, KeyLoader>>
+      | SWRInfiniteConfiguration<
+          Data,
+          Error,
+          SWRInfiniteFetcher<Data, KeyLoader>
+        >
       | undefined
   ): SWRInfiniteResponse<Data, Error>
-  <Data = any, Error = any>(getKey: InfiniteKeyLoader): SWRInfiniteResponse<
+  <Data = any, Error = any>(getKey: SWRInfiniteKeyLoader): SWRInfiniteResponse<
     Data,
     Error
   >
   <Data = any, Error = any>(
-    getKey: InfiniteKeyLoader,
+    getKey: SWRInfiniteKeyLoader,
     fetcher: BareFetcher<Data> | null
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
-    getKey: InfiniteKeyLoader,
+    getKey: SWRInfiniteKeyLoader,
     config: SWRInfiniteConfiguration<Data, Error, BareFetcher<Data>> | undefined
   ): SWRInfiniteResponse<Data, Error>
   <Data = any, Error = any>(
-    getKey: InfiniteKeyLoader,
+    getKey: SWRInfiniteKeyLoader,
     fetcher: BareFetcher<Data> | null,
     config: SWRInfiniteConfiguration<Data, Error, BareFetcher<Data>> | undefined
   ): SWRInfiniteResponse<Data, Error>


### PR DESCRIPTION
Hi, this PR simply exports two types: `SWRInfinteHook` and `InfinteKeyLoader`.

For `InfiniteKeyLoader` I have this use case.

```ts
const keyLoader: InfiniteKeyLoader = (index, previousPageData) => { /* ... */ };
export const useList = () => {
  const { data } = useSWRInfinite(keyLoader, fetcher);
  // ...
};
export const revalidateList = () => mutate(unstable_serialize(keyLoader));
```

I saw `SWRHook` is exported in `swr` so I added `SWRInfinteHook` as well. Thanks!