### PR TITLE
feat: Ensure auto revalidations are executed after state updates

### DIFF
--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -36,21 +36,21 @@ const isVisible = () => {
   return true
 }
 
-const initFocus = (cb: () => void) => {
+const initFocus = (callback: () => void) => {
   // focus revalidate
-  onDocumentEvent('visibilitychange', cb)
-  onWindowEvent('focus', cb)
+  onDocumentEvent('visibilitychange', callback)
+  onWindowEvent('focus', callback)
   return () => {
-    offDocumentEvent('visibilitychange', cb)
-    offWindowEvent('focus', cb)
+    offDocumentEvent('visibilitychange', callback)
+    offWindowEvent('focus', callback)
   }
 }
 
-const initReconnect = (cb: () => void) => {
+const initReconnect = (callback: () => void) => {
   // revalidate on reconnected
   const onOnline = () => {
     online = true
-    cb()
+    callback()
   }
   // nothing to revalidate, just update the status
   const onOffline = () => {

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -183,6 +183,7 @@ describe('useSWR - cache provider', () => {
     await screen.findByText('0')
     await nextTick()
     await focusOn(window)
+    await nextTick()
     screen.getByText('1')
   })
 
@@ -396,6 +397,7 @@ describe('useSWR - global cache', () => {
     await screen.findByText('0')
     await nextTick()
     await focusOn(window)
+    await nextTick()
     screen.getByText('1')
   })
 

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -220,4 +220,29 @@ describe('useSWR - focus', () => {
     await focusWindow()
     await screen.findByText('data: 1')
   })
+
+  it('should not revalidate on focus when key changes in the same tick', async () => {
+    const fetchLogs = []
+
+    function Page() {
+      const [key, setKey] = useState(() => createKey())
+      useSWR(key, k => fetchLogs.push(k), {
+        revalidateOnFocus: true,
+        dedupingInterval: 0
+      })
+      return <div onClick={() => setKey(createKey())}>change key</div>
+    }
+
+    renderWithConfig(<Page />)
+    await waitForNextTick()
+
+    fireEvent.focus(window)
+    fireEvent.click(screen.getByText('change key'))
+
+    await waitForNextTick()
+
+    // Only fetched twice with the initial and the new keys.
+    expect(fetchLogs.length).toBe(2)
+    expect(fetchLogs[0]).not.toEqual(fetchLogs[1])
+  })
 })


### PR DESCRIPTION
Most of the time, the "refocus" event also comes with a "click" which as a result can cause React state changes. Currently SWR revalidates synchronously on page focus (and network recovery too), but a React state change can make that revalidation unnecessary. #1680 is a good example.

Similar to the `rAF` improvement we added for `revalidateOnMount`, we can delay these auto revalidations a bit.

Closes #1693, closes #1680.