### PR TITLE
fix: Re-export InfiniteFetcher

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -13,7 +13,8 @@ import { useIsomorphicLayoutEffect } from '../src/utils/env'
 import { serialize } from '../src/utils/serialize'
 import { isUndefined, isFunction, UNDEFINED } from '../src/utils/helper'
 import { withMiddleware } from '../src/utils/with-middleware'
-import {
+
+import type {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   SWRInfiniteHook,
@@ -265,6 +266,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
   }) as unknown as Middleware
 
 export default withMiddleware(useSWR, infinite) as SWRInfiniteHook
+
 export {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
@@ -272,3 +274,9 @@ export {
   SWRInfiniteKeyLoader,
   SWRInfiniteFetcher
 }
+
+// @TODO: remove this in 2.0
+/**
+ * @deprecated `InfiniteFetcher` will be renamed to `SWRInfiniteFetcher`.
+ */
+export type InfiniteFetcher = SWRInfiniteFetcher


### PR DESCRIPTION
As mentioned [here](https://github.com/vercel/swr/pull/1714#issuecomment-1000526182), we are adding back `InfiniteFetcher` to avoid breaking changes.