### PR TITLE
Merge states for concurrent requests

### DIFF
--- a/src/utils/broadcast-state.ts
+++ b/src/utils/broadcast-state.ts
@@ -11,14 +11,8 @@ export const broadcastState: Broadcaster = (
   revalidate,
   populateCache = true
 ) => {
-  const [
-    EVENT_REVALIDATORS,
-    STATE_UPDATERS,
-    ,
-    ,
-    CONCURRENT_PROMISES,
-    CONCURRENT_PROMISES_TS
-  ] = SWRGlobalState.get(cache) as GlobalState
+  const [EVENT_REVALIDATORS, STATE_UPDATERS, , , CONCURRENT_REQUESTS] =
+    SWRGlobalState.get(cache) as GlobalState
   const revalidators = EVENT_REVALIDATORS[key]
   const updaters = STATE_UPDATERS[key] || []
 
@@ -33,8 +27,7 @@ export const broadcastState: Broadcaster = (
   if (revalidate) {
     // Invalidate the key by deleting the concurrent request markers so new
     // requests will not be deduped.
-    delete CONCURRENT_PROMISES[key]
-    delete CONCURRENT_PROMISES_TS[key]
+    delete CONCURRENT_REQUESTS[key]
 
     if (revalidators && revalidators[0]) {
       return revalidators[0](revalidateEvents.MUTATE_EVENT).then(() =>

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -48,15 +48,7 @@ export const initCache = <Data = any>(
     let unmount = noop
 
     // Update the state if it's new, or the provider has been extended.
-    SWRGlobalState.set(provider, [
-      EVENT_REVALIDATORS,
-      {},
-      {},
-      {},
-      {},
-      {},
-      mutate
-    ])
+    SWRGlobalState.set(provider, [EVENT_REVALIDATORS, {}, {}, {}, {}, mutate])
 
     // This is a new provider, we need to initialize it and setup DOM events
     // listeners for `focus` and `reconnect` actions.
@@ -104,5 +96,5 @@ export const initCache = <Data = any>(
     return [provider, mutate, unmount]
   }
 
-  return [provider, (SWRGlobalState.get(provider) as GlobalState)[6]]
+  return [provider, (SWRGlobalState.get(provider) as GlobalState)[5]]
 }

--- a/src/utils/global-state.ts
+++ b/src/utils/global-state.ts
@@ -10,8 +10,7 @@ export type GlobalState = [
   Record<string, StateUpdateCallback[]>, // STATE_UPDATERS
   Record<string, number>, // MUTATION_TS
   Record<string, number>, // MUTATION_END_TS
-  Record<string, any>, // CONCURRENT_PROMISES
-  Record<string, number>, // CONCURRENT_PROMISES_TS
+  Record<string, [any, number]>, // CONCURRENT_REQUESTS: [data, ts]
   ScopedMutator // Mutator
 ]
 


### PR DESCRIPTION
Use one object to store all states for concurrent requests, currently the promise and the timestamp. Later we will add more fields to it to handle callbacks more correctly.