### PR TITLE
feat: Optimistic mutation with error rollback

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -142,9 +142,11 @@ export type MutatorCallback<Data = any> = (
   currentValue?: Data
 ) => Promise<undefined | Data> | undefined | Data
 
-export type MutatorOptions = {
+export type MutatorOptions<Data = any> = {
   revalidate?: boolean
   populateCache?: boolean
+  optimisticData?: Data
+  rollbackOnError?: boolean
 }
 
 export type Broadcaster<Data = any, Error = any> = (
@@ -167,7 +169,7 @@ export type Mutator<Data = any> = (
   cache: Cache,
   key: Key,
   data?: Data | Promise<Data> | MutatorCallback<Data>,
-  opts?: boolean | MutatorOptions
+  opts?: boolean | MutatorOptions<Data>
 ) => Promise<Data | undefined>
 
 export interface ScopedMutator<Data = any> {
@@ -175,19 +177,19 @@ export interface ScopedMutator<Data = any> {
   (
     key: Key,
     data?: Data | Promise<Data> | MutatorCallback<Data>,
-    opts?: boolean | MutatorOptions
+    opts?: boolean | MutatorOptions<Data>
   ): Promise<Data | undefined>
   /** This is used for global mutator */
   <T = any>(
     key: Key,
     data?: T | Promise<T> | MutatorCallback<T>,
-    opts?: boolean | MutatorOptions
+    opts?: boolean | MutatorOptions<Data>
   ): Promise<T | undefined>
 }
 
 export type KeyedMutator<Data> = (
   data?: Data | Promise<Data> | MutatorCallback<Data>,
-  opts?: boolean | MutatorOptions
+  opts?: boolean | MutatorOptions<Data>
 ) => Promise<Data | undefined>
 
 // Public types

--- a/src/utils/broadcast-state.ts
+++ b/src/utils/broadcast-state.ts
@@ -9,15 +9,15 @@ export const broadcastState: Broadcaster = (
   error,
   isValidating,
   revalidate,
-  populateCache = true
+  broadcast = true
 ) => {
   const [EVENT_REVALIDATORS, STATE_UPDATERS, , , CONCURRENT_REQUESTS] =
     SWRGlobalState.get(cache) as GlobalState
   const revalidators = EVENT_REVALIDATORS[key]
-  const updaters = STATE_UPDATERS[key] || []
+  const updaters = STATE_UPDATERS[key]
 
   // Cache was populated, update states of all hooks.
-  if (populateCache && updaters) {
+  if (broadcast && updaters) {
     for (let i = 0; i < updaters.length; ++i) {
       updaters[i](data, error, isValidating)
     }

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1011,4 +1011,62 @@ describe('useSWR - local mutation', () => {
     await sleep(30)
     await screen.findByText('data: foo')
   })
+
+  it('should support optimistic updates via `optimisticData`', async () => {
+    const key = createKey()
+    const renderedData = []
+    let mutate
+
+    function Page() {
+      const { data, mutate: boundMutate } = useSWR(key, () =>
+        createResponse('foo', { delay: 20 })
+      )
+      mutate = boundMutate
+      renderedData.push(data)
+      return <div>data: {String(data)}</div>
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data: foo')
+
+    await act(() =>
+      mutate(createResponse('baz', { delay: 20 }), {
+        optimisticData: 'bar'
+      })
+    )
+    await sleep(30)
+    expect(renderedData).toEqual([undefined, 'foo', 'bar', 'baz', 'foo'])
+  })
+
+  it('should rollback optimistic updates when mutation fails', async () => {
+    const key = createKey()
+    const renderedData = []
+    let mutate
+    let cnt = 0
+
+    function Page() {
+      const { data, mutate: boundMutate } = useSWR(key, () =>
+        createResponse(cnt++, { delay: 20 })
+      )
+      mutate = boundMutate
+      renderedData.push(data)
+      return <div>data: {String(data)}</div>
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data: 0')
+
+    try {
+      await act(() =>
+        mutate(createResponse(new Error('baz'), { delay: 20 }), {
+          optimisticData: 'bar'
+        })
+      )
+    } catch (e) {
+      expect(e.message).toEqual('baz')
+    }
+
+    await sleep(30)
+    expect(renderedData).toEqual([undefined, 0, 'bar', 0, 1])
+  })
 })


### PR DESCRIPTION
## Quick Overview

This PR a adds two more options to `mutate`, `rollbackOnError` and `optimisticData`:

```js
mutate(updateUser(user), {
  revalidate: true,
  populateCache: true,
  rollbackOnError: true,
  optimisticData: user,
})
```

Here `updateUser(user)` is a promise or async function to actually do the **remote mutation**, and `optimisticData` is the value for immediate and **optimistic update**.

When `populateCache` is disabled, the result of that remote mutation will not be written to the cache. 

And if `rollbackOnError` is enabled, and the remote mutation errors (the promise rejects), the previously updated optimistic data will be rolled back.

And overall, using the mutate API can avoid race conditions from normal `useSWR` requests.

A detailed example:  https://codesandbox.io/s/swr-basic-forked-k5hps?file=/src/App.js.

## Documentation 

https://github.com/vercel/swr-site/pull/202

## Related Discussions

Resolves #157. Related to #1450.