### PR TITLE
Merge extra request states in cache

### DIFF
--- a/src/utils/mutate.ts
+++ b/src/utils/mutate.ts
@@ -1,5 +1,5 @@
 import { serialize } from './serialize'
-import { isFunction, isUndefined, UNDEFINED } from './helper'
+import { isFunction, isUndefined, mergeObjects, UNDEFINED } from './helper'
 import { SWRGlobalState, GlobalState } from './global-state'
 import { broadcastState } from './broadcast-state'
 import { getTimestamp } from './timestamp'
@@ -28,7 +28,7 @@ export const internalMutate = async <Data>(
   const optimisticData = options.optimisticData
 
   // Serilaize key
-  const [key, , keyErr] = serialize(_key)
+  const [key, , keyInfo] = serialize(_key)
   if (!key) return
 
   const [, , MUTATION] = SWRGlobalState.get(cache) as GlobalState
@@ -40,7 +40,7 @@ export const internalMutate = async <Data>(
       cache,
       key,
       cache.get(key),
-      cache.get(keyErr),
+      UNDEFINED,
       UNDEFINED,
       revalidate,
       populateCache
@@ -100,7 +100,7 @@ export const internalMutate = async <Data>(
       cache.set(key, data)
     }
     // Always update or reset the error.
-    cache.set(keyErr, error)
+    cache.set(keyInfo, mergeObjects(cache.get(keyInfo), { error }))
   }
 
   // Reset the timestamp to mark the mutation has ended.

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -3,7 +3,7 @@ import { isFunction } from './helper'
 
 import { Key } from '../types'
 
-export const serialize = (key: Key): [string, any[], string, string] => {
+export const serialize = (key: Key): [string, any[], string] => {
   if (isFunction(key)) {
     try {
       key = key()
@@ -19,14 +19,10 @@ export const serialize = (key: Key): [string, any[], string, string] => {
   key =
     typeof key == 'string'
       ? key
-      : (Array.isArray(key)
-        ? key.length
-        : key)
+      : (Array.isArray(key) ? key.length : key)
       ? stableHash(key)
       : ''
 
-  const errorKey = key ? '$err$' + key : ''
-  const isValidatingKey = key ? '$req$' + key : ''
-
-  return [key, args, errorKey, isValidatingKey]
+  const infoKey = key ? '$swr$' + key : ''
+  return [key, args, infoKey]
 }

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -536,8 +536,8 @@ describe('useSWR - local mutation', () => {
     })
 
     screen.getByText(message)
-    const [keyData, , keyErr] = serialize(key)
-    let cacheError = cache.get(keyErr)
+    const [keyData, , keyInfo] = serialize(key)
+    let cacheError = cache.get(keyInfo)?.error
     expect(cacheError.message).toMatchInlineSnapshot(`"${message}"`)
 
     // if mutate throws an error synchronously, the cache shouldn't be updated
@@ -545,7 +545,7 @@ describe('useSWR - local mutation', () => {
 
     // if mutate succeed, error should be cleared
     await act(() => mutate(key, value, false))
-    cacheError = cache.get(keyErr)
+    cacheError = cache.get(keyInfo)?.error
     expect(cacheError).toMatchInlineSnapshot(`undefined`)
   })
 
@@ -807,8 +807,8 @@ describe('useSWR - local mutation', () => {
         createResponse('data', { delay: 30 })
       )
       const { cache } = useSWRConfig()
-      const [, , , keyValidating] = serialize(key)
-      const cacheIsValidating = cache.get(keyValidating) || false
+      const [, , keyInfo] = serialize(key)
+      const cacheIsValidating = cache.get(keyInfo)?.isValidating
       return (
         <>
           <p>data:{data}</p>


### PR DESCRIPTION
This PR gets rid of the error and isValidating cache keys and use one single key to track both states. In 2.0 we will also merge data into it and directly use the unmodified cache key.