### PR TITLE
fix: rename ESM entrypoints to .mjs

### DIFF
--- a/immutable/package.json
+++ b/immutable/package.json
@@ -2,7 +2,7 @@
   "name": "swr-immutable",
   "version": "0.0.1",
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/immutable",
   "peerDependencies": {
     "swr": "*",

--- a/infinite/package.json
+++ b/infinite/package.json
@@ -2,7 +2,7 @@
   "name": "swr-infinite",
   "version": "0.0.1",
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "types": "./dist/infinite",
   "peerDependencies": {
     "swr": "*",

--- a/package.json
+++ b/package.json
@@ -3,26 +3,26 @@
   "version": "1.2.0-beta.0",
   "description": "React Hooks library for remote data fetching",
   "main": "./dist/index.js",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./infinite": {
-      "import": "./infinite/dist/index.esm.js",
+      "import": "./infinite/dist/index.mjs",
       "require": "./infinite/dist/index.js",
       "types": "./infinite/dist/infinite/index.d.ts"
     },
     "./immutable": {
-      "import": "./immutable/dist/index.esm.js",
+      "import": "./immutable/dist/index.mjs",
       "require": "./immutable/dist/index.js",
       "types": "./immutable/dist/immutable/index.d.ts"
     }
   },
-  "react-native": "./dist/index.esm.js",
+  "react-native": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**",


### PR DESCRIPTION
Fixes #1758 by renaming the various ESM paths to be .mjs instead of .esm.js (the simplest fix I could think of). See that issue for more information.