### PR TITLE
chore: remove useless react-native field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
       "types": "./immutable/dist/immutable/index.d.ts"
     }
   },
-  "react-native": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist/**",


### PR DESCRIPTION
follow up: #1760 

RN can pick other exports fields