### PR TITLE
polish: display name in devtool

### DIFF
--- a/src/utils/resolve-args.ts
+++ b/src/utils/resolve-args.ts
@@ -4,8 +4,8 @@ import { useSWRConfig } from './use-swr-config'
 
 // It's tricky to pass generic types as parameters, so we just directly override
 // the types here.
-export const withArgs = <SWRType>(hook: any) => {
-  return (((...args: any) => {
+export function withArgs<SWRType>(hook: any) {
+  return function useSWRArgs(...args: any) {
     // Get the default and inherited configuration.
     const fallbackConfig = useSWRConfig()
 
@@ -25,5 +25,5 @@ export const withArgs = <SWRType>(hook: any) => {
     }
 
     return next(key, fn || config.fetcher, config)
-  }) as unknown) as SWRType
+  } as unknown as SWRType
 }

--- a/src/utils/resolve-args.ts
+++ b/src/utils/resolve-args.ts
@@ -4,7 +4,7 @@ import { useSWRConfig } from './use-swr-config'
 
 // It's tricky to pass generic types as parameters, so we just directly override
 // the types here.
-export function withArgs<SWRType>(hook: any) {
+export const withArgs = <SWRType>(hook: any) => {
   return function useSWRArgs(...args: any) {
     // Get the default and inherited configuration.
     const fallbackConfig = useSWRConfig()


### PR DESCRIPTION
Related #1768

react devtool now parses all the function calls so polish the anonymous function name to a readable one

After
![image](https://user-images.githubusercontent.com/4800338/148849390-efff538f-e414-411b-8f83-5efbbed65f4b.png)
