### PR TITLE
chore: remove unnecessary exports

### DIFF
--- a/immutable/index.ts
+++ b/immutable/index.ts
@@ -1,7 +1,7 @@
 import useSWR, { Middleware } from 'swr'
 import { withMiddleware } from '../src/utils/with-middleware'
 
-export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
+const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
   // Always override all revalidate options.
   config.revalidateOnFocus = false
   config.revalidateIfStale = false

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -32,7 +32,7 @@ export const unstable_serialize = (getKey: SWRInfiniteKeyLoader) => {
   return INFINITE_PREFIX + getFirstPageKey(getKey)
 }
 
-export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
+const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
   (
     getKey: SWRInfiniteKeyLoader,
     fn: BareFetcher<Data> | null,


### PR DESCRIPTION
These exports are implementation details of each hook, so it would be unnecessary to export them.