### PR TITLE
chore: Clean up configurations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,0 @@
-dist/
-node_modules
-scripts
-examples

--- a/.eslintrc
+++ b/.eslintrc
@@ -47,5 +47,6 @@
     "react-hooks/exhaustive-deps": 1,
     "react/prop-types": 0,
     "testing-library/no-unnecessary-act": 0
-  }
+  },
+  "ignorePatterns": ["dist/", "node_modules", "scripts", "examples"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,4 @@ dist
 examples/**/yarn.lock
 package-lock.json
 tsconfig.tsbuildinfo
-**/*.yalc
-yalc.lock
 coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-node_modules
-*.log
-*.tgz
-.env
-.next
-.DS_Store

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "useTabs": false,
-  "trailingComma": "none",
-  "tabWidth": 2,
-  "arrowParens": "avoid"
-}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,0 @@
-save-prefix ""
-

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "swr",
   "version": "1.2.0-beta.1",
   "description": "React Hooks library for remote data fetching",
+  "keywords": [
+    "swr",
+    "react",
+    "hooks",
+    "request",
+    "cache",
+    "fetch"
+  ],
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
   "exports": {
@@ -33,7 +41,7 @@
     "infinite/package.json",
     "immutable/package.json"
   ],
-  "repository": "vercel/swr",
+  "repository": "github:vercel/swr",
   "homepage": "https://swr.vercel.app",
   "license": "MIT",
   "scripts": {
@@ -101,5 +109,13 @@
   },
   "peerDependencies": {
     "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+  },
+  "prettier": {
+    "semi": false,
+    "singleQuote": true,
+    "useTabs": false,
+    "trailingComma": "none",
+    "tabWidth": 2,
+    "arrowParens": "avoid"
   }
 }


### PR DESCRIPTION
- .eslintignore can be merged into .eslintrc
- .npmignore is already a subset of .gitignore
- .yarnrc is not needed as SWR has only dev dependences, safe to use the `^` semver matcher
- .prettierrc can be merged into package.json

Also improved package.json a bit.