### PR TITLE
fix: use the latest reference of fetcher with suspense mode

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -510,6 +510,9 @@ export const useSWRHandler = <Data = any, Error = any>(
   // If there is no `error`, the `revalidation` promise needs to be thrown to
   // the suspense boundary.
   if (suspense && isUndefined(data) && key) {
+    // Always update fetcher and config refs even with the Suspense mode.
+    fetcherRef.current = fetcher
+    configRef.current = config
     throw isUndefined(error) ? revalidate(WITH_DEDUPE) : error
   }
 

--- a/test/use-swr-fetcher.test.tsx
+++ b/test/use-swr-fetcher.test.tsx
@@ -1,5 +1,5 @@
-import { act, screen } from '@testing-library/react'
-import React, { useState } from 'react'
+import { act, fireEvent, screen } from '@testing-library/react'
+import React, { Suspense, useState } from 'react'
 import useSWR from 'swr'
 import { createKey, renderWithConfig, nextTick } from './utils'
 
@@ -29,6 +29,76 @@ describe('useSWR - fetcher', () => {
 
     // Revalidate.
     await act(() => mutate())
+
+    // Should fetch with the new fetcher.
+    await screen.findByText('data:bar')
+  })
+
+  it('should use the latest fetcher reference when the key has been changed', async () => {
+    const key = createKey()
+    let fetcher = () => 'foo'
+
+    function Page() {
+      const [prefix, setPrefix] = useState('a')
+      const { data } = useSWR(prefix + key, fetcher)
+
+      return (
+        <div>
+          <p>data:{data}</p>
+          <button
+            onClick={() => {
+              setPrefix('b')
+            }}
+          >
+            mutate
+          </button>
+        </div>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data:foo')
+
+    // Change the fetcher and make sure the ref is updated.
+    fetcher = () => 'bar'
+    fireEvent.click(screen.getByText('mutate'))
+
+    // Should fetch with the new fetcher.
+    await screen.findByText('data:bar')
+  })
+
+  it('should use the latest fetcher reference with the suspense mode when the key has been changed', async () => {
+    const key = createKey()
+    let fetcher = () => 'foo'
+
+    function Page() {
+      const [prefix, setPrefix] = useState('a')
+      const { data } = useSWR(prefix + key, fetcher, { suspense: true })
+
+      return (
+        <div>
+          <p>data:{data}</p>
+          <button
+            onClick={() => {
+              setPrefix('b')
+            }}
+          >
+            mutate
+          </button>
+        </div>
+      )
+    }
+
+    renderWithConfig(
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
+    )
+    await screen.findByText('data:foo')
+
+    // Change the fetcher and make sure the ref is updated.
+    fetcher = () => 'bar'
+    fireEvent.click(screen.getByText('mutate'))
 
     // Should fetch with the new fetcher.
     await screen.findByText('data:bar')


### PR DESCRIPTION
fixes #1776

This is similar to #1727, but this is for the suspense mode.
#1776 seems to be caused by the stale `getKey`, which is referenced from the stale `fetcher` function.
This mutates the fetcher and config ref objects in rendering, but I think it's not a desirable way, so I should probably find out another way.