### PR TITLE
Fix/stale fetcher on suspense

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -69,6 +69,8 @@ export const useSWRHandler = <Data = any, Error = any>(
   // Refs to keep the key and config.
   const keyRef = useRef(key)
   const fetcherRef = useRef(fetcher)
+  fetcherRef.current = fetcher
+
   const configRef = useRef(config)
   const getConfig = () => configRef.current
   const isActive = () => getConfig().isVisible() && getConfig().isOnline()


### PR DESCRIPTION
Attempts to fix #1806 

I would have hoped the `useIsomorphicLayoutEffect` to take care of this, but it would seem that it needs to be done the good ol' way, by refreshing the ref to the fetcher on every render. 

Though, the tests pass under this change, so it might be correct?