### PR TITLE
`shouldRetryOnError` accepts a function that can be used to conditionally stop retrying  

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,7 @@ export interface PublicConfiguration<
   revalidateOnReconnect: boolean
   revalidateOnMount?: boolean
   revalidateIfStale: boolean
-  shouldRetryOnError: boolean
+  shouldRetryOnError: boolean | ((err: Error) => boolean)
   suspense?: boolean
   fallbackData?: Data
   fetcher?: Fn

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -304,7 +304,12 @@ export const useSWRHandler = <Data = any, Error = any>(
           // deduped ones.
           if (shouldStartNewRequest && isCurrentKeyMounted()) {
             getConfig().onError(err, key, config)
-            if (config.shouldRetryOnError) {
+            if (
+              (typeof config.shouldRetryOnError === 'boolean' &&
+                config.shouldRetryOnError) ||
+              (isFunction(config.shouldRetryOnError) &&
+                config.shouldRetryOnError(err as Error))
+            ) {
               // When retrying, dedupe is always enabled
               if (isActive()) {
                 // If it's active, stop. It will auto revalidate when refocusing


### PR DESCRIPTION
As discussed in #1574 `shouldRetryOnError` accepts a function and we can stop retrying if some condition fails.

This is useful in case we want to stop retrying on some logic, like if the status code is `401` but still want to have Exponential backoff algorithm to retry for other errors

Currently, if you provide `onErrorRetry` in `SWRConfig` you will essentially override the default `onErrorRetry` which will also stop using exponential backoff for retrying other errors 