### PR TITLE
fix: reset stale unmountedRef in suspense

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -520,6 +520,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // Always update fetcher and config refs even with the Suspense mode.
     fetcherRef.current = fetcher
     configRef.current = config
+    unmountedRef.current = false
     throw isUndefined(error) ? revalidate(WITH_DEDUPE) : error
   }
 


### PR DESCRIPTION
Fix #1836 


* key changes from `foo` to `''`
https://github.com/vercel/swr/blob/01e05946e22edbfbfd63eff9b8617d7c6283992c/src/use-swr.ts#L461
* Then key changes from `''` to `bar`
* In suspense mode,
   https://github.com/vercel/swr/blob/01e05946e22edbfbfd63eff9b8617d7c6283992c/src/use-swr.ts#L433 
   ***would not be executed***
* So fetcher will not have chance to update the cache
https://github.com/vercel/swr/blob/01e05946e22edbfbfd63eff9b8617d7c6283992c/src/use-swr.ts#L134-L141

