### PR TITLE
breaking: Change the fetcher argument to be consistent with the passed key

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -120,7 +120,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
         let previousPageData = null
         for (let i = 0; i < pageSize; ++i) {
-          const [pageKey, pageArgs] = serialize(getKey(i, previousPageData))
+          const [pageKey, pageArg] = serialize(getKey(i, previousPageData))
 
           if (!pageKey) {
             // `pageKey` is falsy, stop fetching new pages.
@@ -148,7 +148,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
               !config.compare(originalData[i], pageData))
 
           if (fn && shouldFetchPage) {
-            pageData = await fn(...pageArgs)
+            pageData = await fn(pageArg)
             cache.set(pageKey, pageData)
           }
 

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -6,14 +6,10 @@ export type SWRInfiniteFetcher<
   Data = any,
   KeyLoader extends SWRInfiniteKeyLoader = SWRInfiniteKeyLoader
 > = KeyLoader extends (...args: any[]) => any
-  ? ReturnType<KeyLoader> extends
-      | readonly [...infer K]
-      | null
-      | false
-      | undefined
-    ? (...args: [...K]) => FetcherResponse<Data>
+  ? ReturnType<KeyLoader> extends readonly [...infer K]
+    ? (args: [...K]) => FetcherResponse<Data>
     : ReturnType<KeyLoader> extends infer T | null | false | undefined
-    ? (...args: [T]) => FetcherResponse<Data>
+    ? (args: T) => FetcherResponse<Data>
     : never
   : never
 

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -6,8 +6,8 @@ export type SWRInfiniteFetcher<
   Data = any,
   KeyLoader extends SWRInfiniteKeyLoader = SWRInfiniteKeyLoader
 > = KeyLoader extends (...args: any[]) => any
-  ? ReturnType<KeyLoader> extends readonly [...infer K]
-    ? (args: [...K]) => FetcherResponse<Data>
+  ? ReturnType<KeyLoader> extends readonly [...infer T]
+    ? (args: T) => FetcherResponse<Data>
     : ReturnType<KeyLoader> extends infer T | null | false | undefined
     ? (args: T) => FetcherResponse<Data>
     : never

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,16 +7,16 @@ export type BareFetcher<Data = unknown> = (
 export type Fetcher<
   Data = unknown,
   SWRKey extends Key = Key
-> = SWRKey extends () => readonly [...infer Args] | null | undefined | false
-  ? (...args: [...Args]) => FetcherResponse<Data>
+> = SWRKey extends () => readonly [...infer Args]
+  ? (args: [...Args]) => FetcherResponse<Data>
   : SWRKey extends readonly [...infer Args]
-  ? (...args: [...Args]) => FetcherResponse<Data>
+  ? (args: [...Args]) => FetcherResponse<Data>
   : SWRKey extends () => infer Arg | null | undefined | false
-  ? (...args: [Arg]) => FetcherResponse<Data>
+  ? (args: Arg) => FetcherResponse<Data>
   : SWRKey extends null | undefined | false
   ? never
   : SWRKey extends infer Arg
-  ? (...args: [Arg]) => FetcherResponse<Data>
+  ? (args: Arg) => FetcherResponse<Data>
   : never
 
 // Configuration types that are only used internally, not exposed to the user.

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,9 @@ export type Fetcher<
   Data = unknown,
   SWRKey extends Key = Key
 > = SWRKey extends () => readonly [...infer Args]
-  ? (args: [...Args]) => FetcherResponse<Data>
+  ? (args: Args) => FetcherResponse<Data>
   : SWRKey extends readonly [...infer Args]
-  ? (args: [...Args]) => FetcherResponse<Data>
+  ? (args: Args) => FetcherResponse<Data>
   : SWRKey extends () => infer Arg | null | undefined | false
   ? (args: Arg) => FetcherResponse<Data>
   : SWRKey extends null | undefined | false

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -33,6 +33,18 @@ import {
 
 const WITH_DEDUPE = { dedupe: true }
 
+type DefinitelyTruthy<T> = false extends T
+  ? never
+  : 0 extends T
+  ? never
+  : '' extends T
+  ? never
+  : null extends T
+  ? never
+  : undefined extends T
+  ? never
+  : T
+
 export const useSWRHandler = <Data = any, Error = any>(
   _key: Key,
   fetcher: Fetcher<Data> | null,
@@ -205,7 +217,11 @@ export const useSWRHandler = <Data = any, Error = any>(
           }
 
           // Start the request and save the timestamp.
-          FETCH[key] = [currentFetcher(fnArg), getTimestamp()]
+          // Key must be truthly if entering here.
+          FETCH[key] = [
+            currentFetcher(fnArg as DefinitelyTruthy<Key>),
+            getTimestamp()
+          ]
         }
 
         // Wait until the ongoing request is done. Deduplication is also

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -55,9 +55,9 @@ export const useSWRHandler = <Data = any, Error = any>(
   // `key` is the identifier of the SWR `data` state, `keyInfo` holds extra
   // states such as `error` and `isValidating` inside,
   // all of them are derived from `_key`.
-  // `fnArgs` is an array of arguments parsed from the key, which will be passed
+  // `fnArg` is the argument/arguments parsed from the key, which will be passed
   // to the fetcher.
-  const [key, fnArgs, keyInfo] = serialize(_key)
+  const [key, fnArg, keyInfo] = serialize(_key)
 
   // If it's the initial render of this hook.
   const initialMountedRef = useRef(false)
@@ -205,7 +205,7 @@ export const useSWRHandler = <Data = any, Error = any>(
           }
 
           // Start the request and save the timestamp.
-          FETCH[key] = [currentFetcher(...fnArgs), getTimestamp()]
+          FETCH[key] = [currentFetcher(fnArg), getTimestamp()]
         }
 
         // Wait until the ongoing request is done. Deduplication is also
@@ -342,7 +342,7 @@ export const useSWRHandler = <Data = any, Error = any>(
 
       return true
     },
-    // `setState` is immutable, and `eventsCallback`, `fnArgs`, `keyInfo`,
+    // `setState` is immutable, and `eventsCallback`, `fnArg`, `keyInfo`,
     // and `keyValidating` are depending on `key`, so we can exclude them from
     // the deps array.
     //

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -3,7 +3,7 @@ import { isFunction } from './helper'
 
 import { Key } from '../types'
 
-export const serialize = (key: Key): [string, any[], string] => {
+export const serialize = (key: Key): [string, Key, string] => {
   if (isFunction(key)) {
     try {
       key = key()
@@ -13,7 +13,9 @@ export const serialize = (key: Key): [string, any[], string] => {
     }
   }
 
-  const args = [].concat(key as any)
+  // Use the original key as the argument of fether. This can be a stirng or an
+  // array of values.
+  const args = key
 
   // If key is not falsy, or not an empty array, hash it.
   key =

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -262,7 +262,7 @@ export function useReturnTuple() {
 
   useSWR(
     () => (truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : false),
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
@@ -318,7 +318,7 @@ export function useReturnReadonlyTuple() {
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
     keys => {
       expectType<
-        [
+        readonly [
           {
             readonly a: '1'
             readonly b: {
@@ -337,7 +337,7 @@ export function useReturnReadonlyTuple() {
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
     keys => {
       expectType<
-        [
+        readonly [
           {
             readonly a: '1'
             readonly b: {
@@ -355,7 +355,7 @@ export function useReturnReadonlyTuple() {
     () => [{ a: '1', b: { c: '3' } }, [1231, '888']] as const,
     keys => {
       expectType<
-        [
+        readonly [
           {
             readonly a: '1'
             readonly b: {
@@ -373,7 +373,7 @@ export function useReturnReadonlyTuple() {
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
     keys => {
       expectType<
-        [
+        readonly [
           {
             readonly a: '1'
             readonly b: {
@@ -392,7 +392,7 @@ export function useReturnReadonlyTuple() {
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
     keys => {
       expectType<
-        [
+        readonly [
           {
             readonly a: '1'
             readonly b: {

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -58,20 +58,17 @@ export function useRecord() {
 }
 
 export function useTuple() {
-  useSWR([{ a: '1', b: { c: '3' } }, [1231, '888']], (...keys) => {
+  useSWR([{ a: '1', b: { c: '3' } }, [1231, '888']], keys => {
+    expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
+    return keys
+  })
+  useSWR(truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : null, keys => {
     expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
     return keys
   })
   useSWR(
-    truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : null,
-    (...keys) => {
-      expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
-      return keys
-    }
-  )
-  useSWR(
     truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : false,
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
@@ -79,7 +76,7 @@ export function useTuple() {
 }
 
 export function useReadonlyTuple() {
-  useSWR([{ a: '1', b: { c: '3' } }, [1231, '888']] as const, (...keys) => {
+  useSWR([{ a: '1', b: { c: '3' } }, [1231, '888']] as const, keys => {
     expectType<
       [
         {
@@ -95,7 +92,7 @@ export function useReadonlyTuple() {
   })
   useSWR(
     truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -112,7 +109,7 @@ export function useReadonlyTuple() {
   )
   useSWR(
     truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -250,14 +247,14 @@ export function useReturnRecord() {
 export function useReturnTuple() {
   useSWR(
     () => [{ a: '1', b: { c: '3' } }, [1231, '888']],
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
   )
   useSWR(
     () => (truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : null),
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
@@ -273,7 +270,7 @@ export function useReturnTuple() {
 
   useSWRInfinite(
     index => [{ a: '1', b: { c: '3', d: index } }, [1231, '888']],
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys[1]
     }
@@ -282,7 +279,7 @@ export function useReturnTuple() {
   useSWRInfinite(
     index =>
       truthy() ? [{ a: '1', b: { c: '3', d: index } }, [1231, '888']] : null,
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys[1]
     }
@@ -291,7 +288,7 @@ export function useReturnTuple() {
   useSWRInfinite(
     index =>
       truthy() ? [{ a: '1', b: { c: '3', d: index } }, [1231, '888']] : false,
-    (...keys) => {
+    keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys[1]
     }
@@ -301,7 +298,7 @@ export function useReturnTuple() {
 export function useReturnReadonlyTuple() {
   useSWR(
     () => [{ a: '1', b: { c: '3' } }, [1231, '888']] as const,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -319,7 +316,7 @@ export function useReturnReadonlyTuple() {
   useSWR(
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -338,7 +335,7 @@ export function useReturnReadonlyTuple() {
   useSWR(
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -356,7 +353,7 @@ export function useReturnReadonlyTuple() {
 
   useSWRInfinite(
     () => [{ a: '1', b: { c: '3' } }, [1231, '888']] as const,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -374,7 +371,7 @@ export function useReturnReadonlyTuple() {
   useSWRInfinite(
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {
@@ -393,7 +390,7 @@ export function useReturnReadonlyTuple() {
   useSWRInfinite(
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
-    (...keys) => {
+    keys => {
       expectType<
         [
           {

--- a/test/type/option-fetcher.ts
+++ b/test/type/option-fetcher.ts
@@ -337,7 +337,7 @@ export function useReturnReadonlyTuple() {
     {
       fetcher: keys => {
         expectType<
-          [
+          readonly [
             {
               readonly a: '1'
               readonly b: {
@@ -358,7 +358,7 @@ export function useReturnReadonlyTuple() {
     {
       fetcher: keys => {
         expectType<
-          [
+          readonly [
             {
               readonly a: '1'
               readonly b: {
@@ -395,7 +395,7 @@ export function useReturnReadonlyTuple() {
     {
       fetcher: keys => {
         expectType<
-          [
+          readonly [
             {
               readonly a: '1'
               readonly b: {
@@ -416,7 +416,7 @@ export function useReturnReadonlyTuple() {
     {
       fetcher: keys => {
         expectType<
-          [
+          readonly [
             {
               readonly a: '1'
               readonly b: {

--- a/test/type/option-fetcher.ts
+++ b/test/type/option-fetcher.ts
@@ -57,19 +57,19 @@ export function useRecord() {
 
 export function useTuple() {
   useSWR([{ a: '1', b: { c: '3' } }, [1231, '888']], {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
   })
   useSWR(truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : null, {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
   })
   useSWR(truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : false, {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
@@ -78,7 +78,7 @@ export function useTuple() {
 
 export function useReadonlyTuple() {
   useSWR([{ a: '1', b: { c: '3' } }, [1231, '888']] as const, {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<
         [
           {
@@ -96,7 +96,7 @@ export function useReadonlyTuple() {
   useSWR(
     truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<
           [
             {
@@ -115,7 +115,7 @@ export function useReadonlyTuple() {
   useSWR(
     truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<
           [
             {
@@ -259,13 +259,13 @@ export function useReturnRecord() {
 
 export function useReturnTuple() {
   useSWR(() => [{ a: '1', b: { c: '3' } }, [1231, '888']], {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
   })
   useSWR(() => (truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : null), {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
       return keys
     }
@@ -274,7 +274,7 @@ export function useReturnTuple() {
   useSWR(
     () => (truthy() ? [{ a: '1', b: { c: '3' } }, [1231, '888']] : false),
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
         return keys
       }
@@ -284,7 +284,7 @@ export function useReturnTuple() {
   useSWRInfinite(
     index => [{ a: '1', b: { c: '3', d: index } }, [1231, '888']],
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
         return keys[1]
       }
@@ -295,7 +295,7 @@ export function useReturnTuple() {
     index =>
       truthy() ? [{ a: '1', b: { c: '3', d: index } }, [1231, '888']] : null,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
         return keys[1]
       }
@@ -306,7 +306,7 @@ export function useReturnTuple() {
     index =>
       truthy() ? [{ a: '1', b: { c: '3', d: index } }, [1231, '888']] : false,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<[{ a: string; b: { c: string } }, (string | number)[]]>(keys)
         return keys[1]
       }
@@ -316,7 +316,7 @@ export function useReturnTuple() {
 
 export function useReturnReadonlyTuple() {
   useSWR(() => [{ a: '1', b: { c: '3' } }, [1231, '888']] as const, {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<
         [
           {
@@ -335,7 +335,7 @@ export function useReturnReadonlyTuple() {
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<
           [
             {
@@ -356,7 +356,7 @@ export function useReturnReadonlyTuple() {
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<
           [
             {
@@ -374,7 +374,7 @@ export function useReturnReadonlyTuple() {
   )
 
   useSWRInfinite(() => [{ a: '1', b: { c: '3' } }, [1231, '888']] as const, {
-    fetcher: (...keys) => {
+    fetcher: keys => {
       expectType<
         [
           {
@@ -393,7 +393,7 @@ export function useReturnReadonlyTuple() {
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : null,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<
           [
             {
@@ -414,7 +414,7 @@ export function useReturnReadonlyTuple() {
     () =>
       truthy() ? ([{ a: '1', b: { c: '3' } }, [1231, '888']] as const) : false,
     {
-      fetcher: (...keys) => {
+      fetcher: keys => {
         expectType<
           [
             {

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -74,7 +74,7 @@ describe('useSWRInfinite', () => {
     function Page() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => createResponse(`page ${index}, `)
+        ([_, index]) => createResponse(`page ${index}, `)
       )
 
       useEffect(() => {
@@ -101,7 +101,7 @@ describe('useSWRInfinite', () => {
     function Page() {
       const { data, mutate: boundMutate } = useSWRInfinite(
         index => [key, index],
-        (_, index) => createResponse(`${pageData[index]}, `),
+        ([_, index]) => createResponse(`${pageData[index]}, `),
         {
           initialSize: 3
         }
@@ -212,7 +212,7 @@ describe('useSWRInfinite', () => {
     function Page() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => {
+        ([_, index]) => {
           requests++
           return createResponse(`page ${index}, `)
         }
@@ -262,7 +262,7 @@ describe('useSWRInfinite', () => {
     function Page() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => {
+        ([_, index]) => {
           requests++
           return createResponse(`page ${index}, `)
         },
@@ -315,7 +315,7 @@ describe('useSWRInfinite', () => {
     function Page() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => createResponse(`page ${index}, `)
+        ([_, index]) => createResponse(`page ${index}, `)
       )
 
       return (
@@ -364,7 +364,7 @@ describe('useSWRInfinite', () => {
       const [t, setT] = useState(false)
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index, t ? 'A' : 'B'],
-        (_, index) => createResponse(`page ${index}, `)
+        ([_, index]) => createResponse(`page ${index}, `)
       )
 
       toggle = setT
@@ -403,7 +403,7 @@ describe('useSWRInfinite', () => {
       const [t, setT] = useState(false)
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index, t ? 'A' : 'B'],
-        async (_, index) => createResponse(`page ${index}, `),
+        async ([_, index]) => createResponse(`page ${index}, `),
         {
           persistSize: true
         }
@@ -445,7 +445,7 @@ describe('useSWRInfinite', () => {
     function Comp() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => createResponse(`page ${index}, `)
+        ([_, index]) => createResponse(`page ${index}, `)
       )
 
       return (
@@ -491,7 +491,7 @@ describe('useSWRInfinite', () => {
     function Comp() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => createResponse(`page ${index}, `)
+        ([_, index]) => createResponse(`page ${index}, `)
       )
 
       setters.push(setSize)
@@ -580,7 +580,7 @@ describe('useSWRInfinite', () => {
         index => {
           return [key, `/api?page=${index + 1}`]
         },
-        (_, index) => {
+        ([_, index]) => {
           requests.push(index)
           return createResponse<string[]>(dummyResponses[index])
         },
@@ -621,7 +621,7 @@ describe('useSWRInfinite', () => {
     const useCustomSWRInfinite = () => {
       const { data, setSize, size } = useSWRInfinite(
         index => [key, `/api?page=${index + 1}`],
-        (_, index) => createResponse<string[]>(dummyResponses[index])
+        ([_, index]) => createResponse<string[]>(dummyResponses[index])
       )
       return {
         data: data ? [].concat(...data) : [],
@@ -735,7 +735,7 @@ describe('useSWRInfinite', () => {
     let mutate
     function Comp() {
       mutate = useSWRConfig().mutate
-      const { data, size, setSize } = useSWRInfinite(getKey, (_, index) =>
+      const { data, size, setSize } = useSWRInfinite(getKey, ([_, index]) =>
         createResponse(`page ${index}, `)
       )
       useEffect(() => {
@@ -827,7 +827,7 @@ describe('useSWRInfinite', () => {
     function Comp() {
       const { data, size, setSize } = useSWRInfinite(
         index => [key, index],
-        (_, index) => createResponse(`page ${index}`)
+        ([_, index]) => createResponse(`page ${index}`)
       )
 
       return (

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -279,7 +279,10 @@ describe('useSWR', () => {
     const key1 = createKey()
     const key2 = createKey()
     function Page() {
-      const { data: v1 } = useSWR([key1, obj, arr], (a, b, c) => a + b.v + c[0])
+      const { data: v1 } = useSWR(
+        [key1, obj, arr],
+        ([a, b, c]) => a + b.v + c[0]
+      )
 
       // reuse the cache
       const { data: v2 } = useSWR([key1, obj, arr], () => 'not called!')
@@ -287,7 +290,7 @@ describe('useSWR', () => {
       // different object
       const { data: v3 } = useSWR(
         [key2, obj, 'world'],
-        (a, b, c) => a + b.v + c
+        ([a, b, c]) => a + b.v + c
       )
 
       return (
@@ -312,7 +315,7 @@ describe('useSWR', () => {
     function Page() {
       const { data } = useSWR(
         () => [key, obj, arr],
-        (a, b, c) => a + b.v + c[0]
+        ([a, b, c]) => a + b.v + c[0]
       )
 
       return <div>{data}</div>

--- a/test/use-swr-key.test.tsx
+++ b/test/use-swr-key.test.tsx
@@ -114,7 +114,7 @@ describe('useSWR - key', () => {
 
     let updateId
 
-    const fetcher = fn => fn()
+    const fetcher = ([fn]) => fn()
 
     function Page() {
       const [id, setId] = React.useState('first')


### PR DESCRIPTION
Currently `useSWR([1, 2, 3], fetcher)` will use the fetcher signature `fetcher(a, b, c) => data`. With this PR it changes to `fetcher([a, b, c]) => data`, which makes the argument consistent, and unblocks other features we want to add in the future. 

This also simplifies the type definitions and inference a lot.

Planned as a breaking change in 2.0.