### PR TITLE
test: fix an act warning

### DIFF
--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1099,7 +1099,7 @@ describe('useSWR - local mutation', () => {
 
     renderWithConfig(<Page />)
     fireEvent.click(screen.getByText('mutate'))
-    await sleep(30)
+    await act(() => sleep(30))
 
     expect(renderedData).toEqual([undefined, 'loading', 'final'])
   })


### PR DESCRIPTION
This fixes the `act` warning that you can see at https://github.com/vercel/swr/runs/5253406383?check_suite_focus=true