### PR TITLE
Add isFallback state

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -258,14 +258,17 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       size: resolvePageSize(),
       setSize,
       mutate,
-      get error() {
-        return swr.error
-      },
       get data() {
         return swr.data
       },
+      get error() {
+        return swr.error
+      },
       get isValidating() {
         return swr.isValidating
+      },
+      get isFallback() {
+        return swr.isFallback
       }
     } as SWRInfiniteResponse<Data, Error>
   }) as unknown as Middleware

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "watch:infinite": "yarn build:infinite -w",
     "watch:immutable": "yarn build:immutable -w",
     "watch:mutation": "yarn build:mutation -w",
-    "build:core": "bunchee src/index.ts --no-sourcemap",
+    "build:core": "bunchee src/index.ts --no-sourcemap -m",
     "build:infinite": "bunchee index.ts --cwd infinite --no-sourcemap",
     "build:immutable": "bunchee index.ts --cwd immutable --no-sourcemap",
     "build:mutation": "bunchee index.ts --cwd mutation --no-sourcemap",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "watch:infinite": "yarn build:infinite -w",
     "watch:immutable": "yarn build:immutable -w",
     "watch:mutation": "yarn build:mutation -w",
-    "build:core": "bunchee src/index.ts --no-sourcemap -m",
+    "build:core": "bunchee src/index.ts --no-sourcemap",
     "build:infinite": "bunchee index.ts --cwd infinite --no-sourcemap",
     "build:immutable": "bunchee index.ts --cwd immutable --no-sourcemap",
     "build:mutation": "bunchee index.ts --cwd mutation --no-sourcemap",

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,10 +216,11 @@ export type SWRConfiguration<
 > = Partial<PublicConfiguration<Data, Error, Fn>>
 
 export interface SWRResponse<Data = any, Error = any> {
-  data?: Data
-  error?: Error
+  data: Data | undefined
+  error: Error | undefined
   mutate: KeyedMutator<Data>
   isValidating: boolean
+  isFallback: boolean
 }
 
 export type KeyLoader<Args extends Arguments = Arguments> =

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -198,19 +198,23 @@ describe('useSWR - cache provider', () => {
   it('should support fallback values with custom provider', async () => {
     const key = createKey()
     function Page() {
-      const { data } = useSWR(key, async () => {
+      const { data, isFallback } = useSWR(key, async () => {
         await sleep(10)
         return 'data'
       })
-      return <>{String(data)}</>
+      return (
+        <>
+          {String(data)},{String(isFallback)}
+        </>
+      )
     }
 
     renderWithConfig(<Page />, {
       provider: () => provider,
       fallback: { [key]: 'fallback' }
     })
-    screen.getByText('fallback') // no `undefined`, directly fallback
-    await screen.findByText('data')
+    screen.getByText('fallback,true') // no `undefined`, directly fallback
+    await screen.findByText('data,false')
   })
 
   it('should not return the fallback if cached', async () => {

--- a/test/use-swr-loading.test.tsx
+++ b/test/use-swr-loading.test.tsx
@@ -138,7 +138,7 @@ describe('useSWR - loading', () => {
     }
 
     renderWithConfig(<Page />)
-    screen.getByText('data,error,isValidating,mutate')
+    screen.getByText('data,error,isFallback,isValidating,mutate')
   })
 
   it('should sync loading states', async () => {


### PR DESCRIPTION
After putting some time into #1922, I got the conclusion that:
- The fallback logic should be inside the useSWR hook, and middleware should receive the same _final value_ as the end user.
- To correctly implement some logic, not limiting to laggy, both middleware and the user should be able to tell if the fallback is returned.

And in 2.0, fallback will be an important feature for SWR as it covers all the SSR cases (Suspense in SSR too). It's critical to make it more complete.