### PR TITLE
Add `isLoading` state and refactor the core

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -267,8 +267,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       get isValidating() {
         return swr.isValidating
       },
-      get isFallback() {
-        return swr.isFallback
+      get isLoading() {
+        return swr.isLoading
       }
     } as SWRInfiniteResponse<Data, Error>
   }) as unknown as Middleware

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as revalidateEvents from './constants'
+import { defaultConfig } from './utils/config'
 
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 export type BareFetcher<Data = unknown> = (
@@ -121,7 +122,8 @@ export type Middleware = (
 ) => <Data = any, Error = any>(
   key: Key,
   fetcher: BareFetcher<Data> | null,
-  config: SWRConfiguration<Data, Error, BareFetcher<Data>>
+  config: typeof defaultConfig &
+    SWRConfiguration<Data, Error, BareFetcher<Data>>
 ) => SWRResponse<Data, Error>
 
 type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
@@ -164,6 +166,7 @@ export type State<Data, Error> = {
   data?: Data
   error?: Error
   isValidating?: boolean
+  isLoading?: boolean
 }
 
 export type MutatorFn<Data = any> = (
@@ -220,7 +223,7 @@ export interface SWRResponse<Data = any, Error = any> {
   error: Error | undefined
   mutate: KeyedMutator<Data>
   isValidating: boolean
-  isFallback: boolean
+  isLoading: boolean
 }
 
 export type KeyLoader<Args extends Arguments = Arguments> =

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect } from 'react'
-import { hasRequestAnimationFrame, hasWindow } from './helper'
+import { hasRequestAnimationFrame, isWindowDefined } from './helper'
 
-export const IS_SERVER = !hasWindow() || 'Deno' in window
+export const IS_SERVER = !isWindowDefined || 'Deno' in window
 
 // Polyfill requestAnimationFrame
 export const rAF = (f: (...args: any[]) => void) =>

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -1,7 +1,7 @@
 export const noop = () => {}
 
 // Using noop() as the undefined value as undefined can possibly be replaced
-// by something else.  Prettier ignore and extra parentheses are necessary here
+// by something else. Prettier ignore and extra parentheses are necessary here
 // to ensure that tsc doesn't remove the __NOINLINE__ comment.
 // prettier-ignore
 export const UNDEFINED = (/*#__NOINLINE__*/ noop()) as undefined
@@ -15,7 +15,7 @@ export const mergeObjects = (a: any, b: any) => OBJECT.assign({}, a, b)
 const STR_UNDEFINED = 'undefined'
 
 // NOTE: Use function to guarantee it's re-evaluated between jsdom and node runtime for tests.
-export const hasWindow = () => typeof window != STR_UNDEFINED
-export const hasDocument = () => typeof document != STR_UNDEFINED
+export const isWindowDefined = typeof window != STR_UNDEFINED
+export const isDocumentDefined = typeof document != STR_UNDEFINED
 export const hasRequestAnimationFrame = () =>
-  hasWindow() && typeof window['requestAnimationFrame'] != STR_UNDEFINED
+  isWindowDefined && typeof window['requestAnimationFrame'] != STR_UNDEFINED

--- a/src/utils/web-preset.ts
+++ b/src/utils/web-preset.ts
@@ -1,5 +1,5 @@
 import { ProviderConfiguration } from '../types'
-import { isUndefined, noop, hasWindow, hasDocument } from './helper'
+import { isUndefined, noop, isWindowDefined, isDocumentDefined } from './helper'
 
 /**
  * Due to bug https://bugs.chromium.org/p/chromium/issues/detail?id=678075,
@@ -11,34 +11,30 @@ import { isUndefined, noop, hasWindow, hasDocument } from './helper'
 let online = true
 const isOnline = () => online
 
-const hasWin = hasWindow()
-const hasDoc = hasDocument()
-
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
-const onWindowEvent =
-  hasWin && window.addEventListener
-    ? window.addEventListener.bind(window)
-    : noop
-const onDocumentEvent = hasDoc ? document.addEventListener.bind(document) : noop
-const offWindowEvent =
-  hasWin && window.removeEventListener
-    ? window.removeEventListener.bind(window)
-    : noop
-const offDocumentEvent = hasDoc
-  ? document.removeEventListener.bind(document)
-  : noop
+const [onWindowEvent, offWindowEvent] =
+  isWindowDefined && window.addEventListener
+    ? [
+        window.addEventListener.bind(window),
+        window.removeEventListener.bind(window)
+      ]
+    : [noop, noop]
 
 const isVisible = () => {
-  const visibilityState = hasDoc && document.visibilityState
+  const visibilityState = isDocumentDefined && document.visibilityState
   return isUndefined(visibilityState) || visibilityState !== 'hidden'
 }
 
 const initFocus = (callback: () => void) => {
   // focus revalidate
-  onDocumentEvent('visibilitychange', callback)
+  if (isDocumentDefined) {
+    document.addEventListener('visibilitychange', callback)
+  }
   onWindowEvent('focus', callback)
   return () => {
-    offDocumentEvent('visibilitychange', callback)
+    if (isDocumentDefined) {
+      document.removeEventListener('visibilitychange', callback)
+    }
     offWindowEvent('focus', callback)
   }
 }

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -198,13 +198,13 @@ describe('useSWR - cache provider', () => {
   it('should support fallback values with custom provider', async () => {
     const key = createKey()
     function Page() {
-      const { data, isFallback } = useSWR(key, async () => {
+      const { data, isLoading } = useSWR(key, async () => {
         await sleep(10)
         return 'data'
       })
       return (
         <>
-          {String(data)},{String(isFallback)}
+          {String(data)},{String(isLoading)}
         </>
       )
     }


### PR DESCRIPTION
This PR removes the `isFallback` state added in #1925, with a new `isLoading` state which covers more common use cases. Basically it's considered as "loading" when there is no **loaded data*** for the current key yet, while we are loading new data.

_*loaded data = data returned by the fetcher, not fallback or laggy data._

Here is a diagram showing the difference between `isLoading` and `isValidating`:

![Page 1](https://user-images.githubusercontent.com/3676859/163681495-fd141e00-0545-4f0f-9607-deb2726f9ef1.jpeg)

