### PR TITLE
Add `keepPreviousData` option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface PublicConfiguration<
   revalidateIfStale: boolean
   shouldRetryOnError: boolean | ((err: Error) => boolean)
   suspense?: boolean
+  laggy?: boolean
   fallbackData?: Data
   fetcher?: Fn
   use?: Middleware[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,8 +40,8 @@ export interface PublicConfiguration<
   revalidateOnMount?: boolean
   revalidateIfStale: boolean
   shouldRetryOnError: boolean | ((err: Error) => boolean)
+  keepPreviousData?: boolean
   suspense?: boolean
-  laggy?: boolean
   fallbackData?: Data
   fetcher?: Fn
   use?: Middleware[]

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -54,14 +54,14 @@ export const useSWRHandler = <Data = any, Error = any>(
 ) => {
   const {
     cache,
-    laggy,
     compare,
     suspense,
     fallbackData,
     revalidateOnMount,
     refreshInterval,
     refreshWhenHidden,
-    refreshWhenOffline
+    refreshWhenOffline,
+    keepPreviousData
   } = config
 
   const [EVENT_REVALIDATORS, STATE_UPDATERS, MUTATION, FETCH] =
@@ -103,7 +103,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   const laggyDataRef = useRef(data)
 
   const isInitialMount = !initialMountedRef.current
-  const returnedData = laggy ? laggyDataRef.current : data
+  const returnedData = keepPreviousData ? laggyDataRef.current : data
 
   // - Suspense mode and there's stale data for the initial render.
   // - Not suspense mode and there is no fallback data and `revalidateIfStale` is enabled.

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -103,7 +103,11 @@ export const useSWRHandler = <Data = any, Error = any>(
   const laggyDataRef = useRef(data)
 
   const isInitialMount = !initialMountedRef.current
-  const returnedData = keepPreviousData ? laggyDataRef.current : data
+  const returnedData = keepPreviousData
+    ? isUndefined(cachedData)
+      ? laggyDataRef.current
+      : cachedData
+    : data
 
   // - Suspense mode and there's stale data for the initial render.
   // - Not suspense mode and there is no fallback data and `revalidateIfStale` is enabled.
@@ -184,8 +188,10 @@ export const useSWRHandler = <Data = any, Error = any>(
         isLoading: false
       }
       const finishRequestAndUpdateState = () => {
+        // Set the global cache.
         setCache(finalState)
-        // We can only set state if it's safe (still mounted with the same key).
+
+        // We can only set the local state if it's safe (still mounted with the same key).
         if (isCurrentKeyMounted()) {
           setState(finalState)
         }

--- a/test/use-swr-laggy.test.tsx
+++ b/test/use-swr-laggy.test.tsx
@@ -1,0 +1,163 @@
+import { screen, act, fireEvent } from '@testing-library/react'
+import React, { useState } from 'react'
+import useSWR from 'swr'
+import useSWRInfinite from 'swr/infinite'
+
+import { createKey, createResponse, renderWithConfig, sleep } from './utils'
+
+describe('useSWR - keep previous data', () => {
+  it('should keep previous data when key changes when `keepPreviousData` is enabled', async () => {
+    const loggedData = []
+    const fetcher = k => createResponse(k, { delay: 50 })
+    function App() {
+      const [key, setKey] = useState(createKey())
+      const { data: laggedData } = useSWR(key, fetcher, {
+        keepPreviousData: true
+      })
+      loggedData.push([key, laggedData])
+      return <button onClick={() => setKey(createKey())}>change key</button>
+    }
+
+    renderWithConfig(<App />)
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+
+    const key1 = loggedData[0][0]
+    const key2 = loggedData[2][0]
+    expect(loggedData).toEqual([
+      [key1, undefined],
+      [key1, key1],
+      [key2, key1],
+      [key2, key2]
+    ])
+  })
+
+  it('should keep previous data when sharing the cache', async () => {
+    const loggedData = []
+    const fetcher = k => createResponse(k, { delay: 50 })
+    function App() {
+      const [key, setKey] = useState(createKey())
+
+      const { data } = useSWR(key, fetcher)
+      const { data: laggedData } = useSWR(key, fetcher, {
+        keepPreviousData: true
+      })
+
+      loggedData.push([key, data, laggedData])
+      return <button onClick={() => setKey(createKey())}>change key</button>
+    }
+
+    renderWithConfig(<App />)
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+
+    const key1 = loggedData[0][0]
+    const key2 = loggedData[2][0]
+    expect(loggedData).toEqual([
+      [key1, undefined, undefined],
+      [key1, key1, key1],
+      [key2, undefined, key1],
+      [key2, key2, key2]
+    ])
+  })
+
+  it('should keep previous data even if there is fallback data', async () => {
+    const loggedData = []
+    const fetcher = k => createResponse(k, { delay: 50 })
+    function App() {
+      const [key, setKey] = useState(createKey())
+
+      const { data } = useSWR(key, fetcher, {
+        fallbackData: 'fallback'
+      })
+      const { data: laggedData } = useSWR(key, fetcher, {
+        keepPreviousData: true,
+        fallbackData: 'fallback'
+      })
+
+      loggedData.push([key, data, laggedData])
+      return <button onClick={() => setKey(createKey())}>change key</button>
+    }
+
+    renderWithConfig(<App />)
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+
+    const key1 = loggedData[0][0]
+    const key2 = loggedData[2][0]
+    expect(loggedData).toEqual([
+      [key1, 'fallback', 'fallback'],
+      [key1, key1, key1],
+      [key2, 'fallback', key1],
+      [key2, key2, key2]
+    ])
+  })
+
+  it('should always return the latest data', async () => {
+    const loggedData = []
+    const fetcher = k => createResponse(k, { delay: 50 })
+    function App() {
+      const [key, setKey] = useState(createKey())
+      const { data: laggedData, mutate } = useSWR(key, fetcher, {
+        keepPreviousData: true
+      })
+      loggedData.push([key, laggedData])
+      return (
+        <>
+          <button onClick={() => setKey(createKey())}>change key</button>
+          <button onClick={() => mutate('mutate')}>mutate</button>
+        </>
+      )
+    }
+
+    renderWithConfig(<App />)
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('mutate'))
+    await act(() => sleep(100))
+
+    const key1 = loggedData[0][0]
+    const key2 = loggedData[2][0]
+    expect(loggedData).toEqual([
+      [key1, undefined],
+      [key1, key1],
+      [key2, key1],
+      [key2, key2],
+      [key2, 'mutate'],
+      [key2, key2]
+    ])
+  })
+
+  it('should keep previous data for the useSWRInfinite hook', async () => {
+    const loggedData = []
+    const fetcher = k => createResponse(k, { delay: 50 })
+    function App() {
+      const [key, setKey] = useState(createKey())
+
+      const { data } = useSWRInfinite(() => key, fetcher, {
+        keepPreviousData: true
+      })
+
+      loggedData.push([key, data])
+      return <button onClick={() => setKey(createKey())}>change key</button>
+    }
+
+    renderWithConfig(<App />)
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+
+    const key1 = loggedData[0][0]
+    const key2 = loggedData[2][0]
+    expect(loggedData).toEqual([
+      [key1, undefined],
+      [key1, [key1]],
+      [key2, [key1]],
+      [key2, [key2]]
+    ])
+  })
+})

--- a/test/use-swr-laggy.test.tsx
+++ b/test/use-swr-laggy.test.tsx
@@ -160,4 +160,38 @@ describe('useSWR - keep previous data', () => {
       [key2, [key2]]
     ])
   })
+
+  it('should support changing the `keepPreviousData` option', async () => {
+    const loggedData = []
+    const fetcher = k => createResponse(k, { delay: 50 })
+    let keepPreviousData = false
+    function App() {
+      const [key, setKey] = useState(createKey())
+      const { data: laggedData } = useSWR(key, fetcher, {
+        keepPreviousData
+      })
+      loggedData.push([key, laggedData])
+      return <button onClick={() => setKey(createKey())}>change key</button>
+    }
+
+    renderWithConfig(<App />)
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+    keepPreviousData = true
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(100))
+
+    const key1 = loggedData[0][0]
+    const key2 = loggedData[2][0]
+    const key3 = loggedData[4][0]
+    expect(loggedData).toEqual([
+      [key1, undefined],
+      [key1, key1],
+      [key2, undefined],
+      [key2, key2],
+      [key3, key2],
+      [key3, key3]
+    ])
+  })
 })


### PR DESCRIPTION
Closes #192. Unlike the [middleware solution](https://swr.vercel.app/docs/middleware#keep-previous-result), this built-in solution:
- Supports toggling the `keepPreviousData` option. 
- Handles fallback states correctly.

## Todos
- [x] Tests
- [ ] Docs