### PR TITLE
breaking: Throw error when using suspense on the server side without fallback in React 18

### DIFF
--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -1,7 +1,12 @@
 import { useCallback, useRef, useDebugValue } from 'react'
 import { defaultConfig } from './utils/config'
 import { SWRGlobalState, GlobalState } from './utils/global-state'
-import { IS_SERVER, rAF, useIsomorphicLayoutEffect } from './utils/env'
+import {
+  IS_REACT_LEGACY,
+  IS_SERVER,
+  rAF,
+  useIsomorphicLayoutEffect
+} from './utils/env'
 import { serialize } from './utils/serialize'
 import {
   isUndefined,
@@ -542,6 +547,15 @@ export const useSWRHandler = <Data = any, Error = any>(
   // If there is no `error`, the `revalidation` promise needs to be thrown to
   // the suspense boundary.
   if (suspense && isUndefined(data) && key) {
+    // SWR should throw when trying to use Suspense on the server with React 18,
+    // without providing any initial data. See:
+    // https://github.com/vercel/swr/issues/1832
+    if (!IS_REACT_LEGACY && IS_SERVER) {
+      throw new Error(
+        'Fallback data is required to use suspense on the server side.'
+      )
+    }
+
     // Always update fetcher and config refs even with the Suspense mode.
     fetcherRef.current = fetcher
     configRef.current = config

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -552,7 +552,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // https://github.com/vercel/swr/issues/1832
     if (!IS_REACT_LEGACY && IS_SERVER) {
       throw new Error(
-        'Fallback data is required to use suspense on the server side.'
+        'Fallback data is required when using suspense in SSR.'
       )
     }
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,6 +1,7 @@
-import { useEffect, useLayoutEffect } from 'react'
+import React, { useEffect, useLayoutEffect } from 'react'
 import { hasRequestAnimationFrame, isWindowDefined } from './helper'
 
+export const IS_REACT_LEGACY = !(React as any).useId
 export const IS_SERVER = !isWindowDefined || 'Deno' in window
 
 // Polyfill requestAnimationFrame


### PR DESCRIPTION
Close #1841, close #1832. 

More discussions can be found [here](https://github.com/vercel/swr/issues/1906). In short, libraries like SWR should not support fetching data on the server side as of today.