### PR TITLE
(WIP) Adding hash config

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ export type BareFetcher<Data = unknown> = (
 export type Fetcher<
   Data = unknown,
   SWRKey extends Key = Key
-> = SWRKey extends () => infer Arg | null | undefined | false
+  > = SWRKey extends () => infer Arg | null | undefined | false
   ? (args: Arg) => FetcherResponse<Data>
   : SWRKey extends null | undefined | false
   ? never
@@ -26,7 +26,7 @@ export interface PublicConfiguration<
   Data = any,
   Error = any,
   Fn extends Fetcher = BareFetcher
-> {
+  > {
   errorRetryInterval: number
   errorRetryCount?: number
   loadingTimeout: number
@@ -72,6 +72,7 @@ export interface PublicConfiguration<
   onDiscarded: (key: string) => void
 
   compare: (a: Data | undefined, b: Data | undefined) => boolean
+  hash: (a: Arguments) => string
 
   isOnline: () => boolean
   isVisible: () => boolean
@@ -121,11 +122,11 @@ export interface SWRHook {
 export type Middleware = (
   useSWRNext: SWRHook
 ) => <Data = any, Error = any>(
-  key: Key,
-  fetcher: BareFetcher<Data> | null,
-  config: typeof defaultConfig &
-    SWRConfiguration<Data, Error, BareFetcher<Data>>
-) => SWRResponse<Data, Error>
+    key: Key,
+    fetcher: BareFetcher<Data> | null,
+    config: typeof defaultConfig &
+      SWRConfiguration<Data, Error, BareFetcher<Data>>
+  ) => SWRResponse<Data, Error>
 
 type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
 export type Arguments =
@@ -181,12 +182,12 @@ export type MutatorWrapper<Fn> = Fn extends (
   ...args: [...infer Parameters]
 ) => infer Result
   ? Parameters[3] extends boolean
-    ? Result
-    : Parameters[3] extends Required<Pick<MutatorOptions, 'populateCache'>>
-    ? Parameters[3]['populateCache'] extends false
-      ? never
-      : Result
-    : Result
+  ? Result
+  : Parameters[3] extends Required<Pick<MutatorOptions, 'populateCache'>>
+  ? Parameters[3]['populateCache'] extends false
+  ? never
+  : Result
+  : Result
   : never
 
 export type Mutator<Data = any> = MutatorWrapper<MutatorFn<Data>>
@@ -217,7 +218,7 @@ export type SWRConfiguration<
   Data = any,
   Error = any,
   Fn extends BareFetcher<any> = BareFetcher<any>
-> = Partial<PublicConfiguration<Data, Error, Fn>>
+  > = Partial<PublicConfiguration<Data, Error, Fn>>
 
 export interface SWRResponse<Data = any, Error = any> {
   data: Data | undefined

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -32,6 +32,7 @@ import {
   StateUpdateCallback,
   RevalidateEvent
 } from './types'
+import { stableHash } from './utils/hash'
 
 const WITH_DEDUPE = { dedupe: true }
 
@@ -55,6 +56,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   const {
     cache,
     compare,
+    hash,
     suspense,
     fallbackData,
     revalidateOnMount,
@@ -72,7 +74,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   // all of them are derived from `_key`.
   // `fnArg` is the argument/arguments parsed from the key, which will be passed
   // to the fetcher.
-  const [key, fnArg] = serialize(_key)
+  const [key, fnArg] = serialize(_key, hash)
 
   // If it's the initial render of this hook.
   const initialMountedRef = useRef(false)
@@ -431,8 +433,8 @@ export const useSWRHandler = <Data = any, Error = any>(
           compare(stateRef.current.data, state.data)
             ? UNDEFINED
             : {
-                data: state.data
-              }
+              data: state.data
+            }
         )
       )
     }
@@ -576,6 +578,6 @@ export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'default', {
   default: FullConfiguration
 }
 
-export const unstable_serialize = (key: Key) => serialize(key)[0]
+export const unstable_serialize = (key: Key) => serialize(key, stableHash)[0]
 
 export default withArgs<SWRHook>(useSWRHandler)

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -70,6 +70,7 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     // providers
     compare: (currentData: any, newData: any) =>
       stableHash(currentData) == stableHash(newData),
+    hash: (a: any) => stableHash(a),
     isPaused: () => false,
     cache,
     mutate,

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,9 +1,8 @@
-import { stableHash } from './hash'
 import { isFunction } from './helper'
 
-import { Key } from '../types'
+import { Arguments, Key } from '../types'
 
-export const serialize = (key: Key): [string, Key] => {
+export const serialize = (key: Key, hash: (a: Arguments) => string): [string, Key] => {
   if (isFunction(key)) {
     try {
       key = key()
@@ -22,8 +21,8 @@ export const serialize = (key: Key): [string, Key] => {
     typeof key == 'string'
       ? key
       : (Array.isArray(key) ? key.length : key)
-      ? stableHash(key)
-      : ''
+        ? hash(key)
+        : ''
 
   return [key, args]
 }


### PR DESCRIPTION
Adding a function to the configuration to replace `stableHash`.

This pr is meant to resolve issues discussed in #1846. 

It adds a hash function in the configuration that defaults to stableHash.

I haven't written any tests for this, but I have tested this on my personal repository and seen that it works. Can anyone please take a look at this and give me some direction on how to make this ready to merge? 

E.g.:

-  what tests should I write?
- Am I missing any places I should put the default configuration
- This changes the signature of `serialize`. Should I make the hash function in `serialize` optional and make it defualt to `stableHash` internally? 