### PR TITLE
Add missing clear method to Cache type definition

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -264,4 +264,5 @@ export interface Cache<Data = any> {
   get(key: Key): Data | null | undefined
   set(key: Key, value: Data): void
   delete(key: Key): void
+  clear(): void
 }

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -260,7 +260,8 @@ describe('useSWR - cache provider', () => {
             }
             return v
           },
-          delete: k => parentCache_.delete(k)
+          delete: k => parentCache_.delete(k),
+          clear: () => parentCache_.clear()
         }
       }
     })


### PR DESCRIPTION
The Cache has been exposed since [1], which supposedly includes a
.clear() method [2], which in turn is not actually present in the
type definition [3]. This adds it to the type definition to align
with the implementation.

Since Map also contains a .clear() method [4], this shouldn't break
the ability to pass that in as a map.

[1] https://github.com/vercel/swr/pull/231
[2] https://github.com/vercel/swr/issues/161#issuecomment-695417107 and https://swr.vercel.app/docs/advanced/cache#access-to-the-cache
[3] https://github.com/vercel/swr/issues/161#issuecomment-1079198998
[4] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear