### PR TITLE
types: loose cache types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -264,4 +264,5 @@ export interface Cache<Data = any> {
   get(key: Key): Data | null | undefined
   set(key: Key, value: Data): void
   delete(key: Key): void
+  [key: string]: any
 }

--- a/test/type/cache.ts
+++ b/test/type/cache.ts
@@ -1,0 +1,12 @@
+import { useSWRConfig } from 'swr'
+import { expectType } from './utils'
+
+export function useSWRLooseCache() {
+  const { cache } = useSWRConfig()
+  expectType<any>(cache.values())
+}
+
+export function useSWRMapCache() {
+  const cache = useSWRConfig().cache as Map<string, any>
+  expectType<Map<string, any>['values']>(cache.values)
+}


### PR DESCRIPTION
Makes type of `cache` looser, so user could use any method without inferring or use type casting

x-ref: #161 
x-ref: #1775 
x-ref: #1480 
Closes: #1936

