### PR TITLE
try to add custom hash

### DIFF
--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -21,7 +21,7 @@ const mutation = (<Data, Error>() =>
     fetcher: MutationFetcher<Data>,
     config: SWRMutationConfiguration<Data, Error> = {}
   ) => {
-    const { mutate } = useSWRConfig()
+    const { mutate, hash } = useSWRConfig()
 
     const keyRef = useRef(key)
     // Ditch all mutation results that happened earlier than this timestamp.
@@ -36,7 +36,7 @@ const mutation = (<Data, Error>() =>
 
     const trigger = useCallback(
       async (arg, opts?: SWRMutationConfiguration<Data, Error>) => {
-        const [serializedKey, resolvedKey] = serialize(keyRef.current)
+        const [serializedKey, resolvedKey] = serialize(keyRef.current, hash)
 
         if (!fetcher) {
           throw new Error('Can’t trigger the mutation: missing fetcher.')

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,6 +72,7 @@ export interface PublicConfiguration<
   onDiscarded: (key: string) => void
 
   compare: (a: Data | undefined, b: Data | undefined) => boolean
+  hash: (a: Arguments) => string
 
   isOnline: () => boolean
   isVisible: () => boolean

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -37,6 +37,7 @@ import {
   StateUpdateCallback,
   RevalidateEvent
 } from './types'
+import { stableHash } from './utils/hash'
 
 const WITH_DEDUPE = { dedupe: true }
 
@@ -60,6 +61,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   const {
     cache,
     compare,
+    hash,
     suspense,
     fallbackData,
     revalidateOnMount,
@@ -77,7 +79,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   // all of them are derived from `_key`.
   // `fnArg` is the argument/arguments parsed from the key, which will be passed
   // to the fetcher.
-  const [key, fnArg] = serialize(_key)
+  const [key, fnArg] = serialize(_key, hash)
 
   // If it's the initial render of this hook.
   const initialMountedRef = useRef(false)
@@ -411,7 +413,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // By using `bind` we don't need to modify the size of the rest arguments.
     // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
     // cast it to any for now.
-    internalMutate.bind(UNDEFINED, cache, () => keyRef.current) as any,
+    internalMutate.bind(UNDEFINED, hash, cache, () => keyRef.current) as any,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
@@ -601,6 +603,6 @@ export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'default', {
   default: FullConfiguration
 }
 
-export const unstable_serialize = (key: Key) => serialize(key)[0]
+export const unstable_serialize = (key: Key) => serialize(key, stableHash)[0]
 
 export default withArgs<SWRHook>(useSWRHandler)

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -11,7 +11,8 @@ import {
   ScopedMutator,
   RevalidateEvent,
   RevalidateCallback,
-  ProviderConfiguration
+  ProviderConfiguration,
+  SWRConfiguration
 } from '../types'
 
 const revalidateAllKeys = (
@@ -25,7 +26,7 @@ const revalidateAllKeys = (
 
 export const initCache = <Data = any>(
   provider: Cache<Data>,
-  options?: Partial<ProviderConfiguration>
+  options?: Partial<ProviderConfiguration & SWRConfiguration>
 ):
   | [Cache<Data>, ScopedMutator<Data>, () => void]
   | [Cache<Data>, ScopedMutator<Data>]
@@ -44,6 +45,7 @@ export const initCache = <Data = any>(
     const EVENT_REVALIDATORS = {}
     const mutate = internalMutate.bind(
       UNDEFINED,
+      options?.hash,
       provider
     ) as ScopedMutator<Data>
     let unmount = noop

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -70,6 +70,7 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     // providers
     compare: (currentData: any, newData: any) =>
       stableHash(currentData) == stableHash(newData),
+    hash: (a: any) => stableHash(a),
     isPaused: () => false,
     cache,
     mutate,

--- a/src/utils/serialize.ts
+++ b/src/utils/serialize.ts
@@ -1,9 +1,11 @@
-import { stableHash } from './hash'
 import { isFunction } from './helper'
 
-import { Key } from '../types'
+import { Arguments, Key } from '../types'
 
-export const serialize = (key: Key): [string, Key] => {
+export const serialize = (
+  key: Key,
+  hashFn: (a: Arguments) => string
+): [string, Key] => {
   if (isFunction(key)) {
     try {
       key = key()
@@ -22,7 +24,7 @@ export const serialize = (key: Key): [string, Key] => {
     typeof key == 'string'
       ? key
       : (Array.isArray(key) ? key.length : key)
-      ? stableHash(key)
+      ? hashFn(key)
       : ''
 
   return [key, args]

--- a/test/unit/utils.test.tsx
+++ b/test/unit/utils.test.tsx
@@ -29,7 +29,7 @@ describe('Utils', () => {
 
   it('should hash arguments correctly', async () => {
     // Empty
-    expect(serialize([])[0]).toEqual('')
+    expect(serialize([], hash)[0]).toEqual('')
 
     // Primitives
     expect(hash(['key'])).toEqual('@"key",')

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -383,7 +383,7 @@ describe('useSWR - error', () => {
 
     // mount
     await screen.findByText('hello, error')
-
+    console.log(mutate)
     await act(() => mutate())
     // initial -> first error -> mutate -> receive another error
     // error won't be cleared during revalidation

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -10,6 +10,7 @@ import {
   renderWithConfig,
   renderWithGlobalCache
 } from './utils'
+import { stableHash } from '../src/utils/hash'
 
 describe('useSWRInfinite', () => {
   it('should render the first page component', async () => {
@@ -740,13 +741,15 @@ describe('useSWRInfinite', () => {
     await screen.findByText(`data:page-test-${key}-0:1`)
 
     await act(() =>
-      mutate(unstable_serialize(index => `page-test-${key}-${index}`))
+      mutate(
+        unstable_serialize(index => `page-test-${key}-${index}`, stableHash)
+      )
     )
     await screen.findByText(`data:page-test-${key}-0:2`)
 
     await act(() =>
       mutate(
-        unstable_serialize(index => `page-test-${key}-${index}`),
+        unstable_serialize(index => `page-test-${key}-${index}`, stableHash),
         'local-mutation',
         false
       )
@@ -780,7 +783,7 @@ describe('useSWRInfinite', () => {
 
     await act(() =>
       mutate(
-        unstable_serialize(getKey),
+        unstable_serialize(getKey, stableHash),
         data => data.map(value => `(edited)${value}`),
         false
       )
@@ -818,12 +821,14 @@ describe('useSWRInfinite', () => {
 
     await screen.findByText('data:initial-cache')
 
-    await act(() => mutateCustomCache(unstable_serialize(() => key)))
+    await act(() =>
+      mutateCustomCache(unstable_serialize(() => key, stableHash))
+    )
     await screen.findByText('data:response data')
 
     await act(() =>
       mutateCustomCache(
-        unstable_serialize(() => key),
+        unstable_serialize(() => key, stableHash),
         'local-mutation',
         false
       )

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -10,6 +10,7 @@ import {
   renderWithConfig,
   renderWithGlobalCache
 } from './utils'
+import { stableHash } from '../src/utils/hash'
 
 describe('useSWR - local mutation', () => {
   it('should trigger revalidation programmatically', async () => {
@@ -536,7 +537,7 @@ describe('useSWR - local mutation', () => {
     })
 
     screen.getByText(message)
-    const [keyInfo] = serialize(key)
+    const [keyInfo] = serialize(key, stableHash)
     let cacheError = cache.get(keyInfo)?.error
     expect(cacheError.message).toMatchInlineSnapshot(`"${message}"`)
 
@@ -806,8 +807,8 @@ describe('useSWR - local mutation', () => {
       const { data, isValidating } = useSWR(key, () =>
         createResponse('data', { delay: 30 })
       )
-      const { cache } = useSWRConfig()
-      const [keyInfo] = serialize(key)
+      const { cache, hash } = useSWRConfig()
+      const [keyInfo] = serialize(key, hash)
       const cacheIsValidating = cache.get(keyInfo)?.isValidating
       return (
         <>


### PR DESCRIPTION
Adding a function to the configuration to replace stableHash.

This pr is meant to resolve issues discussed in https://github.com/vercel/swr/issues/1846.

It adds a hash function in the configuration that defaults to `stableHash`.

This attempt is based on https://github.com/vercel/swr/pull/1934 and but passes the custom hash function to every `serialize` invocation to ensure consistency in the hashing.

Unfortunately, five tests are failing as soon as I add another argument to he internalMutate function (even if I do not use the passed arguments or just pass null). It seems like an additional render is causing the tests to fail.

```
 FAIL  test/use-swr-error.test.tsx
  ● useSWR - error › should not clear error during revalidating until fetcher is finished successfully

    expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

      Array [
        null,
        "error",
    +   null,
        "error",
      ]

      388 |     // initial -> first error -> mutate -> receive another error
      389 |     // error won't be cleared during revalidation
    > 390 |     expect(errors).toEqual([null, 'error', 'error'])
          |                    ^
      391 |   })


 FAIL  test/use-swr-refresh.test.tsx
  ● useSWR - refresh › should allow use custom compare method

    expect(received).toEqual(expected) // deep equality

    Expected: "1"
    Received: "2"

      261 |
      262 |     const cachedData = customCache.get(key)?.data
    > 263 |     expect(cachedData.timestamp.toString()).toEqual('1')
          |                                             ^
      264 |     screen.getByText('1')
      265 |   })


 FAIL  test/use-swr-config.test.tsx
  ● useSWR - configs › should stop revalidations when config.isPaused returns true

    TestingLibraryElementError: Unable to find an element with the text: data: 0. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.

    Ignored nodes: comments, <script />, <style />
    <body>
      <div>
        <div>
          data: undefined
        </div>
      </div>
    </body>

      70 |     // should not be revalidated
      71 |     await act(() => mutate())
    > 72 |     screen.getByText('data: 0')
         |            ^
      73 |     await act(() => mutate())
      74 |     screen.getByText('data: 0')



 FAIL  test/use-swr-infinite.test.tsx
  ● useSWRInfinite › should revalidate the resource with bound mutate when no argument is passed

    expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

      Array [
        undefined,
        Array [
          "foo-0",
        ],
    +   undefined,
        Array [
          "foo-1",
        ],
      ]

      1100 |     expect(fetcher).toBeCalledTimes(2)
      1101 |
    > 1102 |     expect(logger).toEqual([undefined, ['foo-0'], ['foo-1']])
           |                    ^
      1103 |   })


 FAIL  test/use-swr-loading.test.tsx
  ● useSWR - loading › should not trigger loading state when revalidating

    TestingLibraryElementError: Unable to find an element with the text: ready,validating. This could be because the text is broken up by multiple elements. In this case, you can provide a function for your text matcher to make your matcher more flexible.

    Ignored nodes: comments, <script />, <style />
    <body>
      <div>
        <div>
          <div>
            loading
            ,
            validating
          </div>
          <button>
            revalidate
          </button>
        </div>
      </div>
    </body>

      286 |
      287 |     fireEvent.click(screen.getByText('revalidate'))
    > 288 |     screen.getByText('ready,validating')
          |            ^
      289 |     await screen.findByText('ready,ready')


 ● useSWR - error › should not clear error during revalidating until fetcher is finished successfully

    expect(received).toEqual(expected) // deep equality

    - Expected  - 0
    + Received  + 1

      Array [
        null,
        "error",
    +   null,
        "error",
      ]

      388 |     // initial -> first error -> mutate -> receive another error
      389 |     // error won't be cleared during revalidation
    > 390 |     expect(errors).toEqual([null, 'error', 'error'])
          |                    ^
      391 |   })
      392 |

```

