### PR TITLE
Fix cache types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -144,7 +144,7 @@ export type MutatorCallback<Data = any> = (
 
 export type MutatorOptions<Data = any> = {
   revalidate?: boolean
-  populateCache?: boolean | ((result: any, currentData: Data) => Data)
+  populateCache?: boolean | ((result: any, currentData?: Data) => Data)
   optimisticData?: Data | ((currentData?: Data) => Data)
   rollbackOnError?: boolean
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -255,14 +255,12 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
   type: K
 ) => RevalidateCallbackReturnType[K]
 
-export type StateUpdateCallback<Data = any, Error = any> = (state: {
-  data?: Data
-  error?: Error
-  isValidating?: boolean
-}) => void
+export type StateUpdateCallback<Data = any, Error = any> = (
+  state: State<Data, Error>
+) => void
 
-export interface Cache<Data = any> {
-  get(key: Key): Data | null | undefined
-  set(key: Key, value: Data): void
+export interface Cache<Data = any, Error = any> {
+  get(key: Key): State<Data, Error> | undefined
+  set(key: Key, value: State<Data, Error>): void
   delete(key: Key): void
 }

--- a/src/use-swr.ts
+++ b/src/use-swr.ts
@@ -178,7 +178,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       // new request should be initiated.
       const shouldStartNewRequest = !FETCH[key] || !opts.dedupe
 
-      /* 
+      /*
          For React 17
          Do unmount check for calls:
          If key has changed during the revalidation, or the component has been
@@ -442,7 +442,8 @@ export const useSWRHandler = <Data = any, Error = any>(
         mergeObjects(
           {
             error: state.error,
-            isValidating: state.isValidating
+            isValidating: state.isValidating,
+            isLoading: state.isLoading
           },
           // Since `setState` only shallowly compares states, we do a deep
           // comparison here.

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -8,6 +8,7 @@ import * as revalidateEvents from '../constants'
 import {
   Key,
   Cache,
+  State,
   ScopedMutator,
   RevalidateEvent,
   RevalidateCallback,
@@ -106,13 +107,9 @@ export const createCacheHelper = <Data = any, ExtendedInfo = {}>(
 ) =>
   [
     // Getter
-    () => cache.get(key) || {},
+    () => (cache.get(key) || {}) as State<Data, any> & Partial<ExtendedInfo>,
     // Setter
-    (
-      info: Partial<
-        { data: Data; error: any; isValidating: boolean } | ExtendedInfo
-      >
-    ) => {
+    (info: Partial<State<Data, any> | ExtendedInfo>) => {
       cache.set(key, mergeObjects(cache.get(key), info))
     }
   ] as const

--- a/src/utils/mutate.ts
+++ b/src/utils/mutate.ts
@@ -100,7 +100,7 @@ export const internalMutate = async <Data>(
   if (populateCache) {
     if (!error) {
       // Transform the result into data.
-      if (isFunction(populateCache)) {
+      if (isFunction(populateCache) && originalData) {
         data = populateCache(data, originalData)
       }
 

--- a/src/utils/mutate.ts
+++ b/src/utils/mutate.ts
@@ -100,7 +100,7 @@ export const internalMutate = async <Data>(
   if (populateCache) {
     if (!error) {
       // Transform the result into data.
-      if (isFunction(populateCache) && originalData) {
+      if (isFunction(populateCache)) {
         data = populateCache(data, originalData)
       }
 

--- a/src/utils/use-swr-config.ts
+++ b/src/utils/use-swr-config.ts
@@ -5,7 +5,7 @@ import { mergeObjects } from './helper'
 import { FullConfiguration, Cache } from '../types'
 
 export const useSWRConfig = <
-  T extends Cache = Map<string, any>
+  T extends Cache = Cache
 >(): FullConfiguration<T> => {
   return mergeObjects(defaultConfig, useContext(SWRConfigContext))
 }

--- a/test/type/config.ts
+++ b/test/type/config.ts
@@ -6,7 +6,6 @@ interface CustomCache<Data = any> extends Cache<Data> {
 }
 
 export function useTestCache() {
-  expectType<Map<string, any>>(useSWRConfig().cache)
-  expectType<Map<string, number>>(useSWRConfig<Map<string, number>>().cache)
+  expectType<Cache>(useSWRConfig().cache)
   expectType<CustomCache>(useSWRConfig<CustomCache>().cache)
 }


### PR DESCRIPTION
With the [2.0.0 update](https://github.com/vercel/swr/releases/tag/2.0.0-beta.0) (https://github.com/vercel/swr/pull/1863), each value in `cache` now holds the current states.

### Type changes

- Reuse the existing `State` type whenever necessary
- Remove `null` from a list of possible values of the cache
- Update the type of `createCacheHelper` to be compatible with `infinite/index.ts`
- Update the default type argument of `useSWRConfig`.
- Update the type of `MutatorOptions[`populateCache`] to allow `undefined` for `currentData` on function argument.

### Non-type changes

- `use-swr.ts`: `isLoading` was not being copied over in `onStateUpdate`. This became obvious as I saw that the `State` type contained `isLoading`.
