### PR TITLE
build: import with-selector with extension from useESE

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useDebugValue } from 'react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/with-selector.js'
 
 import {
   defaultConfig,

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -27,7 +27,7 @@ import type {
   SWRInfiniteFetcher,
   SWRInfiniteCacheValue
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 const INFINITE_PREFIX = '$inf$'
 


### PR DESCRIPTION
useESE 1.1.0 is missing `exports` field which will break esm module resolution

* add extension
* `./shim/with-selector` and `./with-selector` references the same file