### PR TITLE
Bug fixes

### DIFF
--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -42,6 +42,3 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
     state[5]
   ] as const
 }
-
-// Extend a SWR object without triggering its getters.
-export const extendSWR = () => {}

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -1,5 +1,7 @@
 import { SWRGlobalState } from './global-state'
 import { Key, Cache, State, GlobalState } from '../types'
+
+const EMPTY_CACHE = {}
 export const noop = () => {}
 
 // Using noop() as the undefined value as undefined can possibly be replaced
@@ -23,7 +25,6 @@ export const isDocumentDefined = typeof document != STR_UNDEFINED
 export const hasRequestAnimationFrame = () =>
   isWindowDefined && typeof window['requestAnimationFrame'] != STR_UNDEFINED
 
-const EMPTY_CACHE = {}
 export const createCacheHelper = <Data = any, T = State<Data, any>>(
   cache: Cache,
   key: Key
@@ -41,3 +42,6 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
     state[5]
   ] as const
 }
+
+// Extend a SWR object without triggering its getters.
+export const extendSWR = () => {}

--- a/_internal/utils/resolve-args.ts
+++ b/_internal/utils/resolve-args.ts
@@ -19,7 +19,7 @@ export const withArgs = <SWRType>(hook: any) => {
     let next = hook
     const { use } = config
     if (use) {
-      for (let i = use.length; i-- > 0; ) {
+      for (let i = use.length; i--; ) {
         next = use[i](next)
       }
     }

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -30,7 +30,7 @@ import type {
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 const INFINITE_PREFIX = '$inf$'
-const EMPTY_PROMISE = Promise.resolve(UNDEFINED)
+const EMPTY_PROMISE = Promise.resolve() as Promise<undefined>
 
 const getFirstPageKey = (getKey: SWRInfiniteKeyLoader) => {
   return serialize(getKey ? getKey(0, null) : null)[0]

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -30,6 +30,7 @@ import type {
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 const INFINITE_PREFIX = '$inf$'
+const EMPTY_PROMISE = Promise.resolve(UNDEFINED)
 
 const getFirstPageKey = (getKey: SWRInfiniteKeyLoader) => {
   return serialize(getKey ? getKey(0, null) : null)[0]
@@ -192,27 +193,21 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     }, [swr.data])
 
     const mutate = useCallback(
-      (
-        ...args:
-          | []
-          | [undefined | Data[] | Promise<Data[]> | MutatorCallback<Data[]>]
-          | [
-              undefined | Data[] | Promise<Data[]> | MutatorCallback<Data[]>,
-              undefined | boolean | MutatorOptions<Data>
-            ]
-      ) => {
-        const data = args[0]
-
+      // eslint-disable-next-line func-names
+      function (
+        data?: undefined | Data[] | Promise<Data[]> | MutatorCallback<Data[]>,
+        opts?: undefined | boolean | MutatorOptions<Data[]>
+      ) {
         // When passing as a boolean, it's explicitly used to disable/enable
         // revalidation.
         const options =
-          typeof args[1] === 'boolean' ? { revalidate: args[1] } : args[1] || {}
+          typeof opts === 'boolean' ? { revalidate: opts } : opts || {}
 
         // Default to true.
         const shouldRevalidate = options.revalidate !== false
 
         // It is possible that the key is still falsy.
-        if (!infiniteKey) return
+        if (!infiniteKey) return EMPTY_PROMISE
 
         if (shouldRevalidate) {
           if (!isUndefined(data)) {
@@ -225,7 +220,13 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
           }
         }
 
-        return args.length ? swr.mutate(data, shouldRevalidate) : swr.mutate()
+        // We are using `arguments` here because there's no other way around to
+        // tell if an argument is missing or `undefined`. It will be compiled to
+        // `arguments` anyways.
+        // @ts-ignore
+        return arguments.length
+          ? swr.mutate(data, shouldRevalidate)
+          : swr.mutate()
       },
       // swr.mutate is always the same reference
       // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -259,7 +260,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     const setSize = useCallback(
       (arg: number | ((size: number) => number)) => {
         // It is possible that the key is still falsy.
-        if (!infiniteKey) return
+        if (!infiniteKey) return EMPTY_PROMISE
 
         let size
         if (isFunction(arg)) {
@@ -267,7 +268,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
         } else if (typeof arg == 'number') {
           size = arg
         }
-        if (typeof size != 'number') return
+        if (typeof size != 'number') return EMPTY_PROMISE
 
         set({ $len: size })
         lastPageSizeRef.current = size
@@ -296,7 +297,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       get isLoading() {
         return swr.isLoading
       }
-    } as SWRInfiniteResponse<Data, Error>
+    }
   }) as unknown as Middleware
 
 export default withMiddleware(useSWR, infinite) as SWRInfiniteHook

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -220,10 +220,6 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
           }
         }
 
-        // We are using `arguments` here because there's no other way around to
-        // tell if an argument is missing or `undefined`. It will be compiled to
-        // `arguments` anyways.
-        // @ts-ignore
         return arguments.length
           ? swr.mutate(data, shouldRevalidate)
           : swr.mutate()

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -925,6 +925,21 @@ describe('useSWRInfinite', () => {
     await screen.findByText('size: 3')
   })
 
+  it('setSize should return a promise', async () => {
+    let _setSize
+    function Comp() {
+      const { setSize } = useSWRInfinite(
+        () => null,
+        () => createResponse('')
+      )
+
+      _setSize = setSize
+      return null
+    }
+    renderWithConfig(<Comp />)
+    expect(_setSize()).toBeInstanceOf(Promise)
+  })
+
   // https://github.com/vercel/swr/issues/908
   //TODO: This test trigger act warning
   it('should revalidate first page after mutating', async () => {


### PR DESCRIPTION
This PR gets rid of the `as SWRInfiniteResponse<Data, Error>` casting from `swr/infinite`. Also, it ensures that `setSize` and `mutate` returned from `useSWRInfinite` are strictly promises as the typings required (a bug), and fixes `MutatorOptions<Data>` which should be `MutatorOptions<Data[]>` instead.