### PR TITLE
chore: Faster type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,12 +77,12 @@
     "build:internal": "bunchee index.ts --cwd _internal --no-sourcemap",
     "prepublishOnly": "yarn clean && yarn build",
     "publish-beta": "yarn publish --tag beta",
-    "types:check": "tsc --noEmit --project tsconfig.check.json && tsc --noEmit -p test",
+    "types:check": "tsc --noEmit --project tsconfig.check.json",
     "format": "prettier --write ./**/*.{ts,tsx}",
     "lint": "eslint . --ext .ts,.tsx --cache",
     "lint:fix": "yarn lint --fix",
     "coverage": "jest --coverage",
-    "test": "jest"
+    "test": "jest && tsc --noEmit -p test"
   },
   "husky": {
     "hooks": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "swr/immutable": ["./immutable/index.ts"],
       "swr/mutation": ["./mutation/index.ts"]
     },
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "incremental": true
   },
   "include": ["core"],
   "exclude": ["./**/dist", "node_modules", "jest.config.js"],


### PR DESCRIPTION
This PR moves the type tests from pre-commit to tests and only leave basic type checking there, also enables `--incremental` of TypeScript to make local development faster.

Previously a commit takes 10+ seconds and now it takes ~1s.