### PR TITLE
chore: Add test cases for mutate

### DIFF
--- a/test/type/mutator.ts
+++ b/test/type/mutator.ts
@@ -1,4 +1,5 @@
 import { Equal, Expect } from '@type-challenges/utils'
+import useSWR from 'swr'
 
 import {
   MutatorFn,
@@ -54,3 +55,15 @@ export type TestCasesForMutator = [
   Expect<Equal<MutatorWrapper<Case5<{}>>, never>>,
   Expect<Equal<MutatorWrapper<Case6<{}>>, Promise<{} | undefined>>>
 ]
+
+export function useMutatorTypes() {
+  const { mutate } = useSWR<string>('')
+
+  mutate(async () => '1')
+
+  // @ts-expect-error
+  mutate(async () => 1)
+
+  // FIXME: this should work.
+  // mutate(async () => 1, { populateCache: false })
+}


### PR DESCRIPTION
This PR adds test cases for two scenarios mentioned in #1964. For the typing problem, I currently marked it as `FIXME` and it's yet to be fixed:

```ts
// FIXME: this should work.
// mutate(async () => 1, { populateCache: false })
```