### PR TITLE
feat: mutate filter

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -229,7 +229,6 @@ export type KeyedMutator<Data> = (
   data?: Data | Promise<Data> | MutatorCallback<Data>,
   opts?: boolean | MutatorOptions<Data>
 ) => Promise<Data | undefined>
-// Public types
 
 export type SWRConfiguration<
   Data = any,

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -207,10 +207,20 @@ export type Mutator<Data = any> = MutatorWrapper<MutatorFn<Data>>
 
 export interface ScopedMutator<Data = any> {
   <T = Data>(
-    match: ((key: string) => boolean) | Arguments,
+    match: ((key: string) => boolean),
+    data?: T | Promise<T> | MutatorCallback<T>,
+    opts?: boolean | MutatorOptions<Data>
+  ): Promise<Array<T | undefined>>
+  <T = Data>(
+    match: Arguments,
     data?: T | Promise<T> | MutatorCallback<T>,
     opts?: boolean | MutatorOptions<Data>
   ): Promise<T | undefined>
+  <T = Data>(
+    match: ((key: string) => boolean) | Arguments,
+    data?: T | Promise<T> | MutatorCallback<T>,
+    opts?: boolean | MutatorOptions<Data>
+  ): Promise<any>
 }
 
 export type KeyedMutator<Data> = (

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -1,7 +1,8 @@
 import * as revalidateEvents from './constants'
 import { defaultConfig } from './utils/config'
 
-export type Falsy = undefined | null | false
+type Falsy = null | undefined | false
+export type TruthyKey = Exclude<Arguments, Falsy>
 
 export type GlobalState = [
   Record<string, RevalidateCallback[]>, // EVENT_REVALIDATORS
@@ -11,7 +12,7 @@ export type GlobalState = [
   ScopedMutator, // Mutator
   (key: string, value: any, prev: any) => void, // Setter
   (key: string, callback: (current: any, prev: any) => void) => () => void, // Subscriber
-  Set<Omit<Arguments, 'null' | 'undefined'>> // Keys
+  Set<TruthyKey> // Keys
 ]
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 export type BareFetcher<Data = unknown> = (

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -269,7 +269,7 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {
-  keys(): IterableIterator<Key>
+  values(): IterableIterator<State<Data, any>>
   get(key: Key): State<Data> | undefined
   set(key: Key, value: State<Data>): void
   delete(key: Key): void

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -206,20 +206,15 @@ export type Mutator<Data = any> = MutatorWrapper<MutatorFn<Data>>
 
 export interface ScopedMutator<Data = any> {
   <T = Data>(
-    match: (key: string) => boolean,
+    matcher: (key?: Arguments) => boolean,
     data?: T | Promise<T> | MutatorCallback<T>,
     opts?: boolean | MutatorOptions<Data>
   ): Promise<Array<T | undefined>>
   <T = Data>(
-    match: Arguments,
+    key: Arguments,
     data?: T | Promise<T> | MutatorCallback<T>,
     opts?: boolean | MutatorOptions<Data>
   ): Promise<T | undefined>
-  <T = Data>(
-    match: ((key: string) => boolean) | Arguments,
-    data?: T | Promise<T> | MutatorCallback<T>,
-    opts?: boolean | MutatorOptions<Data>
-  ): Promise<any>
 }
 
 export type KeyedMutator<Data> = (

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -10,7 +10,8 @@ export type GlobalState = [
   Record<string, FetcherResponse<any>>, // PRELOAD
   ScopedMutator, // Mutator
   (key: string, value: any, prev: any) => void, // Setter
-  (key: string, callback: (current: any, prev: any) => void) => () => void // Subscriber
+  (key: string, callback: (current: any, prev: any) => void) => () => void, // Subscriber
+  Set<Omit<Arguments, 'null' | 'undefined'>> // Keys
 ]
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 export type BareFetcher<Data = unknown> = (
@@ -207,7 +208,7 @@ export type Mutator<Data = any> = MutatorWrapper<MutatorFn<Data>>
 
 export interface ScopedMutator<Data = any> {
   <T = Data>(
-    match: ((key: string) => boolean),
+    match: (key: string) => boolean,
     data?: T | Promise<T> | MutatorCallback<T>,
     opts?: boolean | MutatorOptions<Data>
   ): Promise<Array<T | undefined>>
@@ -271,7 +272,6 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {
-  keys(): IterableIterator<string>
   get(key: Key): State<Data> | undefined
   set(key: Key, value: State<Data>): void
   delete(key: Key): void

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -180,7 +180,6 @@ export type State<Data = any, Error = any> = {
   error?: Error
   isValidating?: boolean
   isLoading?: boolean
-  key?: Key
 }
 
 export type MutatorFn<Data = any> = (

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -1,9 +1,6 @@
 import * as revalidateEvents from './constants'
 import { defaultConfig } from './utils/config'
 
-type Falsy = null | undefined | false
-export type TruthyKey = Exclude<Arguments, Falsy>
-
 export type GlobalState = [
   Record<string, RevalidateCallback[]>, // EVENT_REVALIDATORS
   Record<string, [number, number]>, // MUTATION: [ts, end_ts]
@@ -11,8 +8,7 @@ export type GlobalState = [
   Record<string, FetcherResponse<any>>, // PRELOAD
   ScopedMutator, // Mutator
   (key: string, value: any, prev: any) => void, // Setter
-  (key: string, callback: (current: any, prev: any) => void) => () => void, // Subscriber
-  Set<TruthyKey> // Keys
+  (key: string, callback: (current: any, prev: any) => void) => () => void // Subscriber
 ]
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 export type BareFetcher<Data = unknown> = (
@@ -184,6 +180,7 @@ export type State<Data = any, Error = any> = {
   error?: Error
   isValidating?: boolean
   isLoading?: boolean
+  key?: Key
 }
 
 export type MutatorFn<Data = any> = (
@@ -272,6 +269,7 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {
+  keys(): IterableIterator<Key>
   get(key: Key): State<Data> | undefined
   set(key: Key, value: State<Data>): void
   delete(key: Key): void

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -1,6 +1,8 @@
 import * as revalidateEvents from './constants'
 import { defaultConfig } from './utils/config'
 
+export type Falsy = undefined | null | false
+
 export type GlobalState = [
   Record<string, RevalidateCallback[]>, // EVENT_REVALIDATORS
   Record<string, [number, number]>, // MUTATION: [ts, end_ts]
@@ -267,6 +269,7 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {
+  keys(): IterableIterator<string>
   get(key: Key): State<Data> | undefined
   set(key: Key, value: State<Data>): void
   delete(key: Key): void

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -269,7 +269,7 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {
-  values(): IterableIterator<State<Data, any>>
+  keys(): IterableIterator<string>
   get(key: Key): State<Data> | undefined
   set(key: Key, value: State<Data>): void
   delete(key: Key): void

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -206,15 +206,8 @@ export type MutatorWrapper<Fn> = Fn extends (
 export type Mutator<Data = any> = MutatorWrapper<MutatorFn<Data>>
 
 export interface ScopedMutator<Data = any> {
-  /** This is used for bound mutator */
-  (
-    key: Key,
-    data?: Data | Promise<Data> | MutatorCallback<Data>,
-    opts?: boolean | MutatorOptions<Data>
-  ): Promise<Data | undefined>
-  /** This is used for global mutator */
-  <T = any>(
-    key: Key,
+  <T = Data>(
+    match: ((key: string) => boolean) | Arguments,
     data?: T | Promise<T> | MutatorCallback<T>,
     opts?: boolean | MutatorOptions<Data>
   ): Promise<T | undefined>
@@ -224,7 +217,6 @@ export type KeyedMutator<Data> = (
   data?: Data | Promise<Data> | MutatorCallback<Data>,
   opts?: boolean | MutatorOptions<Data>
 ) => Promise<Data | undefined>
-
 // Public types
 
 export type SWRConfiguration<

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -43,11 +43,10 @@ export const initCache = <Data = any>(
     // new mutate function.
     const EVENT_REVALIDATORS = {}
 
-    const mutate = (async (...args: Parameters<typeof boundProviderMutate>) => {
-      const boundProviderMutate = internalMutate.bind(UNDEFINED, provider)
-      const res = await boundProviderMutate(...args)
-      return res[0]
-    }) as ScopedMutator<Data>
+    const mutate = internalMutate.bind(
+      UNDEFINED,
+      provider
+    ) as ScopedMutator<Data>
     let unmount = noop
 
     const subscriptions: Record<string, ((current: any, prev: any) => void)[]> =

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -59,16 +59,14 @@ export const initCache = <Data = any>(
       subscriptions[key] = subs
 
       subs.push(callback)
-      return () => {
-        subs.splice(subs.indexOf(callback), 1)
-      }
+      return () => subs.splice(subs.indexOf(callback), 1)
     }
     const setter = (key: string, value: any, prev: any) => {
       provider.set(key, value)
       const subs = subscriptions[key]
       if (subs) {
         for (let i = subs.length; i--; ) {
-          subs[i](value, prev)
+          subs[i](prev, value)
         }
       }
     }

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -83,8 +83,7 @@ export const initCache = <Data = any>(
           {},
           mutate,
           setter,
-          subscribe,
-          new Set()
+          subscribe
         ])
         if (!IS_SERVER) {
           // When listening to the native events for auto revalidations,

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -11,8 +11,7 @@ import {
   RevalidateEvent,
   RevalidateCallback,
   ProviderConfiguration,
-  GlobalState,
-  Arguments
+  GlobalState
 } from '../types'
 
 const revalidateAllKeys = (
@@ -43,16 +42,12 @@ export const initCache = <Data = any>(
     // If there's no global state bound to the provider, create a new one with the
     // new mutate function.
     const EVENT_REVALIDATORS = {}
-    // @ts-ignore
-    const mutate = async (key: Arguments, ...args) => {
-      const res = await internalMutate(
-        provider,
-        key,
-        // @ts-ignore
-        ...args
-      )
+
+    const mutate = (async (...args: Parameters<typeof boundProviderMutate>) => {
+      const boundProviderMutate = internalMutate.bind(UNDEFINED, provider)
+      const res = await boundProviderMutate(...args)
       return res[0]
-    } // as ScopedMutator<Data>
+    }) as ScopedMutator<Data>
     let unmount = noop
 
     const subscriptions: Record<string, ((current: any, prev: any) => void)[]> =

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -83,7 +83,8 @@ export const initCache = <Data = any>(
           {},
           mutate,
           setter,
-          subscribe
+          subscribe,
+          new Set()
         ])
         if (!IS_SERVER) {
           // When listening to the native events for auto revalidations,

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -11,7 +11,8 @@ import {
   RevalidateEvent,
   RevalidateCallback,
   ProviderConfiguration,
-  GlobalState
+  GlobalState,
+  Arguments
 } from '../types'
 
 const revalidateAllKeys = (
@@ -42,10 +43,16 @@ export const initCache = <Data = any>(
     // If there's no global state bound to the provider, create a new one with the
     // new mutate function.
     const EVENT_REVALIDATORS = {}
-    const mutate = internalMutate.bind(
-      UNDEFINED,
-      provider
-    ) as ScopedMutator<Data>
+    // @ts-ignore
+    const mutate = async (key: Arguments, ...args) => {
+      const res = await internalMutate(
+        provider,
+        key,
+        // @ts-ignore
+        ...args
+      )
+      return res[0]
+    } // as ScopedMutator<Data>
     let unmount = noop
 
     const subscriptions: Record<string, ((current: any, prev: any) => void)[]> =

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -13,7 +13,11 @@ export const UNDEFINED = (/*#__NOINLINE__*/ noop()) as undefined
 export const OBJECT = Object
 
 export const isUndefined = (v: any): v is undefined => v === UNDEFINED
-export const isFunction = (v: any): v is Function => typeof v == 'function'
+export const isFunction = <
+  T extends (...args: any[]) => any = (...args: any[]) => any
+>(
+  v: unknown
+): v is T => typeof v == 'function'
 export const isEmptyCache = (v: any): boolean => v === EMPTY_CACHE
 export const mergeObjects = (a: any, b: any) => OBJECT.assign({}, a, b)
 

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -18,8 +18,7 @@ export const isFunction = <
 >(
   v: unknown
 ): v is T => typeof v == 'function'
-export const mergeObjects = (a: any, b: any) => OBJECT.assign({}, a, b)
-export const isEmptyCache = (v: any): boolean => v === EMPTY_CACHE
+export const mergeObjects = (a: any, b?: any) => OBJECT.assign({}, a, b)
 
 const STR_UNDEFINED = 'undefined'
 

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -1,6 +1,7 @@
 import { SWRGlobalState } from './global-state'
 import type { Key, Cache, State, GlobalState } from '../types'
 
+const EMPTY_CACHE = {}
 export const noop = () => {}
 
 // Using noop() as the undefined value as undefined can possibly be replaced
@@ -18,10 +19,7 @@ export const isFunction = <
   v: unknown
 ): v is T => typeof v == 'function'
 export const mergeObjects = (a: any, b: any) => OBJECT.assign({}, a, b)
-export const isEmptyCacheState = (v: State<any, any>): boolean => {
-  const keys = Object.keys(v)
-  return keys.length === 1 && keys[0] === 'key'
-}
+export const isEmptyCache = (v: any): boolean => v === EMPTY_CACHE
 
 const STR_UNDEFINED = 'undefined'
 
@@ -36,14 +34,13 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
   key: Key
 ) => {
   const state = SWRGlobalState.get(cache) as GlobalState
-  const emptyCache = { key }
   return [
     // Getter
-    () => (cache.get(key) || emptyCache) as T,
+    () => (cache.get(key) || EMPTY_CACHE) as T,
     // Setter
     (info: T) => {
-      const prev = cache.get(key) || emptyCache
-      state[5](key as string, mergeObjects(prev, info), prev)
+      const prev = cache.get(key)
+      state[5](key as string, mergeObjects(prev, info), prev || EMPTY_CACHE)
     },
     // Subscriber
     state[6]

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -1,7 +1,6 @@
 import { SWRGlobalState } from './global-state'
-import { Key, Cache, State, GlobalState } from '../types'
+import type { Key, Cache, State, GlobalState } from '../types'
 
-const EMPTY_CACHE = {}
 export const noop = () => {}
 
 // Using noop() as the undefined value as undefined can possibly be replaced
@@ -18,8 +17,11 @@ export const isFunction = <
 >(
   v: unknown
 ): v is T => typeof v == 'function'
-export const isEmptyCache = (v: any): boolean => v === EMPTY_CACHE
 export const mergeObjects = (a: any, b: any) => OBJECT.assign({}, a, b)
+export const isEmptyCacheState = (v: State<any, any>): boolean => {
+  const keys = Object.keys(v)
+  return keys.length === 1 && keys[0] === 'key'
+}
 
 const STR_UNDEFINED = 'undefined'
 
@@ -34,13 +36,14 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
   key: Key
 ) => {
   const state = SWRGlobalState.get(cache) as GlobalState
+  const emptyCache = { key }
   return [
     // Getter
-    () => (cache.get(key) || EMPTY_CACHE) as T,
+    () => (cache.get(key) || emptyCache) as T,
     // Setter
     (info: T) => {
-      const prev = cache.get(key)
-      state[5](key as string, mergeObjects(prev, info), prev || EMPTY_CACHE)
+      const prev = cache.get(key) || emptyCache
+      state[5](key as string, mergeObjects(prev, info), prev)
     },
     // Subscriber
     state[6]

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -49,8 +49,6 @@ export async function internalMutate<Data>(
   const revalidate = options.revalidate !== false
   const rollbackOnError = options.rollbackOnError !== false
 
-  if (!_key) return
-
   const KEYS = (SWRGlobalState.get(cache) as GlobalState)[6]
 
   // If 2nd arg is key filter, return the mutation results of filtered keys
@@ -63,6 +61,7 @@ export async function internalMutate<Data>(
     return await Promise.all(matchedKeys.map(mutateByKey))
   } else {
     const [serializedKey] = serialize(_key)
+    if (!serializedKey) return
     return await mutateByKey(serializedKey)
   }
 

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -4,23 +4,42 @@ import { SWRGlobalState } from './global-state'
 import { getTimestamp } from './timestamp'
 import * as revalidateEvents from '../constants'
 import {
-  Key,
+  // Key,
   Cache,
   MutatorCallback,
   MutatorOptions,
   GlobalState,
-  State
+  State,
+  Falsy,
+  Arguments
 } from '../types'
+
+type KeyFilter = (key?: string) => boolean
 
 export const internalMutate = async <Data>(
   ...args: [
     Cache,
-    Key,
+    KeyFilter | Arguments | Falsy,
     undefined | Data | Promise<Data | undefined> | MutatorCallback<Data>,
     undefined | boolean | MutatorOptions<Data>
   ]
-): Promise<Data | undefined> => {
-  const [cache, _key, _data, _opts] = args
+): Promise<(Data | undefined)[]> => {
+  const [cache, _keyFilter, _data, _opts] = args
+  if (!_keyFilter) return Promise.resolve([])
+  let matchedKeys: string[]
+
+  let keyFilter: KeyFilter
+  if (typeof _keyFilter !== 'function') {
+    const [serializedKey] = serialize(_keyFilter)
+    // keyFilter = (_key?: string) => _key === serializedKey
+    matchedKeys = [serializedKey]
+  } else {
+    keyFilter = _keyFilter as KeyFilter
+    matchedKeys = []
+    for (const _key of cache.keys()) {
+      if (keyFilter(_key)) matchedKeys.push(_key)
+    }
+  }
 
   // When passing as a boolean, it's explicitly used to disable/enable
   // revalidation.
@@ -35,130 +54,128 @@ export const internalMutate = async <Data>(
   const revalidate = options.revalidate !== false
   const rollbackOnError = options.rollbackOnError !== false
 
-  // Serialize key
-  const [key] = serialize(_key)
-  if (!key) return
+  async function mutateByKey(key: string): Promise<Data | undefined> {
+    const [get, set] = createCacheHelper<
+      Data,
+      State<Data, any> & {
+        // The previously committed data.
+        _c?: Data
+      }
+    >(cache, key)
+    const [EVENT_REVALIDATORS, MUTATION, FETCH] = SWRGlobalState.get(
+      cache
+    ) as GlobalState
 
-  const [get, set] = createCacheHelper<
-    Data,
-    State<Data, any> & {
-      // The previously committed data.
-      _c?: Data
+    const revalidators = EVENT_REVALIDATORS[key]
+    const startRevalidate = () => {
+      if (revalidate) {
+        // Invalidate the key by deleting the concurrent request markers so new
+        // requests will not be deduped.
+        delete FETCH[key]
+        if (revalidators && revalidators[0]) {
+          return revalidators[0](revalidateEvents.MUTATE_EVENT).then(
+            () => get().data
+          )
+        }
+      }
+      return get().data
     }
-  >(cache, key)
-  const [EVENT_REVALIDATORS, MUTATION, FETCH] = SWRGlobalState.get(
-    cache
-  ) as GlobalState
 
-  const revalidators = EVENT_REVALIDATORS[key]
-  const startRevalidate = () => {
-    if (revalidate) {
-      // Invalidate the key by deleting the concurrent request markers so new
-      // requests will not be deduped.
-      delete FETCH[key]
-      if (revalidators && revalidators[0]) {
-        return revalidators[0](revalidateEvents.MUTATE_EVENT).then(
-          () => get().data
-        )
+    // If there is no new data provided, revalidate the key with current state.
+    if (args.length < 3) {
+      // Revalidate and broadcast state.
+      return startRevalidate()
+    }
+
+    let data: any = _data
+    let error: unknown
+
+    // Update global timestamps.
+    const beforeMutationTs = getTimestamp()
+    MUTATION[key] = [beforeMutationTs, 0]
+
+    const hasOptimisticData = !isUndefined(optimisticData)
+    const state = get()
+
+    // `displayedData` is the current value on screen. It could be the optimistic value
+    // that is going to be overridden by a `committedData`, or get reverted back.
+    // `committedData` is the validated value that comes from a fetch or mutation.
+    const displayedData = state.data
+    const committedData = isUndefined(state._c) ? displayedData : state._c
+
+    // Do optimistic data update.
+    if (hasOptimisticData) {
+      optimisticData = isFunction(optimisticData)
+        ? optimisticData(committedData)
+        : optimisticData
+
+      // When we set optimistic data, backup the current committedData data in `_c`.
+      set({ data: optimisticData, _c: committedData })
+    }
+
+    if (isFunction(data)) {
+      // `data` is a function, call it passing current cache value.
+      try {
+        data = (data as MutatorCallback<Data>)(committedData)
+      } catch (err) {
+        // If it throws an error synchronously, we shouldn't update the cache.
+        error = err
       }
     }
-    return get().data
-  }
 
-  // If there is no new data provided, revalidate the key with current state.
-  if (args.length < 3) {
-    // Revalidate and broadcast state.
-    return startRevalidate()
-  }
+    // `data` is a promise/thenable, resolve the final data first.
+    if (data && isFunction((data as Promise<Data>).then)) {
+      // This means that the mutation is async, we need to check timestamps to
+      // avoid race conditions.
+      data = await (data as Promise<Data>).catch(err => {
+        error = err
+      })
 
-  let data: any = _data
-  let error: unknown
+      // Check if other mutations have occurred since we've started this mutation.
+      // If there's a race we don't update cache or broadcast the change,
+      // just return the data.
+      if (beforeMutationTs !== MUTATION[key][0]) {
+        if (error) throw error
+        return data
+      } else if (error && hasOptimisticData && rollbackOnError) {
+        // Rollback. Always populate the cache in this case but without
+        // transforming the data.
+        populateCache = true
+        data = committedData
 
-  // Update global timestamps.
-  const beforeMutationTs = getTimestamp()
-  MUTATION[key] = [beforeMutationTs, 0]
-
-  const hasOptimisticData = !isUndefined(optimisticData)
-  const state = get()
-
-  // `displayedData` is the current value on screen. It could be the optimistic value
-  // that is going to be overridden by a `committedData`, or get reverted back.
-  // `committedData` is the validated value that comes from a fetch or mutation.
-  const displayedData = state.data
-  const committedData = isUndefined(state._c) ? displayedData : state._c
-
-  // Do optimistic data update.
-  if (hasOptimisticData) {
-    optimisticData = isFunction(optimisticData)
-      ? optimisticData(committedData)
-      : optimisticData
-
-    // When we set optimistic data, backup the current committedData data in `_c`.
-    set({ data: optimisticData, _c: committedData })
-  }
-
-  if (isFunction(data)) {
-    // `data` is a function, call it passing current cache value.
-    try {
-      data = (data as MutatorCallback<Data>)(committedData)
-    } catch (err) {
-      // If it throws an error synchronously, we shouldn't update the cache.
-      error = err
+        // Reset data to be the latest committed data, and clear the `_c` value.
+        set({ data, _c: UNDEFINED })
+      }
     }
-  }
+    // If we should write back the cache after request.
+    if (populateCache) {
+      if (!error) {
+        // Transform the result into data.
+        if (isFunction(populateCache)) {
+          data = populateCache(data, committedData)
+        }
 
-  // `data` is a promise/thenable, resolve the final data first.
-  if (data && isFunction((data as Promise<Data>).then)) {
-    // This means that the mutation is async, we need to check timestamps to
-    // avoid race conditions.
-    data = await (data as Promise<Data>).catch(err => {
-      error = err
-    })
-
-    // Check if other mutations have occurred since we've started this mutation.
-    // If there's a race we don't update cache or broadcast the change,
-    // just return the data.
-    if (beforeMutationTs !== MUTATION[key][0]) {
-      if (error) throw error
-      return data
-    } else if (error && hasOptimisticData && rollbackOnError) {
-      // Rollback. Always populate the cache in this case but without
-      // transforming the data.
-      populateCache = true
-      data = committedData
-
-      // Reset data to be the latest committed data, and clear the `_c` value.
-      set({ data, _c: UNDEFINED })
-    }
-  }
-
-  // If we should write back the cache after request.
-  if (populateCache) {
-    if (!error) {
-      // Transform the result into data.
-      if (isFunction(populateCache)) {
-        data = populateCache(data, committedData)
+        // Only update cached data if there's no error. Data can be `undefined` here.
+        set({ data, _c: UNDEFINED })
       }
 
-      // Only update cached data if there's no error. Data can be `undefined` here.
-      set({ data, _c: UNDEFINED })
+      // Always update error and original data here.
+      set({ error })
     }
 
-    // Always update error and original data here.
-    set({ error })
+    // Reset the timestamp to mark the mutation has ended.
+    MUTATION[key][1] = getTimestamp()
+
+    // Update existing SWR Hooks' internal states:
+    const res = await startRevalidate()
+
+    // The mutation and revalidation are ended, we can clear it since the data is
+    // not an optimistic value anymore.
+    set({ _c: UNDEFINED })
+
+    // Throw error or return data
+    if (error) throw error
+    return populateCache ? res : data
   }
-
-  // Reset the timestamp to mark the mutation has ended.
-  MUTATION[key][1] = getTimestamp()
-
-  // Update existing SWR Hooks' internal states:
-  const res = await startRevalidate()
-
-  // The mutation and revalidation are ended, we can clear it since the data is
-  // not an optimistic value anymore.
-  set({ _c: UNDEFINED })
-
-  // Throw error or return data
-  if (error) throw error
-  return populateCache ? res : data
+  return await Promise.all(matchedKeys.map(_key => mutateByKey(_key)))
 }

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -9,11 +9,11 @@ import {
   MutatorOptions,
   GlobalState,
   State,
-  Arguments
+  Arguments,
+  TruthyKey
 } from '../types'
 
-type ValidKey = Omit<Arguments, 'null' | 'undefined'>
-type KeyFilter = (key?: ValidKey) => boolean
+type KeyFilter = (key?: TruthyKey) => boolean
 
 export async function internalMutate<Data>(
   cache: Cache,
@@ -66,7 +66,7 @@ export async function internalMutate<Data>(
     return await mutateByKey(serializedKey)
   }
 
-  async function mutateByKey(_k: ValidKey): Promise<Data | undefined> {
+  async function mutateByKey(_k: TruthyKey): Promise<Data | undefined> {
     const [key] = serialize(_k)
     const [get, set] = createCacheHelper<
       Data,

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -4,7 +4,6 @@ import { SWRGlobalState } from './global-state'
 import { getTimestamp } from './timestamp'
 import * as revalidateEvents from '../constants'
 import {
-  // Key,
   Cache,
   MutatorCallback,
   MutatorOptions,
@@ -31,7 +30,6 @@ export const internalMutate = async <Data>(
   let keyFilter: KeyFilter
   if (typeof _keyFilter !== 'function') {
     const [serializedKey] = serialize(_keyFilter)
-    // keyFilter = (_key?: string) => _key === serializedKey
     matchedKeys = [serializedKey]
   } else {
     keyFilter = _keyFilter as KeyFilter

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -15,15 +15,26 @@ import {
 type KeyFilter = (key?: string) => boolean
 
 export async function internalMutate<Data>(
+  cache: Cache,
+  _key: KeyFilter,
+  _data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
+  _opts?: boolean | MutatorOptions<Data>
+): Promise<Array<Data | undefined>>
+export async function internalMutate<Data>(
+  cache: Cache,
+  _key: Arguments,
+  _data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
+  _opts?: boolean | MutatorOptions<Data>
+): Promise<Data | undefined>
+export async function internalMutate<Data>(
   ...args: [
-    Cache,
-    KeyFilter | Arguments,
-    undefined | Data | Promise<Data | undefined> | MutatorCallback<Data>,
-    undefined | boolean | MutatorOptions<Data>
+    cache: Cache,
+    _key: KeyFilter | Arguments,
+    _data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
+    _opts?: boolean | MutatorOptions<Data>
   ]
-): Promise<(Data | undefined)[] | Data | undefined> {
+): Promise<any> {
   const [cache, _key, _data, _opts] = args
-
   // When passing as a boolean, it's explicitly used to disable/enable
   // revalidation.
   const options =

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -13,7 +13,7 @@ import {
   Key
 } from '../types'
 
-type KeyFilter = (key?: Key) => boolean
+type KeyFilter = (key?: Arguments) => boolean
 type MutateState<Data> = State<Data, any> & {
   // The previously committed data.
   _c?: Data

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -58,8 +58,8 @@ export async function internalMutate<Data>(
   if (isFunction(_key)) {
     const keyFilter = _key
     const matchedKeys: Key[] = []
-    for (const originKey of cache.keys()) {
-      if (keyFilter(originKey)) matchedKeys.push(originKey)
+    for (const state of cache.values()) {
+      if (keyFilter(state.key)) matchedKeys.push(state.key)
     }
     return await Promise.all(matchedKeys.map(mutateByKey))
   }

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -60,7 +60,11 @@ export async function internalMutate<Data>(
     const keyFilter = _key
     const matchedKeys: Key[] = []
     for (const key of cache.keys()) {
-      if (keyFilter((cache.get(key) as { _k: any })._k)) {
+      if (
+        // Skip the speical useSWRInfinite keys.
+        !key.startsWith('$inf$') &&
+        keyFilter((cache.get(key) as { _k: Arguments })._k)
+      ) {
         matchedKeys.push(key)
       }
     }

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -54,16 +54,20 @@ export async function internalMutate<Data>(
   const revalidate = options.revalidate !== false
   const rollbackOnError = options.rollbackOnError !== false
 
-  // If 2nd arg is key filter, return the mutation results of filtered keys
+  // If the second argument is a key filter, return the mutation results for all
+  // filtered keys.
   if (isFunction(_key)) {
     const keyFilter = _key
     const matchedKeys: Key[] = []
-    for (const state of cache.values()) {
-      if (keyFilter(state.key)) matchedKeys.push(state.key)
+    for (const key of cache.keys()) {
+      if (keyFilter((cache.get(key) as { _k: any })._k)) {
+        matchedKeys.push(key)
+      }
     }
-    return await Promise.all(matchedKeys.map(mutateByKey))
+    return Promise.all(matchedKeys.map(mutateByKey))
   }
-  return await mutateByKey(_key)
+
+  return mutateByKey(_key)
 
   async function mutateByKey(_k: Key): Promise<Data | undefined> {
     // Serialize key

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -441,9 +441,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // By using `bind` we don't need to modify the size of the rest arguments.
     // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
     // cast it to any for now.
-    async (...args) => {
-      return internalMutate<Data>(cache, keyRef.current, ...args)
-    },
+    internalMutate.bind(UNDEFINED, cache, keyRef.current) as any,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
@@ -460,9 +458,10 @@ export const useSWRHandler = <Data = any, Error = any>(
   })
 
   useIsomorphicLayoutEffect(() => {
-    if (_key && key) KEYS.add(_key)
+    const isTruthyKey = _key && key && !isFunction(_key)
+    if (isTruthyKey) KEYS.add(_key)
     return () => {
-      if (_key && key) KEYS.delete(_key)
+      if (isTruthyKey) KEYS.delete(_key)
     }
   }, [_key])
 

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -164,6 +164,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         ? memorizedSnapshot
         : (memorizedSnapshot = snapshot)
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cache, key])
 
   // Get the current state that SWR should return.

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -442,8 +442,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
     // cast it to any for now.
     async (...args) => {
-      const res = await internalMutate(cache, keyRef.current, ...args)
-      return res[0]
+      return (await internalMutate(cache, keyRef.current, ...args)) as Data
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -67,7 +67,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     keepPreviousData
   } = config
 
-  const [EVENT_REVALIDATORS, MUTATION, FETCH] = SWRGlobalState.get(
+  const [EVENT_REVALIDATORS, MUTATION, FETCH, , , , KEYS] = SWRGlobalState.get(
     cache
   ) as GlobalState
 
@@ -458,6 +458,13 @@ export const useSWRHandler = <Data = any, Error = any>(
       laggyDataRef.current = cachedData
     }
   })
+
+  useIsomorphicLayoutEffect(() => {
+    if (_key && key) KEYS.add(_key)
+    return () => {
+      if (_key && key) KEYS.delete(_key)
+    }
+  }, [_key])
 
   // After mounted or key changed.
   useIsomorphicLayoutEffect(() => {

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -441,7 +441,11 @@ export const useSWRHandler = <Data = any, Error = any>(
     // By using `bind` we don't need to modify the size of the rest arguments.
     // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
     // cast it to any for now.
-    internalMutate.bind(UNDEFINED, cache, keyRef.current) as any,
+    internalMutate.bind(
+      UNDEFINED,
+      cache,
+      (k: string) => k === keyRef.current
+    ) as any,
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -442,7 +442,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
     // cast it to any for now.
     async (...args) => {
-      return (await internalMutate(cache, keyRef.current, ...args)) as Data
+      return internalMutate<Data>(cache, keyRef.current, ...args)
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -443,10 +443,10 @@ export const useSWRHandler = <Data = any, Error = any>(
   // `cache` isn't allowed to change during the lifecycle.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const boundMutate: SWRResponse<Data, Error>['mutate'] = useCallback(
-    // By using `bind` we don't need to modify the size of the rest arguments.
-    // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
-    // cast it to any for now.
-    internalMutate.bind(UNDEFINED, cache, keyRef.current) as any,
+    // Use callback to make sure `keyRef.current` returns latest result every time
+    (...args) => {
+      return internalMutate(cache, keyRef.current, ...args)
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -441,7 +441,10 @@ export const useSWRHandler = <Data = any, Error = any>(
     // By using `bind` we don't need to modify the size of the rest arguments.
     // Due to https://github.com/microsoft/TypeScript/issues/37181, we have to
     // cast it to any for now.
-    internalMutate.bind(UNDEFINED, cache, () => keyRef.current) as any,
+    async (...args) => {
+      const res = await internalMutate(cache, keyRef.current, ...args)
+      return res[0]
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -459,11 +459,8 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   useIsomorphicLayoutEffect(() => {
     const isTruthyKey = _key && key && !isFunction(_key)
-    if (isTruthyKey) KEYS.add(_key)
-    return () => {
-      if (isTruthyKey) KEYS.delete(_key)
-    }
-  }, [_key])
+    if (isTruthyKey && !KEYS.has(_key)) KEYS.add(_key)
+  }, [key])
 
   // After mounted or key changed.
   useIsomorphicLayoutEffect(() => {

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -3,7 +3,6 @@
 
 import { useRef, useCallback } from 'react'
 import useSWR, { SWRConfig } from 'swr'
-import { mergeObjects } from 'swr/_internal'
 import {
   isUndefined,
   isFunction,
@@ -76,7 +75,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     >(cache, infiniteKey)
 
     const getSnapshot = useCallback(() => {
-      const size = isUndefined(get().$len) ? initialSize : get().$len
+      const size = isUndefined(get()._l) ? initialSize : get()._l
       return size
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [cache, infiniteKey, initialSize])
@@ -97,7 +96,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     )
 
     const resolvePageSize = useCallback((): number => {
-      const cachedPageSize = get().$len
+      const cachedPageSize = get()._l
       return isUndefined(cachedPageSize) ? initialSize : cachedPageSize
 
       // `cache` isn't allowed to change during the lifecycle
@@ -115,7 +114,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
       if (infiniteKey) {
         // If the key has been changed, we keep the current page size if persistSize is enabled
-        set({ $len: persistSize ? lastPageSizeRef.current : initialSize })
+        set({ _l: persistSize ? lastPageSizeRef.current : initialSize })
       }
 
       // `initialSize` isn't allowed to change during the lifecycle
@@ -130,7 +129,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       infiniteKey,
       async () => {
         // get the revalidate context
-        const [forceRevalidateAll, originalData] = get().$ctx || []
+        const [forceRevalidateAll, originalData] = get()._i || []
 
         // return an array of page data
         const data: Data[] = []
@@ -173,14 +172,14 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
           if (fn && shouldFetchPage) {
             pageData = await fn(pageArg)
-            setSWRCache(mergeObjects(getSWRCache(), { data: pageData }))
+            setSWRCache({ data: pageData, _k: pageArg })
           }
           data.push(pageData)
           previousPageData = pageData
         }
 
         // once we executed the data fetching based on the context, clear the context
-        set({ $ctx: UNDEFINED })
+        set({ _i: UNDEFINED })
 
         // return the data
         return data
@@ -214,10 +213,10 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
           if (!isUndefined(data)) {
             // We only revalidate the pages that are changed
             const originalData = dataRef.current
-            set({ $ctx: [false, originalData] })
+            set({ _i: [false, originalData] })
           } else {
             // Calling `mutate()`, we revalidate all pages
-            set({ $ctx: [true] })
+            set({ _i: [true] })
           }
         }
 
@@ -267,7 +266,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
         }
         if (typeof size != 'number') return EMPTY_PROMISE
 
-        set({ $len: size })
+        set({ _l: size })
         lastPageSizeRef.current = size
         return mutate(resolvePagesFromCache(size))
       },

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -122,8 +122,9 @@ export interface SWRInfiniteCacheValue<Data = any, Error = any>
   extends State<Data, Error> {
   // We use cache to pass extra info (context) to fetcher so it can be globally
   // shared. The key of the context data is based on the first page key.
-  $ctx?: [boolean] | [boolean, Data[] | undefined]
+  _i?: [boolean] | [boolean, Data[] | undefined]
   // Page size is also cached to share the page data between hooks with the
   // same key.
-  $len?: number
+  _l?: number
+  _k?: Arguments
 }

--- a/test/type/mutator.ts
+++ b/test/type/mutator.ts
@@ -71,18 +71,18 @@ export function useMutatorTypes() {
 
 export function useConfigMutate() {
   const { mutate } = useSWRConfig()
-  mutate<number>(key => {
-    expectType<string>(key)
-    return key.startsWith('swr')
-  }, data => {
-    expectType<number | undefined>(data)
-    return 0
-  })
-  mutate<string>(
-    'string',
+  mutate<number>(
+    (key: string) => {
+      expectType<string>(key)
+      return key.startsWith('swr')
+    },
     data => {
-      expectType<string | undefined>(data)
-      return '0'
+      expectType<number | undefined>(data)
+      return 0
     }
   )
+  mutate<string>('string', data => {
+    expectType<string | undefined>(data)
+    return '0'
+  })
 }

--- a/test/type/mutator.ts
+++ b/test/type/mutator.ts
@@ -71,15 +71,42 @@ export function useMutatorTypes() {
 
 export function useConfigMutate() {
   const { mutate } = useSWRConfig()
-  mutate<number>(
-    (key: string) => {
-      expectType<string>(key)
-      return key.startsWith('swr')
-    },
-    data => {
-      expectType<number | undefined>(data)
-      return 0
-    }
+  expect<Promise<Array<any>>>(
+    mutate(
+      key => {
+        expectType<string>(key)
+        return key.startsWith('swr')
+      },
+      data => {
+        expectType<number | undefined>(data)
+        return 0
+      }
+    )
+  )
+
+  expect<Promise<any>>(
+    mutate('string', data => {
+      expectType<string | undefined>(data)
+      return '0'
+    })
+  )
+  expect<Promise<Array<number | undefined>>>(
+    mutate<number>(
+      key => {
+        expectType<string>(key)
+        return key.startsWith('swr')
+      },
+      data => {
+        expectType<number | undefined>(data)
+        return 0
+      }
+    )
+  )
+  expect<Promise<string | undefined>>(
+    mutate<string>('string', data => {
+      expectType<string | undefined>(data)
+      return '0'
+    })
   )
   mutate<string>('string', data => {
     expectType<string | undefined>(data)

--- a/test/type/mutator.ts
+++ b/test/type/mutator.ts
@@ -1,5 +1,5 @@
 import { Equal, Expect } from '@type-challenges/utils'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 
 import {
   MutatorFn,
@@ -8,6 +8,7 @@ import {
   Mutator,
   MutatorWrapper
 } from '../../_internal/types'
+import { expectType } from './utils'
 
 type Case1<Data = any> = MutatorFn<Data>
 type Case2<Data = any> = (
@@ -66,4 +67,22 @@ export function useMutatorTypes() {
 
   // FIXME: this should work.
   // mutate(async () => 1, { populateCache: false })
+}
+
+export function useConfigMutate() {
+  const { mutate } = useSWRConfig()
+  mutate<number>(key => {
+    expectType<string>(key)
+    return key.startsWith('swr')
+  }, data => {
+    expectType<number | undefined>(data)
+    return 0
+  })
+  mutate<string>(
+    'string',
+    data => {
+      expectType<string | undefined>(data)
+      return '0'
+    }
+  )
 }

--- a/test/type/mutator.ts
+++ b/test/type/mutator.ts
@@ -6,7 +6,8 @@ import {
   Key,
   MutatorCallback,
   Mutator,
-  MutatorWrapper
+  MutatorWrapper,
+  Arguments
 } from '../../_internal/types'
 import { expectType } from './utils'
 
@@ -74,8 +75,8 @@ export function useConfigMutate() {
   expect<Promise<Array<any>>>(
     mutate(
       key => {
-        expectType<string>(key)
-        return key.startsWith('swr')
+        expectType<Arguments>(key)
+        return typeof key === 'string' && key.startsWith('swr')
       },
       data => {
         expectType<number | undefined>(data)
@@ -90,11 +91,12 @@ export function useConfigMutate() {
       return '0'
     })
   )
+
   expect<Promise<Array<number | undefined>>>(
     mutate<number>(
       key => {
-        expectType<string>(key)
-        return key.startsWith('swr')
+        expectType<Arguments>(key)
+        return typeof key === 'string' && key.startsWith('swr')
       },
       data => {
         expectType<number | undefined>(data)
@@ -102,12 +104,14 @@ export function useConfigMutate() {
       }
     )
   )
+
   expect<Promise<string | undefined>>(
     mutate<string>('string', data => {
       expectType<string | undefined>(data)
       return '0'
     })
   )
+
   mutate<string>('string', data => {
     expectType<string | undefined>(data)
     return '0'

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -260,7 +260,6 @@ describe('useSWR - cache provider', () => {
             }
             return v
           },
-          keys: () => parentCache_.keys(),
           delete: k => parentCache_.delete(k)
         }
       }

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -260,6 +260,7 @@ describe('useSWR - cache provider', () => {
             }
             return v
           },
+          keys: () => parentCache_.keys(),
           delete: k => parentCache_.delete(k)
         }
       }

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -251,6 +251,7 @@ describe('useSWR - cache provider', () => {
       provider: parentCache_ => {
         parentCache = parentCache_
         return {
+          keys: () => parentCache.keys(),
           set: (k, v) => parentCache_.set(k, v),
           get: k => {
             // We append `-extended` to the value returned by the parent cache.

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -251,7 +251,6 @@ describe('useSWR - cache provider', () => {
       provider: parentCache_ => {
         parentCache = parentCache_
         return {
-          values: () => parentCache.values(),
           set: (k, v) => parentCache_.set(k, v),
           get: k => {
             // We append `-extended` to the value returned by the parent cache.

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -251,6 +251,7 @@ describe('useSWR - cache provider', () => {
       provider: parentCache_ => {
         parentCache = parentCache_
         return {
+          values: () => parentCache.values(),
           set: (k, v) => parentCache_.set(k, v),
           get: k => {
             // We append `-extended` to the value returned by the parent cache.

--- a/test/use-swr-context-config.test.tsx
+++ b/test/use-swr-context-config.test.tsx
@@ -9,7 +9,7 @@ describe('useSWR - context configs', () => {
     const fetcher = () => createResponse('data')
     const key = createKey()
 
-    await act(() => mutate(key, prefetch))
+    await act(async () => { await mutate(key, prefetch) })
 
     function Page() {
       const { data } = useSWR(key, fetcher)

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -866,7 +866,7 @@ describe('useSWRInfinite', () => {
           <div
             onClick={() => {
               // load next page
-              // @ts-ignore
+              // @ts-expect-error
               setSize('2')
             }}
           >

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -432,34 +432,36 @@ describe('useSWR', () => {
     await act(() => sleep(20))
     screen.getByText('data: 1')
   })
+
   it('Nested SWR hook should only do loading once', async () => {
     const key = createKey()
     let count = 0
     const ChildComponent = () => {
-      const { data } = useSWR(key, (_) => createResponse(_, { delay: 100 }))
-      return (
-        <div id="child">
-          {data}
-        </div>
-      )
+      const { data } = useSWR(key, _ => createResponse(_, { delay: 100 }))
+      return <div id="child">{data}</div>
     }
     const NestedRender = () => {
-      const { data, isValidating } = useSWR(key, (_) => createResponse(_, { delay: 50 }))
+      const { data, isValidating } = useSWR(key, _ =>
+        createResponse(_, { delay: 50 })
+      )
       if (isValidating) {
         return <div>loading</div>
       }
       return (
         <div>
           <div id="parent">{data}</div>
-          <ChildComponent></ChildComponent>
+          <ChildComponent />
         </div>
       )
     }
     const Page = () => (
-      <Profiler id={key} onRender={() => {
-        count += 1
-      }}>
-        <NestedRender></NestedRender>
+      <Profiler
+        id={key}
+        onRender={() => {
+          count += 1
+        }}
+      >
+        <NestedRender />
       </Profiler>
     )
     renderWithConfig(<Page />)

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1495,7 +1495,8 @@ describe('useSWR - local mutation', () => {
 
   it('should support key filter as first argument', async () => {
     const key = createKey()
-    let mutationResults = []
+    const mutationAllResults = []
+    const mutationOneResults = []
 
     function Page() {
       const { data: data1 } = useSWR(key + 'first', v => v)
@@ -1506,23 +1507,25 @@ describe('useSWR - local mutation', () => {
           <span
             data-testid="mutator-filter-all"
             onClick={async () => {
-              mutationResults = await mutate(
+              const res = await mutate(
                 k => k.startsWith(key),
                 data => {
                   return 'value-' + data.replace(key, '')
                 },
                 false
               )
+              mutationAllResults.push(...res)
             }}
           />
           <span
             data-testid="mutator-filter-one"
             onClick={async () => {
-              mutationResults = await mutate(
+              const res = await mutate(
                 k => k.includes('first'),
                 () => 'value-first-g0',
                 false
               )
+              mutationOneResults.push(...res)
             }}
           />
           <p>first:{data1}</p>
@@ -1539,17 +1542,20 @@ describe('useSWR - local mutation', () => {
 
     // filter and mutate `first` and `second`
     fireEvent.click(screen.getByTestId('mutator-filter-all'))
+    await nextTick()
 
     await screen.findByText('first:value-first')
     await screen.findByText('second:value-second')
 
-    expect(mutationResults).toEqual(['value-first', 'value-second'])
+    expect(mutationAllResults).toEqual(['value-first', 'value-second'])
 
     // only filter and mutate `first`
     fireEvent.click(screen.getByTestId('mutator-filter-one'))
+    await nextTick()
+
     await screen.findByText('first:value-first-g0')
     await screen.findByText('second:value-second')
 
-    expect(mutationResults).toEqual(['value-first-g0'])
+    expect(mutationOneResults).toEqual(['value-first-g0'])
   })
 })

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -59,7 +59,7 @@ describe('useSWR - local mutation', () => {
             setJob('chef')
           }}
         >
-          {name}:{job}
+          {`${name}:${job}`}
         </span>
       )
     }
@@ -293,9 +293,9 @@ describe('useSWR - local mutation', () => {
 
     renderWithConfig(<App />)
 
-    const increment = jest.fn(currentValue =>
-      currentValue == null ? undefined : currentValue + 1
-    )
+    const increment = jest.fn(currentValue => {
+      return currentValue == null ? undefined : currentValue + 1
+    })
 
     const key = createKey()
     await mutate(key, increment, false)
@@ -329,11 +329,12 @@ describe('useSWR - local mutation', () => {
     expect(globalMutate(null, Promise.resolve('data'))).resolves.toBe(undefined)
 
     // throw the error if promise rejected
+    const e = new Error('error')
     expect(
       globalMutate(() => {
-        throw new Error('error')
+        throw e
       }, Promise.resolve('data'))
-    ).resolves.toBe(undefined)
+    ).rejects.toEqual(e)
   })
 
   it('should get bound mutate from useSWR', async () => {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -334,7 +334,7 @@ describe('useSWR - local mutation', () => {
       globalMutate(() => {
         throw e
       }, Promise.resolve('data'))
-    ).rejects.toEqual(e)
+    ).resolves.toEqual([])
   })
 
   it('should get bound mutate from useSWR', async () => {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1508,7 +1508,7 @@ describe('useSWR - local mutation', () => {
             data-testid="mutator-filter-all"
             onClick={async () => {
               const res = await mutate(
-                k => k.startsWith(key),
+                k => typeof k === 'string' && k.startsWith(key),
                 data => {
                   return 'value-' + data.replace(key, '')
                 },
@@ -1521,7 +1521,7 @@ describe('useSWR - local mutation', () => {
             data-testid="mutator-filter-one"
             onClick={async () => {
               const res = await mutate(
-                k => k.includes('first'),
+                k => typeof k === 'string' && k.includes('first'),
                 () => 'value-first-g0',
                 false
               )

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -334,7 +334,7 @@ describe('useSWR - local mutation', () => {
       globalMutate(() => {
         throw e
       }, Promise.resolve('data'))
-    ).resolves.toEqual([])
+    ).rejects.toEqual(e)
   })
 
   it('should get bound mutate from useSWR', async () => {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1608,4 +1608,38 @@ describe('useSWR - local mutation', () => {
 
     expect(mutationOneResults).toEqual([undefined])
   })
+
+  it('should pass the original key to the key filter', async () => {
+    const key = createKey()
+    const keys = []
+
+    function Page() {
+      useSWR([key, 'first'])
+      useSWR([key, 'second'])
+      useSWR(key)
+      const { mutate } = useSWRConfig()
+      return (
+        <span
+          data-testid="mutator-filter-all"
+          onClick={() => {
+            mutate(
+              k => {
+                keys.push(k)
+                return false
+              },
+              undefined,
+              false
+            )
+          }}
+        />
+      )
+    }
+    renderWithConfig(<Page />)
+
+    // add and mutate `first` and `second`
+    fireEvent.click(screen.getByTestId('mutator-filter-all'))
+    await nextTick()
+
+    expect(keys).toEqual([[key, 'first'], [key, 'second'], key])
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictBindCallApply": true,
+    "downlevelIteration": true,
     "outDir": "./dist",
     "rootDir": "core",
     "strict": true,


### PR DESCRIPTION
Closes #1946.

## Description

The global `mutate` API (imported directly from SWR or returned by `useSWRConfig`) can now accept a filter function, to match multiple keys for mutating:

```js
await mutate(
  key => typeof key === 'string' && key.startsWith('/api/'),
  undefined, // newData | (data => newData)
  false,     // shouldRevalidate = true
)
```

## Breaking Changes

- This deprecates the use case of accepting a function that returns a key.
- The `Cache` interface now requires a `keys()` method that returns all keys in the cache object, similar to the JavaScript `Map` instances.

## Usage

(See #1946)
