### PR TITLE
chore: add engine field to limit pnpm version

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,5 @@
 {
   "buildCommand": "build",
   "sandboxes": ["swr-basic-p7dg6", "swr-states-4une7", "swr-infinite-jb5bm", "swr-ssr-j9b2y"],
-  "node": "14"
+  "node": "16"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "build",
   "sandboxes": ["swr-basic-p7dg6", "swr-states-4une7", "swr-infinite-jb5bm", "swr-ssr-j9b2y"],
-  "node": "16"
+  "node": "16",
+  "install": "corepack prepare pnpm@7 --activate"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -2,5 +2,5 @@
   "buildCommand": "build",
   "sandboxes": ["swr-basic-p7dg6", "swr-states-4une7", "swr-infinite-jb5bm", "swr-ssr-j9b2y"],
   "node": "16",
-  "install": "corepack prepare pnpm@7 --activate"
+  "install": "pnpm i -g pnpm@7"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,6 +1,6 @@
 {
-  "buildCommand": "build",
   "sandboxes": ["swr-basic-p7dg6", "swr-states-4une7", "swr-infinite-jb5bm", "swr-ssr-j9b2y"],
   "node": "16",
-  "install": "pnpm i -g pnpm@7"
+  "installCommand": "csb:install",
+  "buildCommand": "csb:build"
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 14
 
       - uses: pnpm/action-setup@v2.0.1
         name: Install pnpm

--- a/package.json
+++ b/package.json
@@ -142,6 +142,10 @@
     "arrowParens": "avoid",
     "trailingComma": "none"
   },
+  "engines": {
+    "node": ">= 14",
+    "pnpm": ">= 7"
+  },
   "dependencies": {
     "use-sync-external-store": "^1.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   },
   "engines": {
     "node": ">= 14",
-    "pnpm": ">= 7"
+    "pnpm": ">= 6"
   },
   "dependencies": {
     "use-sync-external-store": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "trailingComma": "none"
   },
   "engines": {
-    "node": ">= 14",
     "pnpm": "7"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "homepage": "https://swr.vercel.app",
   "license": "MIT",
   "scripts": {
-    "csb:install": "pnpm i -g pnpm",
+    "csb:install": "pnpm i -g pnpm@7",
     "csb:build": "pnpm install && pnpm build",
     "clean": "turbo run clean",
     "build": "turbo run build",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
   "homepage": "https://swr.vercel.app",
   "license": "MIT",
   "scripts": {
+    "csb:install": "pnpm i -g pnpm",
+    "csb:build": "pnpm install && pnpm build",
     "clean": "turbo run clean",
     "build": "turbo run build",
     "watch": "turbo run watch --parallel",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
   },
   "engines": {
     "node": ">= 14",
-    "pnpm": ">= 6"
+    "pnpm": "7"
   },
   "dependencies": {
     "use-sync-external-store": "^1.1.0"


### PR DESCRIPTION
We're using pnpm 7, and pnpm v6 will generate different lock files. Add engine field to package.json for pnpm version checking