### PR TITLE
BREAKING: rename SWRConfig.default to SWRConfig.defaultValue

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -599,10 +599,10 @@ export const useSWRHandler = <Data = any, Error = any>(
   } as SWRResponse<Data, Error>
 }
 
-export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'default', {
+export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'defaultValue', {
   value: defaultConfig
 }) as typeof ConfigProvider & {
-  default: FullConfiguration
+  defaultValue: FullConfiguration
 }
 
 export const unstable_serialize = (key: Key) => serialize(key)[0]

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -44,7 +44,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
   (
     getKey: SWRInfiniteKeyLoader,
     fn: BareFetcher<Data> | null,
-    config: Omit<typeof SWRConfig.default, 'fetcher'> &
+    config: Omit<typeof SWRConfig.defaultValue, 'fetcher'> &
       Omit<SWRInfiniteConfiguration<Data, Error>, 'fetcher'>
   ): SWRInfiniteResponse<Data, Error> => {
     const didMountRef = useRef<boolean>(false)

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -264,7 +264,7 @@ describe('useSWR - cache provider', () => {
         }
       }
     })
-    expect(parentCache).toBe(SWRConfig.default.cache)
+    expect(parentCache).toBe(SWRConfig.defaultValue.cache)
 
     screen.getByText('undefined')
     await screen.findByText('data-extended')
@@ -351,7 +351,7 @@ describe('useSWR - global cache', () => {
     }
 
     renderWithGlobalCache(<Page />)
-    expect(localCache).toBe(SWRConfig.default.cache)
+    expect(localCache).toBe(SWRConfig.defaultValue.cache)
     expect(localMutate).toBe(globalMutate)
   })
 

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -89,7 +89,7 @@ describe('useSWR - configs', () => {
   })
 
   it('should expose default config as static property on SWRConfig', () => {
-    expect(SWRConfig.default).toBeDefined()
+    expect(SWRConfig.defaultValue).toBeDefined()
   })
 
   it('should expose the default config from useSWRConfig', () => {
@@ -101,7 +101,7 @@ describe('useSWR - configs', () => {
     }
 
     renderWithGlobalCache(<Page />)
-    expect(SWRConfig.default).toEqual(config)
+    expect(SWRConfig.defaultValue).toEqual(config)
   })
 
   it('should expose the correctly extended config from useSWRConfig', () => {


### PR DESCRIPTION
`SWRConfig.default` was introduced for accessing default value, though `default` is kinda confused property that could be default of anything or like the `default` property of an ES module.

Now rename it to `SWRConfig.defaultValue`, and document in the swr v2 docs later