### PR TITLE
feat: swr/preload

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
       "require": "./immutable/dist/index.js",
       "types": "./immutable/dist/immutable/index.d.ts"
     },
+    "./preload": {
+      "import": "./preload/dist/index.mjs",
+      "module": "./preload/dist/index.esm.js",
+      "require": "./preload/dist/index.js",
+      "types": "./preload/dist/preload/index.d.ts"
+    },
     "./mutation": {
       "import": "./mutation/dist/index.mjs",
       "module": "./mutation/dist/index.esm.js",
@@ -51,11 +57,13 @@
     "core/dist/**",
     "infinite/dist/**",
     "immutable/dist/**",
+    "preload/dist/**",
     "mutation/dist/**",
     "_internal/dist/**",
     "core/package.json",
     "infinite/package.json",
     "immutable/package.json",
+    "preload/package.json",
     "mutation/package.json",
     "_internal/package.json",
     "package.json"
@@ -73,11 +81,13 @@
     "watch:core": "turbo run watch --filter=swr-core",
     "watch:infinite": "turbo run watch --filter=swr-inifinite",
     "watch:immutable": "turbo run watch --filter=swr-immutable",
+    "watch:preload": "turbo run watch --filter=swr-preload",
     "watch:mutation": "turbo run watch --filter=swr-mutation",
     "watch:internal": "turbo run watch --filter=swr-internal",
     "build:core": "turbo run build --filter=swr-core",
     "build:infinite": "turbo run build --filter=swr-infinite",
     "build:immutable": "turbo run build --filter=swr-immutable",
+    "build:preload": "turbo run build --filter=swr-preload",
     "build:mutation": "turbo run build --filter=swr-mutation",
     "build:internal": "turbo run build --filter=swr-internal",
     "prepublishOnly": "pnpm clean && pnpm build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - 'immutable'
   - 'infinite'
   - 'mutation'
+  - 'preload'

--- a/preload/index.ts
+++ b/preload/index.ts
@@ -1,0 +1,31 @@
+import useSWR, { Middleware, unstable_serialize, Key, BareFetcher } from 'swr'
+import { withMiddleware } from 'swr/_internal'
+
+const preloadMap = new Map<string, Promise<any>>()
+
+export const prefetch = (key: Key, fetcher: BareFetcher<any>) => {
+  const promise = fetcher(key)
+  const keyString = unstable_serialize(key)
+  preloadMap.set(keyString, promise)
+  return promise
+}
+
+export const preload: Middleware = useSWRNext => (key, fetcher_, config) => {
+  const fetcher =
+    fetcher_ === null
+      ? null
+      : async (...args: any[]) => {
+          const keyString = unstable_serialize(key)
+          const promise = preloadMap.get(keyString)
+          if (promise) {
+            await promise
+            preloadMap.delete(keyString)
+            return promise
+          }
+          return fetcher_(...args)
+        }
+
+  return useSWRNext(key, fetcher, config)
+}
+
+export default withMiddleware(useSWR, preload)

--- a/preload/package.json
+++ b/preload/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "swr-preload",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "module": "./dist/index.esm.js",
+  "types": "./dist/preload",
+  "exports": "./dist/index.mjs",
+  "private": true,
+  "scripts": {
+    "watch": "bunchee index.ts --no-sourcemap -w",
+    "build": "bunchee index.ts --no-sourcemap",
+    "types:check": "tsc --noEmit",
+    "clean": "rimraf dist"
+  },
+  "peerDependencies": {
+    "swr": "*",
+    "react": "*"
+  }
+}

--- a/preload/tsconfig.json
+++ b/preload/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "outDir": "./dist"
+  },
+  "include": ["./*.ts"]
+}

--- a/test/use-swr-preload.test.tsx
+++ b/test/use-swr-preload.test.tsx
@@ -1,0 +1,93 @@
+import { screen } from '@testing-library/react'
+import React, { Suspense } from 'react'
+import useSWR, { prefetch } from 'swr/preload'
+import { createKey, createResponse, renderWithConfig, sleep } from './utils'
+
+describe('useSWR - preload', () => {
+  it('should be able to prefetch the fetcher function', async () => {
+    const key = createKey()
+
+    let count = 0
+
+    const fetcher = () => {
+      ++count
+      return createResponse('foo')
+    }
+
+    prefetch(key, fetcher)
+
+    expect(count).toBe(1)
+
+    function Page() {
+      const { data } = useSWR(key, fetcher)
+      return <div>data:{data}</div>
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data:foo')
+    expect(count).toBe(1)
+  })
+
+  it('should be able to prefetch the fetcher function with the suspense mode', async () => {
+    const key = createKey()
+
+    let count = 0
+
+    const fetcher = () => {
+      ++count
+      return createResponse('foo')
+    }
+
+    prefetch(key, fetcher)
+
+    expect(count).toBe(1)
+
+    function Page() {
+      const { data } = useSWR(key, fetcher, { suspense: true })
+      return <div>data:{data}</div>
+    }
+
+    renderWithConfig(
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
+    )
+    await screen.findByText('data:foo')
+    expect(count).toBe(1)
+  })
+
+  it('should be able to avoid suspense waterfall by prefetching the resources', async () => {
+    const key1 = createKey()
+    const key2 = createKey()
+
+    const response1 = createResponse('foo', { delay: 50 })
+    const response2 = createResponse('bar', { delay: 50 })
+
+    const fetcher1 = () => response1
+    const fetcher2 = () => response2
+
+    prefetch(key1, fetcher1)
+    prefetch(key2, fetcher2)
+
+    function Page() {
+      const { data: data1 } = useSWR(key1, fetcher1, { suspense: true })
+      const { data: data2 } = useSWR(key2, fetcher2, { suspense: true })
+
+      return (
+        <div>
+          data:{data1}:{data2}
+        </div>
+      )
+    }
+
+    renderWithConfig(
+      <Suspense fallback="loading">
+        <Page />
+      </Suspense>
+    )
+    screen.getByText('loading')
+    // Should avoid waterfall(50ms + 50ms)
+    await sleep(70)
+    screen.getByText('data:foo:bar')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
       "swr": ["./core/index.ts"],
       "swr/infinite": ["./infinite/index.ts"],
       "swr/immutable": ["./immutable/index.ts"],
+      "swr/prelaod": ["./preload/index.ts"],
       "swr/mutation": ["./mutation/index.ts"]
     },
     "typeRoots": ["./node_modules/@types"],


### PR DESCRIPTION
This is an experimental implementation to preload fetcher functions. The following is an example.

```tsx
import useSWR, { prefetch } from 'swr/preload'

// before rendering
prefetch('/api/user', fetcher);

const Page = () => {
  const { data } = useSWR('/api/user', fetcher);
  return <div>...</div>
}
```

The preload function is necessary to avoid waterfall problems with the suspense mode.
Currently, this is implemented as middleware, but the API might be changed before merging.
The limitation of the current implementation is that we have to use `useSWR` from `swr/preload`.

The following has the waterfall problem.

```tsx
import useSWR, { prefetch } from 'swr/preload'

const Page = () => {
  // this suspends the first rendering
  const { data: user } = useSWR('/api/user', fetcher, { suspense: true });
  // this start fetching only after `/api/user` has been fetched
  const { data: movies } = useSWR('/api/movies', fetcher, { suspense: true });
  return <div>...</div>
}
```

To avoid that, we should preload fetcher functions. `prefetch` is the function for it.

```tsx
import useSWR, { prefetch } from 'swr/preload'

// before rendering
prefetch('/api/user', fetcher);
prefetch('/api/movies', fetcher);

const Page = () => {
  // These fetcher functions have been already fetched by calling `prefetch`.
  const { data: user } = useSWR('/api/user', fetcher, { suspense: true });
  const { data: movies } = useSWR('/api/movies', fetcher, { suspense: true });
  return <div>...</div>
}
```