### PR TITLE
test: fix all act warnings

### DIFF
--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -941,22 +941,15 @@ describe('useSWRInfinite', () => {
   })
 
   // https://github.com/vercel/swr/issues/908
-  //TODO: This test trigger act warning
   it('should revalidate first page after mutating', async () => {
-    let renderedData
     const key = createKey()
     let v = 'old'
 
     function Page() {
-      const {
-        data,
-        size,
-        mutate: boundMutate
-      } = useSWRInfinite(
+      const { data, mutate: boundMutate } = useSWRInfinite(
         i => [key, i],
-        () => v
+        () => createResponse(v)
       )
-      renderedData = data
 
       return (
         <div>
@@ -968,19 +961,16 @@ describe('useSWRInfinite', () => {
           >
             mutate
           </button>
-          <p>size=${size}</p>
+          <p>data:{data}</p>
         </div>
       )
     }
 
     renderWithConfig(<Page />)
 
-    await screen.findByText('mutate')
-    await nextTick()
-    expect(renderedData).toEqual(['old'])
+    await screen.findByText('data:old')
     fireEvent.click(screen.getByText('mutate'))
-    await nextTick()
-    expect(renderedData).toEqual(['new'])
+    await screen.findByText('data:new')
   })
 
   it('should reuse cached value for new pages', async () => {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1122,13 +1122,13 @@ describe('useSWR - local mutation', () => {
 
     renderWithConfig(<Page />)
 
-    await sleep(20)
+    await act(() => sleep(20))
     await executeWithoutBatching(() =>
       mutate(createResponse('end', { delay: 50 }), {
         optimisticData: 'start'
       })
     )
-    await sleep(20)
+    await act(() => sleep(20))
 
     // There can never be any changes during a mutation — it should be atomic.
     expect(renderedData.indexOf('end') - renderedData.indexOf('start')).toEqual(


### PR DESCRIPTION
Currently, there are some act warnings in tests (refs. https://github.com/vercel/swr/runs/6850718532?check_suite_focus=true), so I've fixed them.
