### PR TITLE
Use consistent typing imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,7 @@
     "@typescript-eslint/no-var-requires": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/consistent-type-imports": [2, {"prefer": "type-imports"}],
     "@typescript-eslint/ban-types": 0,
     "react-hooks/rules-of-hooks": 2,
     "react-hooks/exhaustive-deps": 1,

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -1,5 +1,5 @@
-import * as revalidateEvents from './constants'
-import { defaultConfig } from './utils/config'
+import type * as revalidateEvents from './constants'
+import type { defaultConfig } from './utils/config'
 
 export type GlobalState = [
   Record<string, RevalidateCallback[]>, // EVENT_REVALIDATORS

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -5,7 +5,7 @@ import { internalMutate } from './mutate'
 import { SWRGlobalState } from './global-state'
 import * as revalidateEvents from '../constants'
 
-import {
+import type {
   Cache,
   ScopedMutator,
   RevalidateEvent,

--- a/_internal/utils/config-context.ts
+++ b/_internal/utils/config-context.ts
@@ -1,17 +1,11 @@
-import {
-  createContext,
-  createElement,
-  useContext,
-  useState,
-  FC,
-  PropsWithChildren
-} from 'react'
+import type { FC, PropsWithChildren } from 'react'
+import { createContext, createElement, useContext, useState } from 'react'
 import { cache as defaultCache } from './config'
 import { initCache } from './cache'
 import { mergeConfigs } from './merge-config'
 import { UNDEFINED, mergeObjects, isFunction } from './helper'
 import { useIsomorphicLayoutEffect } from './env'
-import {
+import type {
   SWRConfiguration,
   FullConfiguration,
   ProviderConfiguration,

--- a/_internal/utils/global-state.ts
+++ b/_internal/utils/global-state.ts
@@ -1,4 +1,4 @@
-import { Cache, GlobalState } from '../types'
+import type { Cache, GlobalState } from '../types'
 
 // Global state used to deduplicate requests and store listeners
 export const SWRGlobalState = new WeakMap<Cache, GlobalState>()

--- a/_internal/utils/merge-config.ts
+++ b/_internal/utils/merge-config.ts
@@ -1,5 +1,5 @@
 import { mergeObjects } from './helper'
-import { FullConfiguration } from '../types'
+import type { FullConfiguration } from '../types'
 
 export const mergeConfigs = (
   a: Partial<FullConfiguration>,

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -3,7 +3,7 @@ import { createCacheHelper, isFunction, isUndefined, UNDEFINED } from './helper'
 import { SWRGlobalState } from './global-state'
 import { getTimestamp } from './timestamp'
 import * as revalidateEvents from '../constants'
-import {
+import type {
   Cache,
   MutatorCallback,
   MutatorOptions,

--- a/_internal/utils/normalize-args.ts
+++ b/_internal/utils/normalize-args.ts
@@ -1,6 +1,6 @@
 import { isFunction } from './helper'
 
-import { Key, Fetcher, SWRConfiguration } from '../types'
+import type { Key, Fetcher, SWRConfiguration } from '../types'
 
 export const normalize = <KeyType = Key, Data = any>(
   args:

--- a/_internal/utils/serialize.ts
+++ b/_internal/utils/serialize.ts
@@ -1,7 +1,7 @@
 import { stableHash } from './hash'
 import { isFunction } from './helper'
 
-import { Key } from '../types'
+import type { Key } from '../types'
 
 export const serialize = (key: Key): [string, Key] => {
   if (isFunction(key)) {

--- a/_internal/utils/state.ts
+++ b/_internal/utils/state.ts
@@ -1,4 +1,5 @@
-import React, { useRef, useCallback, useState, MutableRefObject } from 'react'
+import type { MutableRefObject } from 'react'
+import React, { useRef, useCallback, useState } from 'react'
 
 import { useIsomorphicLayoutEffect, IS_REACT_LEGACY } from './env'
 

--- a/_internal/utils/use-swr-config.ts
+++ b/_internal/utils/use-swr-config.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import { defaultConfig } from './config'
 import { SWRConfigContext } from './config-context'
 import { mergeObjects } from './helper'
-import { FullConfiguration, Cache, State } from '../types'
+import type { FullConfiguration, Cache, State } from '../types'
 
 export const useSWRConfig = <
   T extends Cache = Map<string, State>

--- a/_internal/utils/web-preset.ts
+++ b/_internal/utils/web-preset.ts
@@ -1,4 +1,4 @@
-import { ProviderConfiguration } from '../types'
+import type { ProviderConfiguration } from '../types'
 import { isUndefined, noop, isWindowDefined, isDocumentDefined } from './helper'
 
 /**

--- a/_internal/utils/with-middleware.ts
+++ b/_internal/utils/with-middleware.ts
@@ -1,6 +1,12 @@
 import { normalize } from './normalize-args'
 
-import { Key, Fetcher, Middleware, SWRConfiguration, SWRHook } from '../types'
+import type {
+  Key,
+  Fetcher,
+  Middleware,
+  SWRConfiguration,
+  SWRHook
+} from '../types'
 
 // Create a custom hook with a middleware
 export const withMiddleware = (

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -8,7 +8,6 @@ import {
   rAF,
   useIsomorphicLayoutEffect,
   SWRGlobalState,
-  GlobalState,
   serialize,
   isUndefined,
   UNDEFINED,
@@ -33,7 +32,8 @@ import type {
   SWRConfiguration,
   SWRHook,
   RevalidateEvent,
-  StateDependencies
+  StateDependencies,
+  GlobalState
 } from 'swr/_internal'
 
 const WITH_DEDUPE = { dedupe: true }

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -2,7 +2,8 @@
 // hook where `key` and return type are not like the normal `useSWR` types.
 
 import { useRef, useCallback } from 'react'
-import useSWR, { SWRConfig } from 'swr'
+import type { SWRConfig } from 'swr'
+import useSWR from 'swr'
 import {
   isUndefined,
   isFunction,

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SWRConfiguration,
   SWRResponse,
   Arguments,

--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -1,14 +1,13 @@
 import { useCallback, useRef } from 'react'
 import useSWR, { useSWRConfig } from 'swr'
+import type { Middleware, Key } from 'swr/_internal'
 import {
   serialize,
   useStateWithDeps,
   withMiddleware,
   useIsomorphicLayoutEffect,
   UNDEFINED,
-  getTimestamp,
-  Middleware,
-  Key
+  getTimestamp
 } from 'swr/_internal'
 import type {
   SWRMutationConfiguration,

--- a/mutation/types.ts
+++ b/mutation/types.ts
@@ -1,4 +1,4 @@
-import { SWRResponse, Key, MutatorOptions } from 'swr'
+import type { SWRResponse, Key, MutatorOptions } from 'swr'
 
 type FetcherResponse<Data> = Data | Promise<Data>
 

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { useSWRConfig, SWRConfig, Cache, State } from 'swr'
+import type { Cache, State } from 'swr'
+import { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
 
 interface CustomCache<Data = any> extends Cache<Data> {

--- a/test/type/mutator.ts
+++ b/test/type/mutator.ts
@@ -1,7 +1,7 @@
-import { Equal, Expect } from '@type-challenges/utils'
+import type { Equal, Expect } from '@type-challenges/utils'
 import useSWR, { useSWRConfig } from 'swr'
 
-import {
+import type {
   MutatorFn,
   Key,
   MutatorCallback,

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -1,6 +1,7 @@
 import { act, screen, fireEvent } from '@testing-library/react'
 import React, { useEffect, useState } from 'react'
-import useSWR, { SWRConfig, useSWRConfig, Middleware } from 'swr'
+import type { Middleware } from 'swr'
+import useSWR, { SWRConfig, useSWRConfig } from 'swr'
 import { renderWithConfig, createKey, renderWithGlobalCache } from './utils'
 
 describe('useSWR - configs', () => {

--- a/test/use-swr-middlewares.test.tsx
+++ b/test/use-swr-middlewares.test.tsx
@@ -1,6 +1,7 @@
 import { act, screen } from '@testing-library/react'
 import React, { useState, useEffect, useRef } from 'react'
-import useSWR, { Middleware, SWRConfig } from 'swr'
+import type { Middleware } from 'swr'
+import useSWR, { SWRConfig } from 'swr'
 import { withMiddleware } from '../_internal/utils/with-middleware'
 
 import {

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -1,12 +1,6 @@
 import { act, fireEvent, screen } from '@testing-library/react'
-import React, {
-  ReactNode,
-  Suspense,
-  useEffect,
-  useReducer,
-  useState,
-  PropsWithChildren
-} from 'react'
+import type { ReactNode, PropsWithChildren } from 'react'
+import React, { Suspense, useEffect, useReducer, useState } from 'react'
 import useSWR, { mutate } from 'swr'
 import {
   createKey,


### PR DESCRIPTION
Fixes #2060 

rollup-typescript plugin will output the correct types path when those imports are using `import type`