### PR TITLE
Revert swr config generic

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -26,8 +26,8 @@ export type Fetcher<
   : never
 
 // Configuration types that are only used internally, not exposed to the user.
-export interface InternalConfiguration<T extends Cache = Cache> {
-  cache: T
+export interface InternalConfiguration {
+  cache: Cache
   mutate: ScopedMutator
 }
 
@@ -86,8 +86,7 @@ export interface PublicConfiguration<
   isVisible: () => boolean
 }
 
-export type FullConfiguration<T extends Cache = Cache> =
-  InternalConfiguration<T> & PublicConfiguration
+export type FullConfiguration = InternalConfiguration & PublicConfiguration
 
 export type ProviderConfiguration = {
   initFocus: (callback: () => void) => (() => void) | void

--- a/_internal/utils/use-swr-config.ts
+++ b/_internal/utils/use-swr-config.ts
@@ -2,10 +2,8 @@ import { useContext } from 'react'
 import { defaultConfig } from './config'
 import { SWRConfigContext } from './config-context'
 import { mergeObjects } from './helper'
-import type { FullConfiguration, Cache, State } from '../types'
+import type { FullConfiguration } from '../types'
 
-export const useSWRConfig = <
-  T extends Cache = Map<string, State>
->(): FullConfiguration<T> => {
+export const useSWRConfig = (): FullConfiguration => {
   return mergeObjects(defaultConfig, useContext(SWRConfigContext))
 }

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import type { State } from 'swr'
+import type { Cache } from 'swr'
 import { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
 
 export function useTestCache() {
-  expectType<Map<string, State>>(useSWRConfig().cache)
+  expectType<Cache<any>>(useSWRConfig().cache)
 }
 
 export function useCustomSWRConfig() {

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -1,16 +1,10 @@
 import React from 'react'
-import type { Cache, State } from 'swr'
+import type { State } from 'swr'
 import { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
 
-interface CustomCache<Data = any> extends Cache<Data> {
-  reset(): void
-}
-
 export function useTestCache() {
   expectType<Map<string, State>>(useSWRConfig().cache)
-  expectType<Map<string, State>>(useSWRConfig<Map<string, State>>().cache)
-  expectType<CustomCache>(useSWRConfig<CustomCache>().cache)
 }
 
 export function useCustomSWRConfig() {


### PR DESCRIPTION
### Changes

revert #1938 

After new mutate API is landed, we're able to clear the cache or partially set cache with it, like `mutate((key) => filter(key), data)`. We encourage users to use `mutate` API instead of manipulate cache provider itself directly. 

### Origin Problem
Previously users are struggling with typing with cache provider, and trying to call `cache.clear()`, which might result into inconsistence between cache provider and react state in swr. So we introduce the new mutate API to let users manipulate cache easily. The type generics for `useSWRConfig<CacheType>` is a bit redudant if you really want to forcedly type a returned cache from context. You can just use `as` type guard like below:

```ts
const cache = useSWRConfig().cache as CustomCache
```

By default the cache type is `Cache<any>`
