### PR TITLE
feat: suspense guard in data and error getters

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -590,33 +590,37 @@ export const useSWRHandler = <Data = any, Error = any>(
   // Display debug info in React DevTools.
   useDebugValue(returnedData)
 
-  // In Suspense mode, we can't return the empty `data` state.
-  // If there is `error`, the `error` needs to be thrown to the error boundary.
-  // If there is no `error`, the `revalidation` promise needs to be thrown to
-  // the suspense boundary.
-  if (suspense && isUndefined(data) && key) {
-    // SWR should throw when trying to use Suspense on the server with React 18,
-    // without providing any initial data. See:
-    // https://github.com/vercel/swr/issues/1832
-    if (!IS_REACT_LEGACY && IS_SERVER) {
-      throw new Error('Fallback data is required when using suspense in SSR.')
-    }
+  const suspenseGuard = () => {
+    // In Suspense mode, we can't return the empty `data` state.
+    // If there is `error`, the `error` needs to be thrown to the error boundary.
+    // If there is no `error`, the `revalidation` promise needs to be thrown to
+    // the suspense boundary.
+    if (suspense && isUndefined(data) && key) {
+      // SWR should throw when trying to use Suspense on the server with React 18,
+      // without providing any initial data. See:
+      // https://github.com/vercel/swr/issues/1832
+      if (!IS_REACT_LEGACY && IS_SERVER) {
+        throw new Error('Fallback data is required when using suspense in SSR.')
+      }
 
-    // Always update fetcher and config refs even with the Suspense mode.
-    fetcherRef.current = fetcher
-    configRef.current = config
-    unmountedRef.current = false
-    throw isUndefined(error) ? revalidate(WITH_DEDUPE) : error
+      // Always update fetcher and config refs even with the Suspense mode.
+      fetcherRef.current = fetcher
+      configRef.current = config
+      unmountedRef.current = false
+      throw isUndefined(error) ? revalidate(WITH_DEDUPE) : error
+    }
   }
 
   return {
     mutate: boundMutate,
     get data() {
       stateDependencies.data = true
+      suspenseGuard()
       return returnedData
     },
     get error() {
       stateDependencies.error = true
+      suspenseGuard()
       return error
     },
     get isValidating() {


### PR DESCRIPTION
Alternative to #168
Fixes #5

This PR isolates the suspense guarding into a function, which is then called in the `data` and `error` getters returned from `useSWR`.

This allows you to write your suspense `useSWR`s like this to avoid waterfalls;

```js
function App () {
  const user = useSWR('/api/user')
  const movies = useSWR('/api/movies')

  return (
    <div>
      Hi {user.data.name}, we have {movies.data.length} movies on the list.
    </div>
  )
}

// OR

function App () {
  const userRequest = useSWR('/api/user')
  const moviesRequest = useSWR('/api/movies')
  const user = userRequest.data
  const movies = moviesRequest.data

  return (
    <div>
      Hi {user.name}, we have {movies.length} movies on the list.
    </div>
  )
}
```

This also allows for dependency fetching

```js
const user = useSWR('/api/user')
const posts = useSWR('/api/posts')
// Accessing .data will throw during key evaluation, letting swr know it's not ready
const movies = useSWR(() => '/api/movies?id=' + user.data.id)
```

And it would also (mostly) be backwards compatible, since most usage uses deconstruction which will automatically call the `data` and/or `error` getters, preserving earlier functionality.

I believe this is a much cleaner interface than the other ones proposed. I've yet to test this completely, so it's mostly a proposal for now, feedback needed 😄 