### PR TITLE
Make it possible to infer the fetcher's key

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -113,10 +113,6 @@ export interface SWRHook {
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
-    fetcher: BareFetcher<Data> | null
-  ): SWRResponse<Data, Error>
-  <Data = any, Error = any>(
-    key: Key,
     config: SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(


### PR DESCRIPTION
Hi!

I am using passing objects feature (https://swr.vercel.app/docs/arguments#passing-objects) like this.

<img width="566" alt="image" src="https://user-images.githubusercontent.com/41747333/178154420-da3b429f-e386-412e-bd47-873c144e9a6b.png">

Unfortunately, This obviously leads to incorrect execution.
But you won't know until execute project.

because this fetcher infers the type as a `bare fetcher`, it shows no error information.

### but, enable key inference with this update,

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/41747333/178153845-14a19e42-12b8-4a57-a9f5-4d59f3b1bab5.png">

### can be corrected correctly

<img width="570" alt="image" src="https://user-images.githubusercontent.com/41747333/178153881-5a660802-31ac-4e78-a877-34e18936d5a0.png">

I looked at swr2 (also 1.3), If only a fetcher and a key exist, there is no need to infer that it is a `bare fetcher`.
so I think it would be better to inform the user that this is an incorrect usage.

Please consider this change. 
thank you for read!