### PR TITLE
Remove unused info from dummy package.json

### DIFF
--- a/_internal/package.json
+++ b/_internal/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "swr-internal",
-  "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/_internal",

--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "swr-core",
-  "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/index.d.ts",

--- a/immutable/package.json
+++ b/immutable/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "swr-immutable",
-  "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/immutable",

--- a/infinite/package.json
+++ b/infinite/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "swr-infinite",
-  "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/infinite",

--- a/mutation/package.json
+++ b/mutation/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "swr-mutation",
-  "version": "0.0.1",
   "main": "./dist/index.js",
   "module": "./dist/index.esm.js",
   "types": "./dist/mutation",


### PR DESCRIPTION
Closes #2081 

Those subfolder package.json are created for providing module resolving for some bundler doesn't support `exports` field but need to resolve proper cjs or esm bundle. `"name"` and `"version"` fields are affecting webpack-license-plugin to extract the correct license, this PR will remove them before we deprecate those subfolder package.json to embrace the `exports` sugar