### PR TITLE
types: add generic for SWRInfiniteKeyLoader

### DIFF
--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -17,9 +17,9 @@ export type SWRInfiniteFetcher<
     : never
   : never
 
-export type SWRInfiniteKeyLoader = (
+export type SWRInfiniteKeyLoader<Data = any> = (
   index: number,
-  previousPageData: any | null
+  previousPageData: Data | null
 ) => Arguments
 
 export interface SWRInfiniteConfiguration<


### PR DESCRIPTION
## Description

Sometimes I need to declare a `getKey` function individually, but the original type of `SWRInfiniteKeyLoader` use `any | null` for the second argument. For better type definition, I think this type should have generic. 

## Additional infomation

It seems that `"swr/_internal": ["./_internal/index.ts"]` is missing in `compilerOptions.paths` for tsconfig.ts?