### PR TITLE
Reorder exports conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,34 +17,34 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./core/dist/core/index.d.ts",
       "import": "./core/dist/index.mjs",
       "module": "./core/dist/index.esm.js",
-      "require": "./core/dist/index.js",
-      "types": "./core/dist/core/index.d.ts"
+      "require": "./core/dist/index.js"
     },
     "./infinite": {
+      "types": "./infinite/dist/infinite/index.d.ts",
       "import": "./infinite/dist/index.mjs",
       "module": "./infinite/dist/index.esm.js",
-      "require": "./infinite/dist/index.js",
-      "types": "./infinite/dist/infinite/index.d.ts"
+      "require": "./infinite/dist/index.js"
     },
     "./immutable": {
+      "types": "./immutable/dist/immutable/index.d.ts",
       "import": "./immutable/dist/index.mjs",
       "module": "./immutable/dist/index.esm.js",
-      "require": "./immutable/dist/index.js",
-      "types": "./immutable/dist/immutable/index.d.ts"
+      "require": "./immutable/dist/index.js"
     },
     "./mutation": {
+      "types": "./mutation/dist/mutation/index.d.ts",
       "import": "./mutation/dist/index.mjs",
       "module": "./mutation/dist/index.esm.js",
-      "require": "./mutation/dist/index.js",
-      "types": "./mutation/dist/mutation/index.d.ts"
+      "require": "./mutation/dist/index.js"
     },
     "./_internal": {
+      "types": "./_internal/dist/_internal/index.d.ts",
       "import": "./_internal/dist/index.mjs",
       "module": "./_internal/dist/index.esm.js",
-      "require": "./_internal/dist/index.js",
-      "types": "./_internal/dist/_internal/index.d.ts"
+      "require": "./_internal/dist/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
### Reference

According to [exports sugar usage](https://nodejs.org/api/packages.html#exports-sugar)

> "types" - can be used by typing systems to resolve the typing file for the given export. This condition should always be included first.
Within the ["exports"](https://nodejs.org/api/packages.html#exports) object, key order is significant. During condition matching, earlier entries have higher priority and take precedence over later entries. The general rule is that conditions should be from most specific to least specific in object order.

### Changes

This PR adjust the type exports to the top matched conditions to fit usage with typing