### PR TITLE
memoize config values to avoid frequent context propagation

### DIFF
--- a/_internal/utils/config-context.ts
+++ b/_internal/utils/config-context.ts
@@ -1,5 +1,11 @@
 import type { FC, PropsWithChildren } from 'react'
-import { createContext, createElement, useContext, useState } from 'react'
+import {
+  createContext,
+  createElement,
+  useContext,
+  useState,
+  useMemo
+} from 'react'
 import { cache as defaultCache } from './config'
 import { initCache } from './cache'
 import { mergeConfigs } from './merge-config'
@@ -27,11 +33,15 @@ const SWRConfig: FC<
   const { value } = props
   const parentConfig = useContext(SWRConfigContext)
   const isFunctionalConfig = isFunction(value)
-  const config = isFunctionalConfig ? value(parentConfig) : value
+  const config = useMemo(
+    () => (isFunctionalConfig ? value(parentConfig) : value),
+    [isFunctionalConfig, parentConfig, value]
+  )
   // Extend parent context values and middleware.
-  const extendedConfig = isFunctionalConfig
-    ? config
-    : mergeConfigs(parentConfig, config)
+  const extendedConfig = useMemo(
+    () => (isFunctionalConfig ? config : mergeConfigs(parentConfig, config)),
+    [isFunctionalConfig, parentConfig, config]
+  )
 
   // Should not use the inherited provider.
   const provider = config && config.provider

--- a/test/use-swr-context-config.test.tsx
+++ b/test/use-swr-context-config.test.tsx
@@ -9,7 +9,9 @@ describe('useSWR - context configs', () => {
     const fetcher = () => createResponse('data')
     const key = createKey()
 
-    await act(async () => { await mutate(key, prefetch) })
+    await act(async () => {
+      await mutate(key, prefetch)
+    })
 
     function Page() {
       const { data } = useSWR(key, fetcher)


### PR DESCRIPTION
every time `<SWRConfig>` renders it propagates a context change even if the config did not change functionally. This can break hydration of Suspense boundaries when this component re-renders shortly after initial render which is common when there are mount effects for root level components.

This PR adds memoization so the config only changes if it's reactive dependencies change