### PR TITLE
chore: fix missing husky warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm lint-staged && pnpm types:check

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   "homepage": "https://swr.vercel.app",
   "license": "MIT",
   "scripts": {
+    "prepare": "husky install",
     "csb:install": "pnpm i -g pnpm@7",
     "csb:build": "pnpm install && pnpm build",
     "clean": "pnpm -r run clean",

--- a/package.json
+++ b/package.json
@@ -79,11 +79,6 @@
     "test": "jest",
     "run-all-checks": "pnpm types:check && pnpm lint && pnpm test && pnpm test-typing"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged && pnpm types:check"
-    }
-  },
   "lint-staged": {
     "*.{ts,tsx}": [
       "eslint --fix --cache",


### PR DESCRIPTION
Seeing error `Can't find Husky, skipping post-checkout hook` when you commit.

Fix it by adding the `.husky` precommit and remove the legacy config in package.json according to the new tutorial in husky