### PR TITLE
fix: re-render when returned data and fallbackData is the same and keepPreviousData is enabled

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -113,7 +113,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       const t = _ as keyof StateDependencies
       if (!compare(current[t], prev[t])) {
         if (t === 'data' && isUndefined(prev[t])) {
-          if (!compare(current[t], fallback)) {
+          if (!compare(current[t], returnedData)) {
             equal = false
           }
         } else {

--- a/test/use-swr-laggy.test.tsx
+++ b/test/use-swr-laggy.test.tsx
@@ -194,4 +194,44 @@ describe('useSWR - keep previous data', () => {
       [key3, key3]
     ])
   })
+
+  // https://github.com/vercel/swr/issues/2128
+  it('should re-render when returned data and fallbackData is the same and keepPreviousData is enabled', async () => {
+    const fallbackData = 'initial'
+    const fetcher = k => createResponse(k, { delay: 50 })
+    const keys = ['initial', 'updated']
+    function App() {
+      const [count, setCount] = useState(0)
+      const { data } = useSWR(keys[count % 2 === 0 ? 0 : 1], fetcher, {
+        fallbackData,
+        keepPreviousData: true,
+        revalidateOnMount: false,
+        revalidateOnFocus: false
+      })
+      return (
+        <>
+          <button onClick={() => setCount(c => c + 1)}>change key</button>
+          <div>{data}</div>
+        </>
+      )
+    }
+
+    renderWithConfig(<App />)
+    // fallbackData
+    screen.getByText('initial')
+
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(10))
+    // previous data
+    screen.getByText('initial')
+    await act(() => sleep(100))
+    screen.getByText('updated')
+
+    fireEvent.click(screen.getByText('change key'))
+    await act(() => sleep(10))
+    // previous data
+    screen.getByText('updated')
+    await act(() => sleep(100))
+    screen.getByText('initial')
+  })
 })


### PR DESCRIPTION
Fixes #2128

This fixes an issue that happens when `keepPreviousData` is enabled and the returned data and the fallback data is the same.
In this case, we have to check the laggy data, not only the fallback data, to update returned data from laggy data to the latest data. Currently, an update is ignored if the latest data and the fallback are the same.
