### PR TITLE
Remove downlevelIteration and traverse iterator manually

### DIFF
--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -59,7 +59,9 @@ export async function internalMutate<Data>(
   if (isFunction(_key)) {
     const keyFilter = _key
     const matchedKeys: Key[] = []
-    for (const key of cache.keys()) {
+    const it = cache.keys()
+    for (let keyIt = it.next(); !keyIt.done; keyIt = it.next()) {
+      const key = keyIt.value
       if (
         // Skip the special useSWRInfinite keys.
         !key.startsWith('$inf$') &&

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strictBindCallApply": true,
-    "downlevelIteration": true,
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,


### PR DESCRIPTION
Closes #2180 

Added the `downlevelIteration` flag when implementing the mutation filter. But swc compiles it to array-like traversal when target is es5. So we remove the flag from tsconfig.json now and then manually iterate the map iterator returning from `map.keys()`