### PR TITLE
breaking: Change the error broadcasting behavior in mutations and add `throwOnError` option

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -267,6 +267,7 @@ export type MutatorOptions<Data = any> = {
     | ((result: any, currentData: Data | undefined) => Data)
   optimisticData?: Data | ((currentData?: Data) => Data)
   rollbackOnError?: boolean
+  throwOnError?: boolean
 }
 
 export type MutatorConfig = {

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -1,5 +1,11 @@
 import { serialize } from './serialize'
-import { createCacheHelper, isFunction, isUndefined, UNDEFINED } from './helper'
+import {
+  createCacheHelper,
+  isFunction,
+  isUndefined,
+  UNDEFINED,
+  mergeObjects
+} from './helper'
 import { SWRGlobalState } from './global-state'
 import { getTimestamp } from './timestamp'
 import * as revalidateEvents from '../constants'
@@ -43,16 +49,17 @@ export async function internalMutate<Data>(
 
   // When passing as a boolean, it's explicitly used to disable/enable
   // revalidation.
-  const options =
+  const options = mergeObjects(
+    { populateCache: true, throwOnError: true },
     typeof _opts === 'boolean' ? { revalidate: _opts } : _opts || {}
+  )
 
-  // Fallback to `true` if it's not explicitly set to `false`
-  let populateCache = isUndefined(options.populateCache)
-    ? true
-    : options.populateCache
+  let populateCache = options.populateCache
   let optimisticData = options.optimisticData
+
   const revalidate = options.revalidate !== false
   const rollbackOnError = options.rollbackOnError !== false
+  const throwOnError = options.throwOnError
 
   // If the second argument is a key filter, return the mutation results for all
   // filtered keys.
@@ -177,9 +184,6 @@ export async function internalMutate<Data>(
         // Only update cached data if there's no error. Data can be `undefined` here.
         set({ data, _c: UNDEFINED })
       }
-
-      // Always update error and original data here.
-      set({ error })
     }
 
     // Reset the timestamp to mark the mutation has ended.
@@ -193,7 +197,10 @@ export async function internalMutate<Data>(
     set({ _c: UNDEFINED })
 
     // Throw error or return data
-    if (error) throw error
+    if (error) {
+      if (throwOnError) throw error
+      return
+    }
     return populateCache ? res : data
   }
 }

--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -7,7 +7,8 @@ import {
   withMiddleware,
   useIsomorphicLayoutEffect,
   UNDEFINED,
-  getTimestamp
+  getTimestamp,
+  mergeObjects
 } from 'swr/_internal'
 import type {
   SWRMutationConfiguration,
@@ -43,11 +44,14 @@ const mutation = (<Data, Error>() =>
           throw new Error('Can’t trigger the mutation: missing fetcher.')
         }
         if (!serializedKey) {
-          throw new Error('Can’t trigger the mutation: key isn’t ready.')
+          throw new Error('Can’t trigger the mutation: missing key.')
         }
 
         // Disable cache population by default.
-        const options = Object.assign({ populateCache: false }, config, opts)
+        const options = mergeObjects(
+          mergeObjects({ populateCache: false, throwOnError: true }, config),
+          opts
+        )
 
         // Trigger a mutation, and also track the timestamp. Any mutation that happened
         // earlier this timestamp should be ignored.
@@ -60,9 +64,9 @@ const mutation = (<Data, Error>() =>
         try {
           const data = await mutate<Data>(
             serializedKey,
-            // FIXME: Error shouldn't be broadcasted here.
             (fetcher as any)(resolvedKey, { arg }),
-            options
+            // We must throw the error here so we can catch and update the states.
+            mergeObjects(options, { throwOnError: true })
           )
 
           // If it's reset after the mutation, we don't broadcast any state change.
@@ -72,11 +76,14 @@ const mutation = (<Data, Error>() =>
           }
           return data
         } catch (error) {
-          // If it's reset after the mutation, we don't broadcast any state change.
+          // If it's reset after the mutation, we don't broadcast any state change
+          // or throw because it's discarded.
           if (ditchMutationsUntilRef.current <= mutationStartedAt) {
             setState({ error: error as Error, isMutating: false })
             options.onError?.(error as Error, serializedKey, options)
-            throw error as Error
+            if (options.throwOnError) {
+              throw error as Error
+            }
           }
         }
       },

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -505,7 +505,7 @@ describe('useSWR - local mutation', () => {
     screen.getByText('data: 1')
   })
 
-  it('should update error in cache when mutate failed with error', async () => {
+  it('should not update error in global cache when mutate failed with error', async () => {
     const value = 0
     const key = createKey()
     const message = 'mutate-error'
@@ -538,18 +538,10 @@ describe('useSWR - local mutation', () => {
       }
     })
 
-    screen.getByText(message)
+    screen.getByText('data: 0')
     const [keyInfo] = serialize(key)
-    let cacheError = cache.get(keyInfo)?.error
-    expect(cacheError.message).toMatchInlineSnapshot(`"${message}"`)
-
-    // if mutate throws an error synchronously, the cache shouldn't be updated
-    expect(cache.get(keyInfo)?.data).toBe(value)
-
-    // if mutate succeed, the error should be cleared
-    await act(() => mutate(key, value, false))
-    cacheError = cache.get(keyInfo)?.error
-    expect(cacheError).toMatchInlineSnapshot(`undefined`)
+    const cacheError = cache.get(keyInfo)?.error
+    expect(cacheError).toBeUndefined()
   })
 
   it('should keep the `mutate` function referential equal', async () => {


### PR DESCRIPTION
Errors from mutations should be separated from direct fetches. Currently, the returned and shared `error` state from `useSWR` will be mutated by `mutate` calls:

```js
const { error } = useSWR('/api')

mutate('/api', mutator) → this might update `error` if it fails
```

The main use case for that is to have a global and declarative error indicator for mutations, but then it conflicts with fetching errors (e.g. resource fails to load). With the new `useSWRMutation` hook, that is no longer needed because we can have a cleaner representation for both:

```js
const { error: loadError } = useSWR('/api')
const { error: actionError } = useSWRMutation('/api')
```

And they will be separated and scoped to different places:

![image](https://user-images.githubusercontent.com/3676859/193939023-146e27c9-3079-4e4c-aa57-d84d615d3139.png)

For example (1) and (2) will always share the same data and error. So if the user fails to load initially, error indicators can be shown in both places (or you can throw to trigger an upper-level error boundary). In (3) and (4) you can trigger remote mutations to update the user resource. If the mutation succeeded, (1) and (2) will be updated and rerendered with the new data. If a mutation from (3) failed, only (3) will get the error state so you can show the error indicator there, without affecting (1) (2) and (4).

## `throwOnError`

Since there is already `onError` supported in `useSWRMutation`, here we are adding a new option `throwOnError` to mutations (both `useSWRMutation` and `mutate`) to define if an error should be thrown inline or not. It defaults to `true`.

```js
// This call will not throw an error if it fails. It will fail silently.
mutate(key, fetcher, {
  throwOnError: false
})
```

```js
const { trigger, error } = useSWRMutation('/api', mutator, {
  throwOnError: false,
  onError: (err) => { ... }
})

// This call will not throw inline
trigger()

// Override the option:
try {
  await trigger(null, { throwOnError: true })
} catch (err) {
  // ...
}
```
