### PR TITLE
docs: Add JSDoc comments to useSWRMutation

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -338,7 +338,13 @@ export type SWRConfiguration<
 > = Partial<PublicConfiguration<Data, Error, Fn>>
 
 export interface SWRResponse<Data = any, Error = any> {
+  /**
+   * The returned data of the fetcher function.
+   */
   data: Data | undefined
+  /**
+   * The error object thrown by the fetcher function.
+   */
   error: Error | undefined
   mutate: KeyedMutator<Data>
   isValidating: boolean

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -639,7 +639,9 @@ export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'defaultValue', {
 export const unstable_serialize = (key: Key) => serialize(key)[0]
 
 /**
- * @link https://swr.vercel.app/
+ * A hook to fetch data.
+ *
+ * @link https://swr.vercel.app
  * @example
  * ```jsx
  * import useSWR from 'swr'

--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -122,6 +122,23 @@ const mutation = (<Data, Error>() =>
     }
   }) as unknown as Middleware
 
+/**
+ * A hook to define and manually trigger remote mutations like POST, PUT, DELETE and PATCH use cases.
+ *
+ * @link https://swr.vercel.app/docs/mutation
+ * @example
+ * ```jsx
+ * import useSWRMutation from 'swr/mutation'
+ *
+ * const {
+ *   data,
+ *   error,
+ *   trigger,
+ *   reset,
+ *   isMutating
+ * } = useSWRMutation(key, fetcher, options?)
+ * ```
+ */
 export default withMiddleware(useSWR, mutation) as unknown as SWRMutationHook
 
 export { SWRMutationConfiguration, SWRMutationResponse, SWRMutationHook }

--- a/mutation/types.ts
+++ b/mutation/types.ts
@@ -47,11 +47,21 @@ export interface SWRMutationResponse<
   ExtraArg = any,
   SWRMutationKey extends Key = Key
 > extends Pick<SWRResponse<Data, Error>, 'data' | 'error'> {
+  /**
+   * Indicates if the mutation is in progress.
+   */
   isMutating: boolean
+  /**
+   * Function to trigger the mutation. You can also pass an extra argument to
+   * the fetcher, and override the options for the mutation hook.
+   */
   trigger: (
     extraArgument?: ExtraArg,
     options?: SWRMutationConfiguration<Data, Error, ExtraArg, SWRMutationKey>
   ) => Promise<Data | undefined>
+  /**
+   * Function to reset the mutation state (`data`, `error`, and `isMutating`).
+   */
   reset: () => void
 }
 
@@ -61,11 +71,26 @@ export type SWRMutationHook = <
   SWRMutationKey extends Key = Key,
   ExtraArg = any
 >(
-  ...args:
-    | readonly [SWRMutationKey, MutationFetcher<Data, ExtraArg, SWRMutationKey>]
-    | readonly [
-        SWRMutationKey,
-        MutationFetcher<Data, ExtraArg, SWRMutationKey>,
-        SWRMutationConfiguration<Data, Error, ExtraArg, SWRMutationKey>
-      ]
+  /**
+   * The key of the resource that will be mutated. It should be the same key
+   * used in the `useSWR` hook so SWR can handle revalidation and race
+   * conditions for that resource.
+   */
+  key: SWRMutationKey,
+  /**
+   * The function to trigger the mutation that accepts the key, extra argument
+   * and options. For example:
+   *
+   * ```jsx
+   * (api, data) => fetch(api, {
+   *   method: 'POST',
+   *   body: JSON.stringify(data)
+   * })
+   * ```
+   */
+  fetcher: MutationFetcher<Data, ExtraArg, SWRMutationKey>,
+  /**
+   * Extra options for the mutation hook.
+   */
+  options?: SWRMutationConfiguration<Data, Error, ExtraArg, SWRMutationKey>
 ) => SWRMutationResponse<Data, Error, ExtraArg, SWRMutationKey>


### PR DESCRIPTION
It will show the basic docs and links for this new hook when the editor supports JSDoc:

![CleanShot 2022-10-05 at 22 39 41@2x](https://user-images.githubusercontent.com/3676859/194159159-f1170621-cb65-41d8-b0c9-2cad383b4af0.png)
