### PR TITLE
type: export MutationFetcher

### DIFF
--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -141,4 +141,9 @@ const mutation = (<Data, Error>() =>
  */
 export default withMiddleware(useSWR, mutation) as unknown as SWRMutationHook
 
-export { SWRMutationConfiguration, SWRMutationResponse, SWRMutationHook }
+export {
+  SWRMutationConfiguration,
+  SWRMutationResponse,
+  SWRMutationHook,
+  MutationFetcher
+}


### PR DESCRIPTION
Hi!

I want to use `MutationFetcher` type.
The following workaround worked in beta.6 .

```ts
import type { MutationFetcher } from 'swr/mutation/dist/mutation/types'
```

However, now it is no longer available due to #2150 .

Or do you know of any workarounds?


example

```ts
type Key = 'ARTICLE_ID'
const likeMutation: MutationFetcher<boolean, {}, Key> = async (key) => {
  const res = await fetch(`/like/${key}`, { method: 'POST' });
  const json = await res.json();
  return json.like;
}

const useLike = (articleId: string) => {
  const res = useSWR(articleId, ...);
  const mut = useSWRMutation(articleId, like);
  ...
}
```