### PR TITLE
Memoizing the return values 🛥️ 

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -627,7 +627,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       stateDependencies.isLoading = true
       return isLoading
     }
-  }), [boundMutate, returnedData, error, isValidating, isLoading]) as SWRResponse<Data, Error>
+  }), [boundMutate, returnedData, error, isValidating, isLoading, stateDependencies.data, stateDependencies.error, stateDependencies.isValidating, stateDependencies.isLoading]) as SWRResponse<Data, Error>
 }
 
 export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'defaultValue', {

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -609,7 +609,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     throw isUndefined(error) ? revalidate(WITH_DEDUPE) : error
   }
 
-  return {
+  return useMemo(() => ({
     mutate: boundMutate,
     get data() {
       stateDependencies.data = true
@@ -627,7 +627,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       stateDependencies.isLoading = true
       return isLoading
     }
-  } as SWRResponse<Data, Error>
+  }), [boundMutate, returnedData, error, isValidating, isLoading]) as SWRResponse<Data, Error>
 }
 
 export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'defaultValue', {


### PR DESCRIPTION
Memoizing the return values using [`React.useMemo`](https://beta.reactjs.org/apis/react/useMemo) to prevent from unnecessary computations when, any unnecessary state changes occurs or when parent component re reder.


_Extremely sorry if I made any mistakes :(_