### PR TITLE
fix: pass null fetcher to middleware

### DIFF
--- a/_internal/utils/resolve-args.ts
+++ b/_internal/utils/resolve-args.ts
@@ -24,6 +24,6 @@ export const withArgs = <SWRType>(hook: any) => {
       next = middleware[i](next)
     }
 
-    return next(key, fn || config.fetcher, config)
+    return next(key, fn || config.fetcher || null, config)
   } as unknown as SWRType
 }

--- a/test/use-swr-middlewares.test.tsx
+++ b/test/use-swr-middlewares.test.tsx
@@ -57,6 +57,25 @@ describe('useSWR - middleware', () => {
     expect(mockConsoleLog.mock.calls.length).toBe(2)
   })
 
+  it('should pass null fetcher to middleware', () => {
+    const key = createKey()
+    const mockConsoleLog = jest.fn(s => s)
+    const loggerMiddleware: Middleware = useSWRNext => (k, fn, config) => {
+      mockConsoleLog(fn)
+      return useSWRNext(k, fn, config)
+    }
+    function Page() {
+      const { data } = useSWR(key, null, {
+        use: [loggerMiddleware]
+      })
+      return <div>hello, {data}</div>
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('hello,')
+    expect(mockConsoleLog.mock.calls[0][0]).toEqual(null)
+  })
+
   it('should support `use` option in context', async () => {
     const key = createKey()
     const mockConsoleLog = jest.fn(s => s)


### PR DESCRIPTION
Fixes #2217

`null` is a valid type of `fetcher` argument, but the `null` fetcher becomes `undefined` in middleware. This is an unexpected behavior for middleware authors, so I've fixed it.