### PR TITLE
feat: support functional rollbackOnError

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -266,7 +266,7 @@ export type MutatorOptions<Data = any> = {
     | boolean
     | ((result: any, currentData: Data | undefined) => Data)
   optimisticData?: Data | ((currentData?: Data) => Data)
-  rollbackOnError?: boolean | ((error: unknown, currentData?: Data) => boolean)
+  rollbackOnError?: boolean | ((error: unknown) => boolean)
   throwOnError?: boolean
 }
 

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -266,7 +266,7 @@ export type MutatorOptions<Data = any> = {
     | boolean
     | ((result: any, currentData: Data | undefined) => Data)
   optimisticData?: Data | ((currentData?: Data) => Data)
-  rollbackOnError?: boolean
+  rollbackOnError?: boolean | ((error: unknown, currentData?: Data) => boolean)
   throwOnError?: boolean
 }
 

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -55,10 +55,16 @@ export async function internalMutate<Data>(
   )
 
   let populateCache = options.populateCache
+
+  const rollbackOnErrorOption = options.rollbackOnError
   let optimisticData = options.optimisticData
 
   const revalidate = options.revalidate !== false
-  const rollbackOnError = options.rollbackOnError !== false
+  const rollbackOnError = (error: unknown, currentData?: Data): boolean => {
+    return typeof rollbackOnErrorOption === 'function'
+      ? rollbackOnErrorOption(error, currentData)
+      : rollbackOnErrorOption !== false
+  }
   const throwOnError = options.throwOnError
 
   // If the second argument is a key filter, return the mutation results for all
@@ -126,7 +132,8 @@ export async function internalMutate<Data>(
     // that is going to be overridden by a `committedData`, or get reverted back.
     // `committedData` is the validated value that comes from a fetch or mutation.
     const displayedData = state.data
-    const committedData = isUndefined(state._c) ? displayedData : state._c
+    const currentData = state._c
+    const committedData = isUndefined(currentData) ? displayedData : currentData
 
     // Do optimistic data update.
     if (hasOptimisticData) {
@@ -162,7 +169,11 @@ export async function internalMutate<Data>(
       if (beforeMutationTs !== MUTATION[key][0]) {
         if (error) throw error
         return data
-      } else if (error && hasOptimisticData && rollbackOnError) {
+      } else if (
+        error &&
+        hasOptimisticData &&
+        rollbackOnError(error, currentData)
+      ) {
         // Rollback. Always populate the cache in this case but without
         // transforming the data.
         populateCache = true

--- a/_internal/utils/mutate.ts
+++ b/_internal/utils/mutate.ts
@@ -60,9 +60,9 @@ export async function internalMutate<Data>(
   let optimisticData = options.optimisticData
 
   const revalidate = options.revalidate !== false
-  const rollbackOnError = (error: unknown, currentData?: Data): boolean => {
+  const rollbackOnError = (error: unknown): boolean => {
     return typeof rollbackOnErrorOption === 'function'
-      ? rollbackOnErrorOption(error, currentData)
+      ? rollbackOnErrorOption(error)
       : rollbackOnErrorOption !== false
   }
   const throwOnError = options.throwOnError
@@ -169,11 +169,7 @@ export async function internalMutate<Data>(
       if (beforeMutationTs !== MUTATION[key][0]) {
         if (error) throw error
         return data
-      } else if (
-        error &&
-        hasOptimisticData &&
-        rollbackOnError(error, currentData)
-      ) {
+      } else if (error && hasOptimisticData && rollbackOnError(error)) {
         // Rollback. Always populate the cache in this case but without
         // transforming the data.
         populateCache = true

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1342,7 +1342,6 @@ describe('useSWR - local mutation', () => {
     const renderedData = []
     let mutate
     let cnt = 0
-    let callbackArgs
 
     function Page() {
       const { data, mutate: boundMutate } = useSWR(key, () =>

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1375,12 +1375,13 @@ describe('useSWR - local mutation', () => {
     await sleep(30)
     expect(renderedData).toEqual([undefined, 0, 'bar-1', 1])
 
+    let rollbackErrorMessage
     try {
       await executeWithoutBatching(() =>
         mutate(createResponse(new Error('baz-2'), { delay: 20 }), {
           optimisticData: 'bar-2',
-          rollbackOnError: (error, currentData) => {
-            callbackArgs = [error.message, currentData]
+          rollbackOnError: error => {
+            rollbackErrorMessage = error.message
             return false
           }
         })
@@ -1391,7 +1392,7 @@ describe('useSWR - local mutation', () => {
 
     await sleep(30)
     expect(renderedData).toEqual([undefined, 0, 'bar-1', 1, 'bar-2', 2])
-    expect(callbackArgs).toEqual(['baz-2', undefined])
+    expect(rollbackErrorMessage).toEqual('baz-2')
   })
 
   it('should support transforming the result with `populateCache` before writing back', async () => {


### PR DESCRIPTION
Resolves #2093

Support both boolean value and functional value for `rollbackOnError` for mutate options. This will let users to control rollback on error behavior based on specific error

```js
const newData = createNewData(...)
mutate(key, updateFn(newData), {
    populateCache: true,
    optimisticData: newData,
    rollbackOnError(error) {
        if (error.name === "TimeOutError") {
            return true
        }
        return false
    },
})
```