### PR TITLE
fix: Do not override falsy (null) fetcher

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -209,7 +209,7 @@ export interface SWRHook {
   ): SWRResponse<Data, Error>
   <Data = any, Error = any, SWRKey extends Key = null>(
     key: SWRKey,
-    fetcher: Fetcher<Data, SWRKey> | null
+    fetcher: Fetcher<Data, SWRKey> | null | undefined
   ): SWRResponse<Data, Error>
   <Data = any, Error = any, SWRKey extends Key = null>(
     key: SWRKey,
@@ -217,13 +217,13 @@ export interface SWRHook {
   ): SWRResponse<Data, Error>
   <Data = any, Error = any, SWRKey extends Key = null>(
     key: SWRKey,
-    fetcher: Fetcher<Data, SWRKey> | null,
+    fetcher: Fetcher<Data, SWRKey> | null | undefined,
     config: SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>> | undefined
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
-    fetcher: BareFetcher<Data> | null
+    fetcher: BareFetcher<Data> | null | undefined
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
@@ -231,7 +231,7 @@ export interface SWRHook {
   ): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
-    fetcher: BareFetcher<Data> | null,
+    fetcher: BareFetcher<Data> | null | undefined,
     config: SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
   ): SWRResponse<Data, Error>
 }

--- a/_internal/utils/normalize-args.ts
+++ b/_internal/utils/normalize-args.ts
@@ -5,11 +5,15 @@ import type { Key, Fetcher, SWRConfiguration } from '../types'
 export const normalize = <KeyType = Key, Data = any>(
   args:
     | [KeyType]
-    | [KeyType, Fetcher<Data> | null]
+    | [KeyType, Fetcher<Data> | null | undefined]
     | [KeyType, SWRConfiguration | undefined]
-    | [KeyType, Fetcher<Data> | null, SWRConfiguration | undefined]
-): [KeyType, Fetcher<Data> | null, Partial<SWRConfiguration<Data>>] => {
-  return isFunction(args[1])
+    | [KeyType, Fetcher<Data> | null | undefined, SWRConfiguration | undefined]
+): [
+  KeyType,
+  Fetcher<Data> | null | undefined,
+  Partial<SWRConfiguration<Data>>
+] => {
+  return isFunction(args[1]) || args[1] === null
     ? [args[0], args[1], args[2] || {}]
-    : [args[0], null, (args[1] === null ? args[2] : args[1]) || {}]
+    : [args[0], undefined, args[1] || {}]
 }

--- a/_internal/utils/resolve-args.ts
+++ b/_internal/utils/resolve-args.ts
@@ -24,6 +24,6 @@ export const withArgs = <SWRType>(hook: any) => {
       next = middleware[i](next)
     }
 
-    return next(key, fn || config.fetcher, config)
+    return next(key, fn || config.fetcher || null, config)
   } as unknown as SWRType
 }

--- a/_internal/utils/resolve-args.ts
+++ b/_internal/utils/resolve-args.ts
@@ -2,6 +2,7 @@ import { mergeConfigs } from './merge-config'
 import { normalize } from './normalize-args'
 import { useSWRConfig } from './use-swr-config'
 import { BUILT_IN_MIDDLEWARE } from './middleware-preset'
+import { isUndefined } from './helper'
 
 // It's tricky to pass generic types as parameters, so we just directly override
 // the types here.
@@ -11,7 +12,7 @@ export const withArgs = <SWRType>(hook: any) => {
     const fallbackConfig = useSWRConfig()
 
     // Normalize arguments.
-    const [key, fn, _config] = normalize<any, any>(args)
+    const [key, fn, _config] = normalize(args)
 
     // Merge configurations.
     const config = mergeConfigs(fallbackConfig, _config)
@@ -24,6 +25,6 @@ export const withArgs = <SWRType>(hook: any) => {
       next = middleware[i](next)
     }
 
-    return next(key, fn || config.fetcher || null, config)
+    return next(key, isUndefined(fn) ? config.fetcher : fn, config)
   } as unknown as SWRType
 }

--- a/_internal/utils/with-middleware.ts
+++ b/_internal/utils/with-middleware.ts
@@ -16,9 +16,9 @@ export const withMiddleware = (
   return <Data = any, Error = any>(
     ...args:
       | [Key]
-      | [Key, Fetcher<Data> | null]
+      | [Key, Fetcher<Data> | null | undefined]
       | [Key, SWRConfiguration | undefined]
-      | [Key, Fetcher<Data> | null, SWRConfiguration | undefined]
+      | [Key, Fetcher<Data> | null | undefined, SWRConfiguration | undefined]
   ) => {
     const [key, fn, config] = normalize(args)
     const uses = (config.use || []).concat(middleware)

--- a/test/unit/utils.test.tsx
+++ b/test/unit/utils.test.tsx
@@ -9,7 +9,7 @@ describe('Utils', () => {
     const opts = { revalidateOnFocus: false }
 
     // Only the `key` argument is passed
-    expect(normalize(['key'])).toEqual(['key', null, {}])
+    expect(normalize(['key'])).toEqual(['key', undefined, {}])
 
     // `key` and `null` as fetcher (no fetcher)
     expect(normalize(['key', null])).toEqual(['key', null, {}])
@@ -18,7 +18,7 @@ describe('Utils', () => {
     expect(normalize(['key', fetcher])).toEqual(['key', fetcher, {}])
 
     // `key` and `options`
-    expect(normalize(['key', opts])).toEqual(['key', null, opts])
+    expect(normalize(['key', opts])).toEqual(['key', undefined, opts])
 
     // `key`, `null` as fetcher, and `options`
     expect(normalize(['key', null, opts])).toEqual(['key', null, opts])

--- a/test/use-swr-fetcher.test.tsx
+++ b/test/use-swr-fetcher.test.tsx
@@ -126,4 +126,26 @@ describe('useSWR - fetcher', () => {
     rerender(<Page fetcher={false} />)
     screen.getByText('data:')
   })
+
+  it('should be able to pass null to the fetcher even config.fetcher is provided', () => {
+    const key = createKey()
+    const fn = jest.fn()
+
+    function Page() {
+      const { data } = useSWR(key, null, {
+        fetcher: fn
+      })
+
+      return (
+        <div>
+          <p>data:{data}</p>
+        </div>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('data:')
+
+    expect(fn).not.toHaveBeenCalled()
+  })
 })

--- a/test/use-swr-middlewares.test.tsx
+++ b/test/use-swr-middlewares.test.tsx
@@ -57,6 +57,25 @@ describe('useSWR - middleware', () => {
     expect(mockConsoleLog.mock.calls.length).toBe(2)
   })
 
+  it('should pass null fetcher to middleware', () => {
+    const key = createKey()
+    const mockConsoleLog = jest.fn(s => s)
+    const loggerMiddleware: Middleware = useSWRNext => (k, fn, config) => {
+      mockConsoleLog(fn)
+      return useSWRNext(k, fn, config)
+    }
+    function Page() {
+      const { data } = useSWR(key, null, {
+        use: [loggerMiddleware]
+      })
+      return <div>hello, {data}</div>
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('hello,')
+    expect(mockConsoleLog.mock.calls[0][0]).toEqual(null)
+  })
+
   it('should support `use` option in context', async () => {
     const key = createKey()
     const mockConsoleLog = jest.fn(s => s)


### PR DESCRIPTION
Fixes #2155 and an alternative of #2240

This changes to use the fetcher argument rather than overriding by `config.fetcher` even if the argument is `null`.
There is an exception when the fetcher argument is `undefined`.