### PR TITLE
Update build target to es2018

### DIFF
--- a/_internal/package.json
+++ b/_internal/package.json
@@ -5,8 +5,8 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "scripts": {
-    "watch": "bunchee index.ts -w",
-    "build": "bunchee index.ts",
+    "watch": "bunchee --target es2018 index.ts -w",
+    "build": "bunchee --target es2018 index.ts",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -18,7 +18,7 @@ export const isFunction = <
 >(
   v: unknown
 ): v is T => typeof v == 'function'
-export const mergeObjects = (a: any, b?: any) => OBJECT.assign({}, a, b)
+export const mergeObjects = (a: any, b?: any) => ({ ...a, ...b })
 
 const STR_UNDEFINED = 'undefined'
 

--- a/core/package.json
+++ b/core/package.json
@@ -5,8 +5,8 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "scripts": {
-    "watch": "bunchee index.ts -w",
-    "build": "bunchee index.ts",
+    "watch": "bunchee --target es2018 index.ts -w",
+    "build": "bunchee --target es2018 index.ts",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -147,13 +147,11 @@ export const useSWRHandler = <Data = any, Error = any>(
         return snapshot
       }
 
-      return Object.assign(
-        {
-          isValidating: true,
-          isLoading: true
-        },
-        snapshot
-      )
+      return {
+        isValidating: true,
+        isLoading: true,
+        ...snapshot
+      }
     }
 
     let memorizedSnapshot = getSelectedCache()

--- a/immutable/package.json
+++ b/immutable/package.json
@@ -5,8 +5,8 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "scripts": {
-    "watch": "bunchee index.ts -w",
-    "build": "bunchee index.ts",
+    "watch": "bunchee --target es2018 index.ts -w",
+    "build": "bunchee --target es2018 index.ts",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/infinite/package.json
+++ b/infinite/package.json
@@ -5,8 +5,8 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "scripts": {
-    "watch": "bunchee index.ts -w",
-    "build": "bunchee index.ts",
+    "watch": "bunchee --target es2018 index.ts -w",
+    "build": "bunchee --target es2018 index.ts",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/mutation/package.json
+++ b/mutation/package.json
@@ -5,8 +5,8 @@
   "exports": "./dist/index.mjs",
   "private": true,
   "scripts": {
-    "watch": "bunchee index.ts -w",
-    "build": "bunchee index.ts",
+    "watch": "bunchee --target es2018 index.ts -w",
+    "build": "bunchee --target es2018 index.ts",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "clean": "pnpm -r run clean",
     "watch": "pnpm -r run watch",
     "build": "pnpm build-package _internal && pnpm build-package core && pnpm build-package infinite && pnpm build-package immutable && pnpm build-package mutation",
-    "build-package": "bunchee index.ts --cwd",
+    "build-package": "bunchee --target es2018 index.ts --cwd",
     "types:check": "pnpm -r run types:check",
     "prepublishOnly": "pnpm clean && pnpm build",
     "publish-beta": "pnpm publish --tag beta",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,
-    "target": "es5",
+    "target": "ES2018",
     "baseUrl": ".",
     "noEmitOnError": true,
     "paths": {


### PR DESCRIPTION
For most use cases of SWR, users either have a modern browser (e.g. using modules in the browser + CDN), or have a bundler (esbuild, Webpack). If you still need to target old browsers, it's easy to target a lower version with the bundler.

This change makes sense for the 2.0 version. For the majority this improves the performance of SWR by a lot. According to #2095, the new bundle size will be ~80% of the `es5` target. And measured by the [SSR benchmark](https://github.com/pwrdrvr/swr-server-side), switching from `Object.assign` to the native spread operator makes SSR 4.7x faster (P50) in Node.js 16. This scales linearly with the app size, because each `useSWR()` call contains around 3 `Object.assign` operations.
