### PR TITLE
[WIP] test: setup e2e testing using playwright components test

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+playwright-ct.config.ts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,3 +29,13 @@ jobs:
       - run: pnpm build
         env:
           CI: true
+      - name: Install Playwright
+        run: npx playwright install --with-deps
+      - run: pnpm test-ct
+      - name: Upload playwright test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ package-lock.json
 *.tsbuildinfo
 coverage
 .rollup.cache
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prepare": "husky install",
     "csb:install": "pnpm i -g pnpm@7",
     "csb:build": "pnpm install && pnpm build",
-    "clean": "pnpm -r run clean",
+    "clean": "pnpm -r run clean && rimraf dist playwright-report test-results",
     "watch": "pnpm -r run watch",
     "build": "pnpm build-package _internal && pnpm build-package core && pnpm build-package infinite && pnpm build-package immutable && pnpm build-package mutation",
     "build-package": "bunchee --target es2018 index.ts --cwd",
@@ -78,8 +78,14 @@
     "lint:fix": "pnpm lint --fix",
     "coverage": "jest --coverage",
     "test-typing": "tsc --noEmit -p test/type/tsconfig.json && tsc --noEmit -p test/tsconfig.json",
-    "test": "jest",
-    "run-all-checks": "pnpm types:check && pnpm lint && pnpm test && pnpm test-typing"
+    "run-all-checks": "pnpm types:check && pnpm lint && pnpm test && pnpm test-typing",
+    "test": "tsc --noEmit -p test && jest",
+    "test-ct": "rimraf playwright/.cache && playwright test -c playwright-ct.config.ts"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged && pnpm types:check"
+    }
   },
   "lint-staged": {
     "*.{ts,tsx}": [
@@ -88,10 +94,12 @@
     ]
   },
   "devDependencies": {
+    "@playwright/experimental-ct-react": "^1.28.1",
+    "@playwright/test": "^1.28.1",
     "@swc/core": "^1.3.5",
     "@swc/jest": "0.2.23",
-    "@testing-library/jest-dom": "^5.16.4",
-    "@testing-library/react": "^13.1.1",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
     "@type-challenges/utils": "0.1.1",
     "@types/jest": "^27.5.1",
     "@types/node": "^18.7.14",
@@ -112,12 +120,12 @@
     "lint-staged": "13.0.3",
     "next": "^12.1.6",
     "prettier": "2.6.2",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "rimraf": "3.0.2",
-    "swr": "workspace:*",
     "tslib": "2.4.0",
-    "typescript": "4.8.2"
+    "typescript": "4.8.2",
+    "swr": "workspace:*"
   },
   "peerDependencies": {
     "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
@@ -133,7 +141,7 @@
   "engines": {
     "pnpm": "7"
   },
-  "dependencies": {
+  "dependencies": { 
     "use-sync-external-store": "^1.2.0"
   }
 }

--- a/playwright-ct.config.ts
+++ b/playwright-ct.config.ts
@@ -1,0 +1,65 @@
+import type { PlaywrightTestConfig } from '@playwright/experimental-ct-react'
+import { devices } from '@playwright/experimental-ct-react'
+
+const config: PlaywrightTestConfig = {
+  testDir: './test/e2e',
+  /* The base directory, relative to the config file, for snapshot files created with toMatchSnapshot and toHaveScreenshot. */
+  snapshotDir: './test/e2e/__snapshots__',
+  /* Maximum time one test can run for. */
+  timeout: 10 * 1000,
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: process.env.CI
+    ? [['github'], ['html', { open: 'on-failure' }]]
+    : [['html', { open: 'on-failure' }]],
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: process.env.CI ? 'on-first-retry' : 'on',
+
+    /* Port to use for Playwright component endpoint. */
+    ctPort: 3100,
+    ctViteConfig: {
+      resolve: {
+        alias: {
+          'react-dom': 'react-dom/profiling'
+        }
+      }
+    }
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome']
+      }
+    },
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox']
+      }
+    },
+    {
+      name: 'edge',
+      use: {
+        ...devices['Desktop Edge']
+      }
+    },
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari']
+      }
+    }
+  ]
+}
+
+export default config

--- a/playwright/index.html
+++ b/playwright/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Testing Page</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/playwright/index.ts"></script>
+  </body>
+</html>

--- a/playwright/tsconfig.json
+++ b/playwright/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": { 
+    "strict": false
+  },
+  "include": ["."],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,12 @@ importers:
 
   .:
     specifiers:
+      '@playwright/experimental-ct-react': ^1.28.1
+      '@playwright/test': ^1.28.1
       '@swc/core': ^1.3.5
       '@swc/jest': 0.2.23
-      '@testing-library/jest-dom': ^5.16.4
-      '@testing-library/react': ^13.1.1
+      '@testing-library/jest-dom': ^5.16.5
+      '@testing-library/react': ^13.4.0
       '@type-challenges/utils': 0.1.1
       '@types/jest': ^27.5.1
       '@types/node': ^18.7.14
@@ -28,8 +30,8 @@ importers:
       lint-staged: 13.0.3
       next: ^12.1.6
       prettier: 2.6.2
-      react: ^18.1.0
-      react-dom: ^18.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
       rimraf: 3.0.2
       swr: workspace:*
       tslib: 2.4.0
@@ -38,10 +40,12 @@ importers:
     dependencies:
       use-sync-external-store: 1.2.0_react@18.2.0
     devDependencies:
+      '@playwright/experimental-ct-react': 1.28.1_@types+node@18.7.14
+      '@playwright/test': 1.28.1
       '@swc/core': 1.3.6
       '@swc/jest': 0.2.23_@swc+core@1.3.6
-      '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 13.3.0_biqbaboplfbrettd7655fr4n2y
+      '@testing-library/jest-dom': 5.16.5
+      '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
       '@type-challenges/utils': 0.1.1
       '@types/jest': 27.5.2
       '@types/node': 18.7.14
@@ -86,6 +90,10 @@ importers:
 
 packages:
 
+  /@adobe/css-tools/4.0.1:
+    resolution: {integrity: sha512-+u76oB43nOHrF4DDWRLWDCtci7f3QJoEBigemIdIeTi1ODqjx6Tad9NCVnPRwewWlKkVab5PlK8DCtPTyX7S8g==}
+    dev: true
+
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
     engines: {node: '>=6.0.0'}
@@ -103,6 +111,11 @@ packages:
 
   /@babel/compat-data/7.18.8:
     resolution: {integrity: sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/compat-data/7.20.1:
+    resolution: {integrity: sha512-EWZ4mE2diW3QALKvDMiXnbZpRvlj+nayZ112nK93SnhqOtpdsbVD4W+2tEoT3YNBAG9RBR0ISY758ZkOgsn6pQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -129,6 +142,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/core/7.20.2:
+    resolution: {integrity: sha512-w7DbG8DtMrJcFOi4VrLm+8QM4az8Mo+PuLBKLp2zrYRCow8W/f9xiXm5sN53C8HksCyDQwCKha9JiDoIyPjT2g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.4
+      '@babel/helper-compilation-targets': 7.20.0_@babel+core@7.20.2
+      '@babel/helper-module-transforms': 7.20.2
+      '@babel/helpers': 7.20.1
+      '@babel/parser': 7.20.3
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
+      convert-source-map: 1.8.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/generator/7.18.9:
     resolution: {integrity: sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==}
     engines: {node: '>=6.9.0'}
@@ -136,6 +172,22 @@ packages:
       '@babel/types': 7.18.9
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
+    dev: true
+
+  /@babel/generator/7.20.4:
+    resolution: {integrity: sha512-luCf7yk/cm7yab6CAW1aiFnmEfBJplb/JojV56MYEK7ziWfGmFlTfmL9Ehwfy4gFhbjBfWO1wj7/TuSbVNEEtA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.2
+      '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/helper-annotate-as-pure/7.18.6:
+    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/helper-compilation-targets/7.18.9_@babel+core@7.18.9:
@@ -151,6 +203,19 @@ packages:
       semver: 6.3.0
     dev: true
 
+  /@babel/helper-compilation-targets/7.20.0_@babel+core@7.20.2:
+    resolution: {integrity: sha512-0jp//vDGp9e8hZzBc6N/KwA5ZK3Wsm/pfm4CrY7vzegkVxc65SgSn6wYOnwHe9Js9HRQ1YTCKLGPzDtaS3RoLQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/compat-data': 7.20.1
+      '@babel/core': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.4
+      semver: 6.3.0
+    dev: true
+
   /@babel/helper-environment-visitor/7.18.9:
     resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
@@ -162,6 +227,14 @@ packages:
     dependencies:
       '@babel/template': 7.18.6
       '@babel/types': 7.18.9
+    dev: true
+
+  /@babel/helper-function-name/7.19.0:
+    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/helper-hoist-variables/7.18.6:
@@ -194,8 +267,29 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helper-module-transforms/7.20.2:
+    resolution: {integrity: sha512-zvBKyJXRbmK07XhMuujYoJ48B5yvvmM6+wcpv6Ivj4Yg6qO7NOZOSnvZN9CRl1zz1Z4cKf8YejmCMh8clOoOeA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.20.2
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-plugin-utils/7.18.9:
     resolution: {integrity: sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-plugin-utils/7.20.2:
+    resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -206,6 +300,13 @@ packages:
       '@babel/types': 7.18.9
     dev: true
 
+  /@babel/helper-simple-access/7.20.2:
+    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.20.2
+    dev: true
+
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
@@ -213,8 +314,18 @@ packages:
       '@babel/types': 7.18.9
     dev: true
 
+  /@babel/helper-string-parser/7.19.4:
+    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-validator-identifier/7.18.6:
     resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-identifier/7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
     dev: true
 
@@ -234,6 +345,17 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/helpers/7.20.1:
+    resolution: {integrity: sha512-J77mUVaDTUJFZ5BpP6mMn6OIl3rEWymk2ZxDBQJUG3P+PbmyMcF3bYWvz0ma69Af1oobDqT/iAsvzhB58xhQUg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.20.1
+      '@babel/types': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
@@ -249,6 +371,14 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.18.9
+    dev: true
+
+  /@babel/parser/7.20.3:
+    resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.18.9:
@@ -294,6 +424,16 @@ packages:
     dependencies:
       '@babel/core': 7.18.9
       '@babel/helper-plugin-utils': 7.18.9
+    dev: true
+
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.18.9:
@@ -370,11 +510,64 @@ packages:
       '@babel/helper-plugin-utils': 7.18.9
     dev: true
 
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.2
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-source/7.19.6_@babel+core@7.20.2:
+    resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/helper-plugin-utils': 7.20.2
+    dev: true
+
+  /@babel/plugin-transform-react-jsx/7.19.0_@babel+core@7.20.2:
+    resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.2
+      '@babel/types': 7.20.2
+    dev: true
+
   /@babel/runtime/7.18.9:
     resolution: {integrity: sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
+    dev: true
+
+  /@babel/template/7.18.10:
+    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
     dev: true
 
   /@babel/template/7.18.6:
@@ -404,6 +597,24 @@ packages:
       - supports-color
     dev: true
 
+  /@babel/traverse/7.20.1:
+    resolution: {integrity: sha512-d3tN8fkVJwFLkHkBN479SOsw4DMZnz8cdbL/gvuDuzy3TS6Nfw80HuQqhw1pITbIruHyh7d1fMA47kWzmcUEGA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.4
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.20.3
+      '@babel/types': 7.20.2
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/types/7.18.9:
     resolution: {integrity: sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==}
     engines: {node: '>=6.9.0'}
@@ -412,9 +623,36 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
+  /@babel/types/7.20.2:
+    resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.19.4
+      '@babel/helper-validator-identifier': 7.19.1
+      to-fast-properties: 2.0.0
+    dev: true
+
   /@bcoe/v8-coverage/0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
+
+  /@esbuild/android-arm/0.15.15:
+    resolution: {integrity: sha512-JJjZjJi2eBL01QJuWjfCdZxcIgot+VoK6Fq7eKF9w4YHm9hwl7nhBR1o2Wnt/WcANk5l9SkpvrldW1PLuXxcbw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.15.15:
+    resolution: {integrity: sha512-lhz6UNPMDXUhtXSulw8XlFAtSYO26WmHQnCi2Lg2p+/TMiJKNLtZCYUxV4wG6rZMzXmr8InGpNwk+DLT2Hm0PA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@eslint/eslintrc/1.3.0:
     resolution: {integrity: sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==}
@@ -876,6 +1114,32 @@ packages:
       fastq: 1.13.0
     dev: true
 
+  /@playwright/experimental-ct-react/1.28.1_@types+node@18.7.14:
+    resolution: {integrity: sha512-YArwIFmRT7Z/VQGOocaUofTQAExd2XNkQdOslVaRwupFKhq6h9qTiWDgR7TQFY7cADtazb3ABRB5itdaRFGydA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@playwright/test': 1.28.1
+      '@vitejs/plugin-react': 2.2.0_vite@3.2.4
+      vite: 3.2.4_@types+node@18.7.14
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /@playwright/test/1.28.1:
+    resolution: {integrity: sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@types/node': 18.7.14
+      playwright-core: 1.28.1
+    dev: true
+
   /@rollup/plugin-commonjs/22.0.2_rollup@2.79.1:
     resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
     engines: {node: '>= 12.0.0'}
@@ -1145,23 +1409,23 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
-  /@testing-library/jest-dom/5.16.4:
-    resolution: {integrity: sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==}
+  /@testing-library/jest-dom/5.16.5:
+    resolution: {integrity: sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==}
     engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
     dependencies:
+      '@adobe/css-tools': 4.0.1
       '@babel/runtime': 7.18.9
       '@types/testing-library__jest-dom': 5.14.5
       aria-query: 5.0.0
       chalk: 3.0.0
-      css: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.5.14
       lodash: 4.17.21
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/13.3.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==}
+  /@testing-library/react/13.4.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
     engines: {node: '>=12'}
     peerDependencies:
       react: ^18.0.0
@@ -1169,7 +1433,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.18.9
       '@testing-library/dom': 8.16.0
-      '@types/react-dom': 18.0.6
+      '@types/react-dom': 18.0.9
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: true
@@ -1281,8 +1545,8 @@ packages:
     resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==}
     dev: true
 
-  /@types/react-dom/18.0.6:
-    resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
+  /@types/react-dom/18.0.9:
+    resolution: {integrity: sha512-qnVvHxASt/H7i+XG1U1xMiY5t+IHcPGUK7TDMDzom08xa7e86eCeKOiLZezwCKVxJn6NEiiy2ekgX8aQssjIKg==}
     dependencies:
       '@types/react': 18.0.15
     dev: true
@@ -1526,6 +1790,24 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
+  /@vitejs/plugin-react/2.2.0_vite@3.2.4:
+    resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^3.0.0
+    dependencies:
+      '@babel/core': 7.20.2
+      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.2
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.20.2
+      '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.2
+      magic-string: 0.26.7
+      react-refresh: 0.14.0
+      vite: 3.2.4_@types+node@18.7.14
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /abab/2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     dev: true
@@ -1691,12 +1973,6 @@ packages:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     dev: true
 
-  /atob/2.1.2:
-    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
-    engines: {node: '>= 4.5.0'}
-    hasBin: true
-    dev: true
-
   /babel-jest/28.1.3_@babel+core@7.18.9:
     resolution: {integrity: sha512-epUaPOEWMk3cWX0M/sPvCHHCe9fMFAa/9hXEgKP8nFfNl/jlGkE9ucq9NqkZGXLDduCJYS0UvSlPUwC0S+rH6Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0}
@@ -1802,6 +2078,17 @@ packages:
       update-browserslist-db: 1.0.5_browserslist@4.21.2
     dev: true
 
+  /browserslist/4.21.4:
+    resolution: {integrity: sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001434
+      electron-to-chromium: 1.4.284
+      node-releases: 2.0.6
+      update-browserslist-db: 1.0.10_browserslist@4.21.4
+    dev: true
+
   /bser/2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
     dependencies:
@@ -1863,6 +2150,10 @@ packages:
 
   /caniuse-lite/1.0.30001369:
     resolution: {integrity: sha512-OY1SBHaodJc4wflDIKnlkdqWzJZd1Ls/2zbVJHBSv3AT7vgOJ58yAhd2CN4d57l2kPJrgMb7P9+N1Mhy4tNSQA==}
+    dev: true
+
+  /caniuse-lite/1.0.30001434:
+    resolution: {integrity: sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==}
     dev: true
 
   /chalk/2.4.2:
@@ -2012,14 +2303,6 @@ packages:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
     dev: true
 
-  /css/3.0.0:
-    resolution: {integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==}
-    dependencies:
-      inherits: 2.0.4
-      source-map: 0.6.1
-      source-map-resolve: 0.6.0
-    dev: true
-
   /cssom/0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
     dev: true
@@ -2062,11 +2345,6 @@ packages:
 
   /decimal.js/10.3.1:
     resolution: {integrity: sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==}
-    dev: true
-
-  /decode-uri-component/0.2.0:
-    resolution: {integrity: sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==}
-    engines: {node: '>=0.10'}
     dev: true
 
   /dedent/0.7.0:
@@ -2150,6 +2428,10 @@ packages:
     resolution: {integrity: sha512-WIGME0Cs7oob3mxsJwHbeWkH0tYkIE/sjkJ8ML2BYmuRcjhRl/q5kVDXG7W9LOOKwzPU5M0LBlXRq9rlSgnNlg==}
     dev: true
 
+  /electron-to-chromium/1.4.284:
+    resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+    dev: true
+
   /emittery/0.10.2:
     resolution: {integrity: sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==}
     engines: {node: '>=12'}
@@ -2211,6 +2493,216 @@ packages:
       is-callable: 1.2.4
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+    dev: true
+
+  /esbuild-android-64/0.15.15:
+    resolution: {integrity: sha512-F+WjjQxO+JQOva3tJWNdVjouFMLK6R6i5gjDvgUthLYJnIZJsp1HlF523k73hELY20WPyEO8xcz7aaYBVkeg5Q==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.15.15:
+    resolution: {integrity: sha512-attlyhD6Y22jNyQ0fIIQ7mnPvDWKw7k6FKnsXlBvQE6s3z6s6cuEHcSgoirquQc7TmZgVCK5fD/2uxmRN+ZpcQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.15.15:
+    resolution: {integrity: sha512-ohZtF8W1SHJ4JWldsPVdk8st0r9ExbAOSrBOh5L+Mq47i696GVwv1ab/KlmbUoikSTNoXEhDzVpxUR/WIO19FQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.15.15:
+    resolution: {integrity: sha512-P8jOZ5zshCNIuGn+9KehKs/cq5uIniC+BeCykvdVhx/rBXSxmtj3CUIKZz4sDCuESMbitK54drf/2QX9QHG5Ag==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.15.15:
+    resolution: {integrity: sha512-KkTg+AmDXz1IvA9S1gt8dE24C8Thx0X5oM0KGF322DuP+P3evwTL9YyusHAWNsh4qLsR80nvBr/EIYs29VSwuA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.15.15:
+    resolution: {integrity: sha512-FUcML0DRsuyqCMfAC+HoeAqvWxMeq0qXvclZZ/lt2kLU6XBnDA5uKTLUd379WYEyVD4KKFctqWd9tTuk8C/96g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.15.15:
+    resolution: {integrity: sha512-q28Qn5pZgHNqug02aTkzw5sW9OklSo96b5nm17Mq0pDXrdTBcQ+M6Q9A1B+dalFeynunwh/pvfrNucjzwDXj+Q==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.15.15:
+    resolution: {integrity: sha512-217KPmWMirkf8liO+fj2qrPwbIbhNTGNVtvqI1TnOWJgcMjUWvd677Gq3fTzXEjilkx2yWypVnTswM2KbXgoAg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.15.15:
+    resolution: {integrity: sha512-RYVW9o2yN8yM7SB1yaWr378CwrjvGCyGybX3SdzPHpikUHkME2AP55Ma20uNwkNyY2eSYFX9D55kDrfQmQBR4w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.15.15:
+    resolution: {integrity: sha512-/ltmNFs0FivZkYsTzAsXIfLQX38lFnwJTWCJts0IbCqWZQe+jjj0vYBNbI0kmXLb3y5NljiM5USVAO1NVkdh2g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.15.15:
+    resolution: {integrity: sha512-PksEPb321/28GFFxtvL33yVPfnMZihxkEv5zME2zapXGp7fA1X2jYeiTUK+9tJ/EGgcNWuwvtawPxJG7Mmn86A==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.15.15:
+    resolution: {integrity: sha512-ek8gJBEIhcpGI327eAZigBOHl58QqrJrYYIZBWQCnH3UnXoeWMrMZLeeZL8BI2XMBhP+sQ6ERctD5X+ajL/AIA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.15.15:
+    resolution: {integrity: sha512-H5ilTZb33/GnUBrZMNJtBk7/OXzDHDXjIzoLXHSutwwsLxSNaLxzAaMoDGDd/keZoS+GDBqNVxdCkpuiRW4OSw==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.15.15:
+    resolution: {integrity: sha512-jKaLUg78mua3rrtrkpv4Or2dNTJU7bgHN4bEjT4OX4GR7nLBSA9dfJezQouTxMmIW7opwEC5/iR9mpC18utnxQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.15.15:
+    resolution: {integrity: sha512-aOvmF/UkjFuW6F36HbIlImJTTx45KUCHJndtKo+KdP8Dhq3mgLRKW9+6Ircpm8bX/RcS3zZMMmaBLkvGY06Gvw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.15.15:
+    resolution: {integrity: sha512-HFFX+WYedx1w2yJ1VyR1Dfo8zyYGQZf1cA69bLdrHzu9svj6KH6ZLK0k3A1/LFPhcEY9idSOhsB2UyU0tHPxgQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.15.15:
+    resolution: {integrity: sha512-jOPBudffG4HN8yJXcK9rib/ZTFoTA5pvIKbRrt3IKAGMq1EpBi4xoVoSRrq/0d4OgZLaQbmkHp8RO9eZIn5atA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.15.15:
+    resolution: {integrity: sha512-MDkJ3QkjnCetKF0fKxCyYNBnOq6dmidcwstBVeMtXSgGYTy8XSwBeIE4+HuKiSsG6I/mXEb++px3IGSmTN0XiA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64/0.15.15:
+    resolution: {integrity: sha512-xaAUIB2qllE888SsMU3j9nrqyLbkqqkpQyWVkfwSil6BBPgcPk3zOFitTTncEKCLTQy3XV9RuH7PDj3aJDljWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.15.15:
+    resolution: {integrity: sha512-ttuoCYCIJAFx4UUKKWYnFdrVpoXa3+3WWkXVI6s09U+YjhnyM5h96ewTq/WgQj9LFSIlABQvadHSOQyAVjW5xQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild/0.15.15:
+    resolution: {integrity: sha512-TEw/lwK4Zzld9x3FedV6jy8onOUHqcEX3ADFk4k+gzPUwrxn8nWV62tH0udo8jOtjFodlEfc4ypsqX3e+WWO6w==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.15.15
+      '@esbuild/linux-loong64': 0.15.15
+      esbuild-android-64: 0.15.15
+      esbuild-android-arm64: 0.15.15
+      esbuild-darwin-64: 0.15.15
+      esbuild-darwin-arm64: 0.15.15
+      esbuild-freebsd-64: 0.15.15
+      esbuild-freebsd-arm64: 0.15.15
+      esbuild-linux-32: 0.15.15
+      esbuild-linux-64: 0.15.15
+      esbuild-linux-arm: 0.15.15
+      esbuild-linux-arm64: 0.15.15
+      esbuild-linux-mips64le: 0.15.15
+      esbuild-linux-ppc64le: 0.15.15
+      esbuild-linux-riscv64: 0.15.15
+      esbuild-linux-s390x: 0.15.15
+      esbuild-netbsd-64: 0.15.15
+      esbuild-openbsd-64: 0.15.15
+      esbuild-sunos-64: 0.15.15
+      esbuild-windows-32: 0.15.15
+      esbuild-windows-64: 0.15.15
+      esbuild-windows-arm64: 0.15.15
     dev: true
 
   /escalade/3.1.1:
@@ -3487,7 +3979,6 @@ packages:
 
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-    dev: true
 
   /js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -3689,7 +4180,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-    dev: true
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -3709,8 +4199,8 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
-  /magic-string/0.26.6:
-    resolution: {integrity: sha512-6d+3bFybzyQFJYSoRsl9ZC0wheze8M1LrQC7tNMRqXR4izUTDOLMd9BtSuExK9iAukFh+s5K0WAhc/dlQ+HKYA==}
+  /magic-string/0.26.7:
+    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
     engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
@@ -4081,8 +4571,23 @@ packages:
       find-up: 4.1.0
     dev: true
 
+  /playwright-core/1.28.1:
+    resolution: {integrity: sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /postcss/8.4.14:
     resolution: {integrity: sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
+  /postcss/8.4.19:
+    resolution: {integrity: sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.4
@@ -4176,12 +4681,16 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
+  /react-refresh/0.14.0:
+    resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /react/18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
     dependencies:
       loose-envify: 1.4.0
-    dev: true
 
   /redent/3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -4290,7 +4799,7 @@ packages:
       rollup: ^2.55
       typescript: ^4.1
     dependencies:
-      magic-string: 0.26.6
+      magic-string: 0.26.7
       rollup: 2.79.1
       typescript: 4.8.2
     optionalDependencies:
@@ -4433,14 +4942,6 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
-    dev: true
-
-  /source-map-resolve/0.6.0:
-    resolution: {integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==}
-    deprecated: See https://github.com/lydell/source-map-resolve#deprecated
-    dependencies:
-      atob: 2.1.2
-      decode-uri-component: 0.2.0
     dev: true
 
   /source-map-support/0.5.13:
@@ -4749,6 +5250,17 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /update-browserslist-db/1.0.10_browserslist@4.21.4:
+    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.21.4
+      escalade: 3.1.1
+      picocolors: 1.0.0
+    dev: true
+
   /update-browserslist-db/1.0.5_browserslist@4.21.2:
     resolution: {integrity: sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==}
     hasBin: true
@@ -4784,6 +5296,40 @@ packages:
       '@jridgewell/trace-mapping': 0.3.14
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
+    dev: true
+
+  /vite/3.2.4_@types+node@18.7.14:
+    resolution: {integrity: sha512-Z2X6SRAffOUYTa+sLy3NQ7nlHFU100xwanq1WDwqaiFiCe+25zdxP1TfCS5ojPV2oDDcXudHIoPnI1Z/66B7Yw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.7.14
+      esbuild: 0.15.15
+      postcss: 8.4.19
+      resolve: 1.22.1
+      rollup: 2.79.1
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /w3c-hr-time/1.0.2:

--- a/test/common-utils.ts
+++ b/test/common-utils.ts
@@ -1,0 +1,19 @@
+export const createKey = () => 'swr-key-' + ~~(Math.random() * 1e7)
+
+export function sleep(time: number) {
+  return new Promise<void>(resolve => setTimeout(resolve, time))
+}
+
+export const createResponse = <T>(
+  response: T,
+  { delay } = { delay: 10 }
+): Promise<T> =>
+  new Promise((resolve, reject) =>
+    setTimeout(() => {
+      if (response instanceof Error) {
+        reject(response)
+      } else {
+        resolve(response)
+      }
+    }, delay)
+  )

--- a/test/e2e/components/provider.tsx
+++ b/test/e2e/components/provider.tsx
@@ -1,0 +1,32 @@
+import React, { type PropsWithChildren, StrictMode } from 'react'
+import { SWRConfig } from 'swr'
+
+const ProviderWithConfig = ({
+  children,
+  value
+}: PropsWithChildren<{ value: Parameters<typeof SWRConfig>[0]['value'] }>) => {
+  return (
+    <StrictMode>
+      <SWRConfig value={value}>{children}</SWRConfig>
+    </StrictMode>
+  )
+}
+
+export const Provider = ({
+  children,
+  value
+}: PropsWithChildren<{ value?: Parameters<typeof SWRConfig>[0]['value'] }>) => {
+  const provider = () => new Map()
+  return (
+    <ProviderWithConfig value={{ ...value, provider }}>
+      {children}
+    </ProviderWithConfig>
+  )
+}
+
+export const ProviderWithGlobalCache = ({
+  children,
+  value
+}: PropsWithChildren<{ value: Parameters<typeof SWRConfig>[0]['value'] }>) => {
+  return <ProviderWithConfig value={value}>{children}</ProviderWithConfig>
+}

--- a/test/e2e/components/swr-nested-render.tsx
+++ b/test/e2e/components/swr-nested-render.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import useSWR from 'swr'
+import { createResponse } from '../../common-utils'
+import { Provider } from './provider'
+
+const NestedRender = ({ testKey }: { testKey: string }) => {
+  const { data, isValidating } = useSWR(testKey, key =>
+    createResponse(key, { delay: 500 })
+  )
+  if (isValidating) {
+    return <div>loading</div>
+  }
+  return (
+    <Provider>
+      <div id="parent">{data}</div>
+      <ChildComponent testKey={testKey}></ChildComponent>
+    </Provider>
+  )
+}
+
+const ChildComponent = ({ testKey }: { testKey: string }) => {
+  const { data } = useSWR(testKey, key => createResponse(key, { delay: 2000 }))
+  return <div id="child">{data}</div>
+}
+
+export default NestedRender

--- a/test/e2e/integration.spec.tsx
+++ b/test/e2e/integration.spec.tsx
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/experimental-ct-react'
+import React, { Profiler } from 'react'
+import { createKey } from '../common-utils'
+import NestedRender from './components/swr-nested-render'
+test.use({ viewport: { width: 500, height: 500 } })
+
+test.describe('SWR integration', () => {
+  test('Nested SWR hook should only do loading once', async ({ mount }) => {
+    const key = createKey()
+    let count = 0
+    const component = await mount(
+      <Profiler
+        id={key}
+        onRender={() => {
+          count += 1
+        }}
+      >
+        <NestedRender testKey={key}></NestedRender>
+      </Profiler>
+    )
+    await expect(component).toContainText('loading')
+    await expect(component).toContainText(key)
+    expect(count).toEqual(2)
+  })
+})

--- a/test/render-utils.tsx
+++ b/test/render-utils.tsx
@@ -1,33 +1,13 @@
 import { act, fireEvent, render } from '@testing-library/react'
 import React from 'react'
 import { SWRConfig } from 'swr'
-
-export function sleep(time: number) {
-  return new Promise<void>(resolve => setTimeout(resolve, time))
-}
-
-export const createResponse = <T,>(
-  response: T,
-  { delay } = { delay: 10 }
-): Promise<T> =>
-  new Promise((resolve, reject) =>
-    setTimeout(() => {
-      if (response instanceof Error) {
-        reject(response)
-      } else {
-        resolve(response)
-      }
-    }, delay)
-  )
-
+import { sleep } from './common-utils'
 export const nextTick = () => act(() => sleep(1))
 
 export const focusOn = (element: any) =>
   act(async () => {
     fireEvent.focus(element)
   })
-
-export const createKey = () => 'swr-key-' + ~~(Math.random() * 1e7)
 
 const _renderWithConfig = (
   element: React.ReactElement,
@@ -68,3 +48,5 @@ export async function executeWithoutBatching(fn: () => any) {
   await fn()
   global.IS_REACT_ACT_ENVIRONMENT = prev
 }
+
+export * from './common-utils'

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "strict": false
+    "strict": false,
+    "skipLibCheck": true
   },
   "include": [".", "./jest-setup.ts"],
   "exclude": ["./type"]

--- a/test/use-swr-cache.test.tsx
+++ b/test/use-swr-cache.test.tsx
@@ -9,7 +9,7 @@ import {
   focusOn,
   renderWithConfig,
   renderWithGlobalCache
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - cache provider', () => {
   let provider

--- a/test/use-swr-concurrent-rendering.test.tsx
+++ b/test/use-swr-concurrent-rendering.test.tsx
@@ -5,7 +5,7 @@ import {
   sleep,
   executeWithoutBatching,
   renderWithConfig
-} from './utils'
+} from './render-utils'
 
 import React from 'react'
 import useSWR from 'swr'

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -1,7 +1,12 @@
 import { act, screen, fireEvent } from '@testing-library/react'
 import React from 'react'
 import useSWR from 'swr'
-import { sleep, createResponse, renderWithConfig, createKey } from './utils'
+import {
+  sleep,
+  createResponse,
+  renderWithConfig,
+  createKey
+} from './render-utils'
 
 describe('useSWR - config callbacks', () => {
   it('should trigger the onSuccess event with the latest version of the onSuccess callback', async () => {

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -2,7 +2,11 @@ import { act, screen, fireEvent } from '@testing-library/react'
 import React, { useEffect, useState } from 'react'
 import type { Middleware } from 'swr'
 import useSWR, { SWRConfig, useSWRConfig } from 'swr'
-import { renderWithConfig, createKey, renderWithGlobalCache } from './utils'
+import {
+  renderWithConfig,
+  createKey,
+  renderWithGlobalCache
+} from './render-utils'
 
 describe('useSWR - configs', () => {
   it('should read the config fallback from the context', async () => {

--- a/test/use-swr-context-config.test.tsx
+++ b/test/use-swr-context-config.test.tsx
@@ -1,7 +1,11 @@
 import { act, screen } from '@testing-library/react'
 import React from 'react'
 import useSWR, { mutate } from 'swr'
-import { createKey, createResponse, renderWithGlobalCache } from './utils'
+import {
+  createKey,
+  createResponse,
+  renderWithGlobalCache
+} from './render-utils'
 
 describe('useSWR - context configs', () => {
   it('mutate before mount should not block rerender', async () => {

--- a/test/use-swr-devtools.test.tsx
+++ b/test/use-swr-devtools.test.tsx
@@ -12,7 +12,11 @@ describe('useSWR - devtools', () => {
       }
     // @ts-expect-error
     window.__SWR_DEVTOOLS_USE__ = [middleware]
-    ;({ createKey, createResponse, renderWithConfig } = require('./utils'))
+    ;({
+      createKey,
+      createResponse,
+      renderWithConfig
+    } = require('./render-utils'))
     useSWR = require('swr').default
   })
   it('window.__SWR_DEVTOOLS_USE__ should be set as middleware', async () => {

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -7,7 +7,7 @@ import {
   createKey,
   renderWithConfig,
   mockVisibilityHidden
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - error', () => {
   it('should handle errors', async () => {

--- a/test/use-swr-fetcher.test.tsx
+++ b/test/use-swr-fetcher.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, screen } from '@testing-library/react'
 import React, { Suspense, useState } from 'react'
 import useSWR from 'swr'
-import { createKey, renderWithConfig, nextTick } from './utils'
+import { createKey, renderWithConfig, nextTick } from './render-utils'
 
 describe('useSWR - fetcher', () => {
   // https://github.com/vercel/swr/issues/1131

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -7,7 +7,7 @@ import {
   focusOn,
   renderWithConfig,
   createKey
-} from './utils'
+} from './render-utils'
 
 const focusWindow = () => focusOn(window)
 

--- a/test/use-swr-immutable.test.tsx
+++ b/test/use-swr-immutable.test.tsx
@@ -8,7 +8,7 @@ import {
   nextTick as waitForNextTick,
   focusOn,
   renderWithConfig
-} from './utils'
+} from './render-utils'
 
 const focusWindow = () => focusOn(window)
 

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -10,7 +10,7 @@ import {
   renderWithConfig,
   renderWithGlobalCache,
   executeWithoutBatching
-} from './utils'
+} from './render-utils'
 
 describe('useSWRInfinite', () => {
   it('should render the first page component', async () => {

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -8,7 +8,7 @@ import {
   renderWithConfig,
   createKey,
   renderWithGlobalCache
-} from './utils'
+} from './render-utils'
 
 describe('useSWR', () => {
   const sharedKey = createKey()

--- a/test/use-swr-key.test.tsx
+++ b/test/use-swr-key.test.tsx
@@ -7,7 +7,7 @@ import {
   executeWithoutBatching,
   renderWithConfig,
   sleep
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - key', () => {
   it('should respect requests after key has changed', async () => {

--- a/test/use-swr-laggy.test.tsx
+++ b/test/use-swr-laggy.test.tsx
@@ -3,7 +3,12 @@ import React, { useState } from 'react'
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
 
-import { createKey, createResponse, renderWithConfig, sleep } from './utils'
+import {
+  createKey,
+  createResponse,
+  renderWithConfig,
+  sleep
+} from './render-utils'
 
 describe('useSWR - keep previous data', () => {
   it('should keep previous data when key changes when `keepPreviousData` is enabled', async () => {

--- a/test/use-swr-loading.test.tsx
+++ b/test/use-swr-loading.test.tsx
@@ -8,7 +8,7 @@ import {
   renderWithConfig,
   nextTick,
   executeWithoutBatching
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - loading', () => {
   it('should return validating state', async () => {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -11,7 +11,7 @@ import {
   renderWithConfig,
   renderWithGlobalCache,
   executeWithoutBatching
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - local mutation', () => {
   it('should trigger revalidation programmatically', async () => {

--- a/test/use-swr-middlewares.test.tsx
+++ b/test/use-swr-middlewares.test.tsx
@@ -10,7 +10,7 @@ import {
   createKey,
   nextTick,
   renderWithConfig
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - middleware', () => {
   it('should use middleware', async () => {

--- a/test/use-swr-node-env.test.tsx
+++ b/test/use-swr-node-env.test.tsx
@@ -10,7 +10,7 @@ import { renderToString } from 'react-dom/server'
 import useSWR from 'swr'
 import useSWRImmutable from 'swr/immutable'
 import { IS_SERVER } from 'swr/_internal'
-import { createKey } from './utils'
+import { createKey } from './render-utils'
 
 describe('useSWR', () => {
   it('env IS_SERVER is true in node env', () => {

--- a/test/use-swr-offline.test.tsx
+++ b/test/use-swr-offline.test.tsx
@@ -6,7 +6,7 @@ import {
   focusOn,
   createKey,
   renderWithConfig
-} from './utils'
+} from './render-utils'
 
 const focusWindow = () => focusOn(window)
 const dispatchWindowEvent = event =>

--- a/test/use-swr-preload.test.tsx
+++ b/test/use-swr-preload.test.tsx
@@ -1,7 +1,12 @@
 import { act, fireEvent, screen } from '@testing-library/react'
 import React, { Suspense, useEffect, useState } from 'react'
 import useSWR, { preload, useSWRConfig } from 'swr'
-import { createKey, createResponse, renderWithConfig, sleep } from './utils'
+import {
+  createKey,
+  createResponse,
+  renderWithConfig,
+  sleep
+} from './render-utils'
 
 describe('useSWR - preload', () => {
   it('preload the fetcher function', async () => {

--- a/test/use-swr-reconnect.test.tsx
+++ b/test/use-swr-reconnect.test.tsx
@@ -6,7 +6,7 @@ import {
   renderWithConfig,
   createKey,
   mockVisibilityHidden
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - reconnect', () => {
   it('should revalidate on reconnect by default', async () => {

--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -1,7 +1,7 @@
 import { act, fireEvent, screen } from '@testing-library/react'
 import React, { useState } from 'react'
 import useSWR, { SWRConfig } from 'swr'
-import { createKey, renderWithConfig, sleep } from './utils'
+import { createKey, renderWithConfig, sleep } from './render-utils'
 
 // This has to be an async function to wait for a microtask to flush updates
 const advanceTimers = async (ms: number) => jest.advanceTimersByTime(ms) as any

--- a/test/use-swr-remote-mutation.test.tsx
+++ b/test/use-swr-remote-mutation.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import React from 'react'
 import useSWR from 'swr'
 import useSWRMutation from 'swr/mutation'
-import { createKey, sleep, nextTick } from './utils'
+import { createKey, sleep, nextTick } from './render-utils'
 
 const waitForNextTick = () => act(() => sleep(1))
 

--- a/test/use-swr-revalidate.test.tsx
+++ b/test/use-swr-revalidate.test.tsx
@@ -8,7 +8,7 @@ import {
   createKey,
   renderWithConfig,
   nextTick
-} from './utils'
+} from './render-utils'
 
 describe('useSWR - revalidate', () => {
   it('should rerender after triggering revalidation', async () => {

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -8,7 +8,7 @@ import {
   renderWithConfig,
   renderWithGlobalCache,
   sleep
-} from './utils'
+} from './render-utils'
 
 class ErrorBoundary extends React.Component<
   PropsWithChildren<{ fallback: ReactNode }>


### PR DESCRIPTION
## Motivation
This pr intends to setup playwright for swr. So we can add e2e test easily in the future. 

Most of tests in swr only need to make assertions about dom. playwright is a good choice for this.

## Benefit
1. Real browser api could be used

swr uses a lot of navigator specific APIs. It would be batter if we could use real browser enviorment for testing. It's more reliable then jsdom.

2. It is easier to write test

we dont need to worry about details like  [act](https://kentcdodds.com/blog/fix-the-not-wrapped-in-act-warning) or [StrictMode](https://github.com/reactwg/react-18/discussions/17) in  e2e test.  playwright also has test generator and vscode extension to help us write tests.

3. It has detailed trace info for debugging or performance monitoring

playwright could provider detailed [trace info](https://playwright.dev/docs/trace-viewer) for debugging or performance monitoring. It would help a lot to prevent flaky tests.  It could also collect some [low-level trace info](https://playwright.dev/docs/api/class-browser#browser-start-tracing) for us to evaluate swr's performance.

