### PR TITLE
types: make FullConfiguration generic

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -191,7 +191,11 @@ export interface PublicConfiguration<
   isVisible: () => boolean
 }
 
-export type FullConfiguration = InternalConfiguration & PublicConfiguration
+export type FullConfiguration<
+  Data = any,
+  Error = any,
+  Fn extends Fetcher = BareFetcher
+> = InternalConfiguration & PublicConfiguration<Data, Error, Fn>
 
 export type ProviderConfiguration = {
   initFocus: (callback: () => void) => (() => void) | void

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -53,7 +53,8 @@ type DefinitelyTruthy<T> = false extends T
 export const useSWRHandler = <Data = any, Error = any>(
   _key: Key,
   fetcher: Fetcher<Data> | null,
-  config: typeof defaultConfig & SWRConfiguration<Data, Error>
+  config: FullConfiguration<Data, Error, Fetcher<Data>> &
+    SWRConfiguration<Data, Error>
 ) => {
   const {
     cache,
@@ -396,7 +397,7 @@ export const useSWRHandler = <Data = any, Error = any>(
             getConfig().onSuccess(newData, key, config)
           }
         }
-      } catch (err) {
+      } catch (err: any) {
         cleanupState()
 
         const currentConfig = getConfig()

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { Cache } from 'swr'
 import { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
+import type { FullConfiguration } from 'swr/_internal'
 
 export function useTestCache() {
   expectType<Cache<any>>(useSWRConfig().cache)
@@ -27,4 +28,13 @@ export function useCustomSWRConfig() {
       />
     </>
   )
+}
+
+export function useFullConfiguration() {
+  type IData = { value: string }
+  type IError = { error: any }
+  type IConfig = FullConfiguration<IData, IError>
+
+  const config: IConfig = SWRConfig.defaultValue
+  expectType<IData | undefined>(config.fallbackData)
 }


### PR DESCRIPTION
Make `FullConfiguration` as generic for better type inference. With this change, `fallbackData` from config could be inferred as `Data | undefined` instead of just `any` inside useSWR hook