### PR TITLE
Issue 1933 - Cancellation of requests when no longer needed

### DIFF
--- a/test/use-swr-middlewares.test.tsx
+++ b/test/use-swr-middlewares.test.tsx
@@ -2,6 +2,7 @@ import { act, screen } from '@testing-library/react'
 import React, { useState, useEffect, useRef } from 'react'
 import type { Middleware } from 'swr'
 import useSWR, { SWRConfig } from 'swr'
+import type { FetcherSecondParameter } from 'swr/_internal'
 import { withMiddleware } from 'swr/_internal'
 
 import {
@@ -242,7 +243,7 @@ describe('useSWR - middleware', () => {
     function Page() {
       const { data } = useSWR(
         [key, { hello: 'world' }],
-        (_, o) => {
+        (_, o: FetcherSecondParameter & { hello: string }) => {
           return o.hello
         },
         {


### PR DESCRIPTION
First attempt at #1933 - adding a cancellation mechanism to fetchers. 

Looking for feedback on the approach and if there is any huge landmines I'm missing. I won't be offended if this is just a big 'no'.

Still working on how to appropriately test this.

TODO:
- Not sure how error handling works as this will cause the await to throw a DOMException from the abort call, and don't want this to send the hook into an error state.
- Testing.
- Tests - fix existing ones and add new ones related to the change.
- Add an example?