### PR TITLE
types: conditional swr response

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -21,7 +21,7 @@ export type Fetcher<
   ? (arg: Arg) => FetcherResponse<Data>
   : SWRKey extends null | undefined | false
   ? never
-  : SWRKey extends string | infer Arg
+  : SWRKey extends infer Arg
   ? (arg: Arg) => FetcherResponse<Data>
   : never
 

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -25,11 +25,14 @@ export type Fetcher<
   ? (arg: Arg) => FetcherResponse<Data>
   : never
 
-export type DataCached<Config, Data = any> = Config extends undefined
+export type BlockingData<
+  Data = any,
+  Options = SWROptions<Data>
+> = Options extends undefined
   ? false
-  : Config extends { suspense: true }
+  : Options extends { suspense: true }
   ? true
-  : Config extends { fallbackData: Data }
+  : Options extends { fallbackData: Data }
   ? true
   : false
 
@@ -235,7 +238,7 @@ export interface SWRHook {
   >(
     key: SWRKey,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
+  ): SWRResponse<Data, Error, SWROptions>
   <
     Data = any,
     Error = any,
@@ -249,7 +252,7 @@ export interface SWRHook {
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
+  ): SWRResponse<Data, Error, SWROptions>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
@@ -264,7 +267,7 @@ export interface SWRHook {
   >(
     key: Key,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
+  ): SWRResponse<Data, Error, SWROptions>
   <
     Data = any,
     Error = any,
@@ -275,7 +278,7 @@ export interface SWRHook {
     key: Key,
     fetcher: BareFetcher<Data> | null,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
+  ): SWRResponse<Data, Error, SWROptions>
 }
 
 // Middleware guarantees that a SWRHook receives a key, fetcher, and config as the argument
@@ -380,18 +383,19 @@ export type SWRConfiguration<
   Fn extends BareFetcher<any> = BareFetcher<any>
 > = Partial<PublicConfiguration<Data, Error, Fn>>
 
-export interface SWRResponse<Data = any, Error = any, Cached = false> {
+type SWROptions<Data> = SWRConfiguration<Data, Error, Fetcher<Data, Key>>
+export interface SWRResponse<Data = any, Error = any, Config = any> {
   /**
    * The returned data of the fetcher function.
    */
-  data: Cached extends true ? Data : Data | undefined
+  data: BlockingData<Data, Config> extends true ? Data : Data | undefined
   /**
    * The error object thrown by the fetcher function.
    */
   error: Error | undefined
   mutate: KeyedMutator<Data>
   isValidating: boolean
-  isLoading: Cached extends true ? false : boolean
+  isLoading: BlockingData<Data, Config> extends true ? false : boolean
 }
 
 export type KeyLoader<Args extends Arguments = Arguments> =

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -21,15 +21,15 @@ export type Fetcher<
   ? (arg: Arg) => FetcherResponse<Data>
   : SWRKey extends null | undefined | false
   ? never
-  : SWRKey extends infer Arg
+  : SWRKey extends string | infer Arg
   ? (arg: Arg) => FetcherResponse<Data>
   : never
 
-export type DataCached<Config> = Config extends undefined
+export type DataCached<Config, Data = any> = Config extends undefined
   ? false
   : Config extends { suspense: true }
   ? true
-  : Config extends { fallbackData: any }
+  : Config extends { fallbackData: Data }
   ? true
   : false
 
@@ -227,25 +227,29 @@ export interface SWRHook {
     Data = any,
     Error = any,
     SWRKey extends Key = StrictKey,
-    SWROptions =
+    SWROptions extends
+      | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined =
       | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
       | undefined
   >(
     key: SWRKey,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions>>
+  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
   <
     Data = any,
     Error = any,
     SWRKey extends Key = StrictKey,
-    SWROptions =
+    SWROptions extends
+      | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined =
       | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
       | undefined
   >(
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions>>
+  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
@@ -254,20 +258,24 @@ export interface SWRHook {
   <
     Data = any,
     Error = any,
-    SWROptions = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
+    SWROptions extends
+      | SWRConfiguration<Data, Error, BareFetcher<Data>>
+      | undefined = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
   >(
     key: Key,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions>>
+  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
   <
     Data = any,
     Error = any,
-    SWROptions = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
+    SWROptions extends
+      | SWRConfiguration<Data, Error, BareFetcher<Data>>
+      | undefined = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
   >(
     key: Key,
     fetcher: BareFetcher<Data> | null,
     config: SWROptions
-  ): SWRResponse<Data, Error, DataCached<SWROptions>>
+  ): SWRResponse<Data, Error, DataCached<SWROptions, Data>>
 }
 
 // Middleware guarantees that a SWRHook receives a key, fetcher, and config as the argument

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -25,6 +25,14 @@ export type Fetcher<
   ? (arg: Arg) => FetcherResponse<Data>
   : never
 
+export type DataCached<Config> = Config extends undefined
+  ? false
+  : Config extends { suspense: true }
+  ? true
+  : Config extends { fallbackData: any }
+  ? true
+  : false
+
 // Configuration types that are only used internally, not exposed to the user.
 export interface InternalConfiguration {
   cache: Cache
@@ -215,29 +223,51 @@ export interface SWRHook {
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null
   ): SWRResponse<Data, Error>
-  <Data = any, Error = any, SWRKey extends Key = StrictKey>(
+  <
+    Data = any,
+    Error = any,
+    SWRKey extends Key = StrictKey,
+    SWROptions =
+      | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined
+  >(
     key: SWRKey,
-    config: SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>> | undefined
-  ): SWRResponse<Data, Error>
-  <Data = any, Error = any, SWRKey extends Key = StrictKey>(
+    config: SWROptions
+  ): SWRResponse<Data, Error, DataCached<SWROptions>>
+  <
+    Data = any,
+    Error = any,
+    SWRKey extends Key = StrictKey,
+    SWROptions =
+      | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined
+  >(
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null,
-    config: SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>> | undefined
-  ): SWRResponse<Data, Error>
+    config: SWROptions
+  ): SWRResponse<Data, Error, DataCached<SWROptions>>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
     fetcher: BareFetcher<Data> | null
   ): SWRResponse<Data, Error>
-  <Data = any, Error = any>(
+  <
+    Data = any,
+    Error = any,
+    SWROptions = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
+  >(
     key: Key,
-    config: SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
-  ): SWRResponse<Data, Error>
-  <Data = any, Error = any>(
+    config: SWROptions
+  ): SWRResponse<Data, Error, DataCached<SWROptions>>
+  <
+    Data = any,
+    Error = any,
+    SWROptions = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
+  >(
     key: Key,
     fetcher: BareFetcher<Data> | null,
-    config: SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
-  ): SWRResponse<Data, Error>
+    config: SWROptions
+  ): SWRResponse<Data, Error, DataCached<SWROptions>>
 }
 
 // Middleware guarantees that a SWRHook receives a key, fetcher, and config as the argument
@@ -342,18 +372,18 @@ export type SWRConfiguration<
   Fn extends BareFetcher<any> = BareFetcher<any>
 > = Partial<PublicConfiguration<Data, Error, Fn>>
 
-export interface SWRResponse<Data = any, Error = any> {
+export interface SWRResponse<Data = any, Error = any, Cached = false> {
   /**
    * The returned data of the fetcher function.
    */
-  data: Data | undefined
+  data: Cached extends true ? Data : Data | undefined
   /**
    * The error object thrown by the fetcher function.
    */
   error: Error | undefined
   mutate: KeyedMutator<Data>
   isValidating: boolean
-  isLoading: boolean
+  isLoading: Cached extends true ? false : boolean
 }
 
 export type KeyLoader<Args extends Arguments = Arguments> =

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -53,8 +53,7 @@ type DefinitelyTruthy<T> = false extends T
 export const useSWRHandler = <Data = any, Error = any>(
   _key: Key,
   fetcher: Fetcher<Data> | null,
-  config: FullConfiguration<Data, Error, Fetcher<Data>> &
-    SWRConfiguration<Data, Error>
+  config: FullConfiguration & SWRConfiguration<Data, Error>
 ) => {
   const {
     cache,

--- a/test/type/.eslintrc
+++ b/test/type/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": "../../.eslintrc",
+  "rules": {
+    "react-hooks/rules-of-hooks": 0
+  }
+}

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -40,22 +40,46 @@ export function testFullConfiguration() {
   expectType<IData | undefined>(config.fallbackData)
 }
 
-export function testCachedkData() {
-  type CachedSWRResponse = SWRResponse<string, any, true>
-  type FilledData = CachedSWRResponse['data']
+export function testSWRResponseCachedDataTypes() {
+  type FilledData = SWRResponse<string, any, true>['data']
   expectType<Equal<FilledData, string>>(true)
 
-  // Specify the type of Data returning from fetcher
-  const fetcher = (k: string) => Promise.resolve(k)
-  const { data: fulfilledData } = useSWR('/api', fetcher, {
-    fallbackData: 'fallback'
-  })
+  type FilledConditionalData = SWRResponse<string | number, any, true>['data']
+  expectType<Equal<FilledConditionalData, string | number>>(true)
+}
+
+export function testSuspense() {
   const { data: suspenseyData } = useSWR(
     '/api',
     (k: string) => Promise.resolve(k),
     { suspense: true }
   )
 
-  expectType<string>(fulfilledData)
   expectType<string>(suspenseyData)
+}
+
+export function testFallbackData() {
+  // Need to specify the type of Data returning from fetcher
+
+  // Basic
+  const fetcher1 = (k: string) => Promise.resolve(k)
+  const { data: data1 } = useSWR('/api', fetcher1, {
+    fallbackData: 'fallback'
+  })
+  expectType<string>(data1)
+
+  // Conditional
+  const fetcher2 = (k: string) =>
+    Promise.resolve(Math.random() > 0.5 ? k : Math.random() * 100)
+  const { data: data2 } = useSWR('/api', fetcher2, {
+    fallbackData: 'fallback'
+  })
+  expectType<string | number>(data2)
+
+  // Complex
+  const fetcher3 = (k: string) => Promise.resolve({ value: k })
+  const { data: data3 } = useSWR('/api', fetcher3, {
+    fallbackData: { value: 'fallback' }
+  })
+  expectType<{ value: string }>(data3)
 }

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -44,9 +44,11 @@ export function testCachedkData() {
   type CachedSWRResponse = SWRResponse<string, any, true>
   type FilledData = CachedSWRResponse['data']
   expectType<Equal<FilledData, string>>(true)
-  const key = '/api'
-  const { data: fulfilledData } = useSWR(key, k => Promise.resolve(k), {
-    fallbackData: 'value'
+
+  // Specify the type of Data returning from fetcher
+  const fetcher = (k: string) => Promise.resolve(k)
+  const { data: fulfilledData } = useSWR('/api', fetcher, {
+    fallbackData: 'fallback'
   })
   const { data: suspenseyData } = useSWR(
     '/api',

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -41,10 +41,14 @@ export function testFullConfiguration() {
 }
 
 export function testSWRResponseCachedDataTypes() {
-  type FilledData = SWRResponse<string, any, true>['data']
+  type FilledData = SWRResponse<string, any, { suspense: true }>['data']
   expectType<Equal<FilledData, string>>(true)
 
-  type FilledConditionalData = SWRResponse<string | number, any, true>['data']
+  type FilledConditionalData = SWRResponse<
+    string | number,
+    any,
+    { suspense: true }
+  >['data']
   expectType<Equal<FilledConditionalData, string | number>>(true)
 }
 

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -44,15 +44,16 @@ export function testCachedkData() {
   type CachedSWRResponse = SWRResponse<string, any, true>
   type FilledData = CachedSWRResponse['data']
   expectType<Equal<FilledData, string>>(true)
-  const { data: fallbackabllData } = useSWR('/api', k => Promise.resolve(k), {
+  const key = '/api'
+  const { data: fulfilledData } = useSWR(key, k => Promise.resolve(k), {
     fallbackData: 'value'
   })
   const { data: suspenseyData } = useSWR(
     '/api',
     (k: string) => Promise.resolve(k),
-    { suspense: true } as const
+    { suspense: true }
   )
 
-  expectType<string>(fallbackabllData)
+  expectType<string>(fulfilledData)
   expectType<string>(suspenseyData)
 }

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
-import type { Cache } from 'swr'
-import { useSWRConfig, SWRConfig } from 'swr'
+import type { Cache, SWRResponse } from 'swr'
+import useSWR, { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
 import type { FullConfiguration } from 'swr/_internal'
+import type { Equal } from '@type-challenges/utils'
 
-export function useTestCache() {
+export function testCache() {
   expectType<Cache<any>>(useSWRConfig().cache)
 }
 
-export function useCustomSWRConfig() {
+export function testCustomSWRConfig() {
   const noNull = [
     // @ts-expect-error
     <SWRConfig key={'null'} value={null} />,
@@ -30,11 +31,28 @@ export function useCustomSWRConfig() {
   )
 }
 
-export function useFullConfiguration() {
+export function testFullConfiguration() {
   type IData = { value: string }
   type IError = { error: any }
   type IConfig = FullConfiguration<IData, IError>
 
   const config: IConfig = SWRConfig.defaultValue
   expectType<IData | undefined>(config.fallbackData)
+}
+
+export function testCachedkData() {
+  type CachedSWRResponse = SWRResponse<string, any, true>
+  type FilledData = CachedSWRResponse['data']
+  expectType<Equal<FilledData, string>>(true)
+  const { data: fallbackabllData } = useSWR('/api', k => Promise.resolve(k), {
+    fallbackData: 'value'
+  })
+  const { data: suspenseyData } = useSWR(
+    '/api',
+    (k: string) => Promise.resolve(k),
+    { suspense: true } as const
+  )
+
+  expectType<string>(fallbackabllData)
+  expectType<string>(suspenseyData)
 }

--- a/test/type/helper-types.tsx
+++ b/test/type/helper-types.tsx
@@ -1,9 +1,13 @@
-import type { DataCached } from '../../_internal/types'
+import type { BlockingData } from '../../_internal/types'
 import { expectType } from './utils'
 
 export function testDataCached() {
-  expectType<DataCached<{ fallbackData: string }>>(true)
-  expectType<DataCached<{ suspense: true }>>(true)
-  expectType<DataCached<{ fallbackData?: string; revalidate: boolean }>>(false)
-  expectType<DataCached<{ suspense: false; revalidate: boolean }>>(false)
+  expectType<BlockingData<string, { fallbackData: string }>>(true)
+  expectType<BlockingData<any, { suspense: true }>>(true)
+  expectType<
+    BlockingData<string, { fallbackData?: string; revalidate: boolean }>
+  >(false)
+  expectType<BlockingData<false, { suspense: false; revalidate: boolean }>>(
+    false
+  )
 }

--- a/test/type/helper-types.tsx
+++ b/test/type/helper-types.tsx
@@ -1,0 +1,9 @@
+import type { DataCached } from '../../_internal/types'
+import { expectType } from './utils'
+
+export function testDataCached() {
+  expectType<DataCached<{ fallbackData: string }>>(true)
+  expectType<DataCached<{ suspense: true }>>(true)
+  expectType<DataCached<{ fallbackData?: string; revalidate: boolean }>>(false)
+  expectType<DataCached<{ suspense: false; revalidate: boolean }>>(false)
+}


### PR DESCRIPTION
Resolves #1410

When `fallbackData` is specified for the swr hook, then:
 * it should match the `Data` type returning from `Fetcher`
 * swr hook should always return a fulfilled `data`
 * the `isLoading` always should be `false`

When `suspense` is specified for the swr hook, then:
 * swr hook should always return a fulfilled `data`
 * the `isLoading` always should be `false`

![image](https://user-images.githubusercontent.com/4800338/208100671-c7ed5628-a3dd-4c44-9308-b0a21037dc9f.png)
