### PR TITLE
fix: delay revalidation if a key is already active and has error

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -511,6 +511,8 @@ export const useSWRHandler = <Data = any, Error = any>(
       return
     }
 
+    const isKeyHasActiveInstance =
+      EVENT_REVALIDATORS[key] && EVENT_REVALIDATORS[key].length > 0
     const unsubEvents = subscribeCallback(key, EVENT_REVALIDATORS, onRevalidate)
 
     // Mark the component as mounted and update corresponding refs.
@@ -520,6 +522,9 @@ export const useSWRHandler = <Data = any, Error = any>(
 
     // Keep the original key in the cache.
     setCache({ _k: fnArg })
+
+    // if a key is already active and has error, we should not trigger revalidation
+    if (isKeyHasActiveInstance && !isUndefined(error)) return
 
     // Trigger a revalidation.
     if (shouldDoInitialRevalidation) {

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -494,4 +494,32 @@ describe('useSWR - error', () => {
     // Since there's only 1 request fired, only 1 error event should be reported.
     expect(errorEvents.length).toBe(1)
   })
+
+  it('should not should not trigger revalidation when a key is already active and has error', async () => {
+    const key = createKey()
+    const useData = () => {
+      return useSWR<any, any>(
+        key,
+        () => createResponse(new Error('error!'), { delay: 200 }),
+        undefined
+      )
+    }
+    const Page = () => {
+      useData()
+      return null
+    }
+    const App = () => {
+      const { error, isLoading } = useData()
+      if (isLoading) return <span>loading</span>
+      return (
+        <div>
+          {error ? error.message : ''},{isLoading.toString()}
+          <Page />
+        </div>
+      )
+    }
+    renderWithConfig(<App />)
+    screen.getByText('loading')
+    await screen.findByText('error!,false')
+  })
 })

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -495,7 +495,7 @@ describe('useSWR - error', () => {
     expect(errorEvents.length).toBe(1)
   })
 
-  it('should not should not trigger revalidation when a key is already active and has error', async () => {
+  it('should not should not trigger revalidation when a key is already active and has error - isLoading', async () => {
     const key = createKey()
     const useData = () => {
       return useSWR<any, any>(
@@ -520,6 +520,34 @@ describe('useSWR - error', () => {
     }
     renderWithConfig(<App />)
     screen.getByText('loading')
+    await screen.findByText('error!,false')
+  })
+
+  it('should not should not trigger revalidation when a key is already active and has error - isValidating', async () => {
+    const key = createKey()
+    const useData = () => {
+      return useSWR<any, any>(
+        key,
+        () => createResponse(new Error('error!'), { delay: 200 }),
+        undefined
+      )
+    }
+    const Page = () => {
+      useData()
+      return null
+    }
+    const App = () => {
+      const { error, isValidating } = useData()
+      if (isValidating) return <span>validating</span>
+      return (
+        <div>
+          {error ? error.message : ''},{isValidating.toString()}
+          <Page />
+        </div>
+      )
+    }
+    renderWithConfig(<App />)
+    screen.getByText('validating')
     await screen.findByText('error!,false')
   })
 })

--- a/test/use-swr-loading.test.tsx
+++ b/test/use-swr-loading.test.tsx
@@ -228,7 +228,8 @@ describe('useSWR - loading', () => {
           await sleep(50)
           throw new Error(key)
         },
-        dedupingInterval: 0
+        dedupingInterval: 0,
+        errorRetryInterval: 50
       })
 
       return isValidating ? <>validating</> : <>stopped</>
@@ -251,8 +252,7 @@ describe('useSWR - loading', () => {
     screen.getByText('stopped,')
 
     fireEvent.click(screen.getByText('start'))
-    await executeWithoutBatching(() => sleep(20))
-    screen.getByText('validating,validating')
+    await screen.findByText('validating,validating')
 
     // Pause before it resolves
     paused = true


### PR DESCRIPTION
close #2336

The reason for #2336 is that 

every time a revalidation is finished, a new swr hook will mount and trigger a new revalidation. 

`isValidating` will also cause similar problem here. 

https://codesandbox.io/s/isvalidating-infinite-render-xgwyyz