### PR TITLE
fix: types properites in exports fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,19 +23,19 @@
       "require": "./core/dist/index.js"
     },
     "./infinite": {
-      "types": "./infinite/dist/index.d.ts",
+      "types": "./infinite/dist/infinite/index.d.ts",
       "import": "./infinite/dist/index.mjs",
       "module": "./infinite/dist/index.esm.js",
       "require": "./infinite/dist/index.js"
     },
     "./immutable": {
-      "types": "./immutable/dist/index.d.ts",
+      "types": "./immutable/dist/immutable/index.d.ts",
       "import": "./immutable/dist/index.mjs",
       "module": "./immutable/dist/index.esm.js",
       "require": "./immutable/dist/index.js"
     },
     "./mutation": {
-      "types": "./mutation/dist/index.d.ts",
+      "types": "./mutation/dist/mutation/index.d.ts",
       "import": "./mutation/dist/index.mjs",
       "module": "./mutation/dist/index.esm.js",
       "require": "./mutation/dist/index.js"


### PR DESCRIPTION
fixes #2308

This fixes the path for the properties of the type in `package.json`.

Each `types` of `package.json` are pointed correctly.

- https://github.com/vercel/swr/blob/main/immutable/package.json#L4
- https://github.com/vercel/swr/blob/main/infinite/package.json#L4
- https://github.com/vercel/swr/blob/main/mutation/package.json#L4