### PR TITLE
fix: parameters passed to subscribe is inconsistent with its declaration

### DIFF
--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -66,7 +66,7 @@ export const initCache = <Data = any>(
       const subs = subscriptions[key]
       if (subs) {
         for (let i = subs.length; i--; ) {
-          subs[i](prev, value)
+          subs[i](value, prev)
         }
       }
     }

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -171,7 +171,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       (callback: () => void) =>
         subscribeCache(
           key,
-          (prev: State<Data, any>, current: State<Data, any>) => {
+          (current: State<Data, any>, prev: State<Data, any>) => {
             if (!isEqual(prev, current)) callback()
           }
         ),


### PR DESCRIPTION
Just as the title describes, the following is a place that has a such problem:

![aab1363a377dbf7d7cb527d78a39400](https://user-images.githubusercontent.com/12696059/211186270-5a5607bc-f241-4257-b056-f3883dc60ebc.png)
