### PR TITLE
build: use npm for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         uses: ./.github/workflows/install
 
       - name: Publish
-        run: pnpm publish --no-git-checks
+        run: npm publish --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
pnpm cannot recognize the npm token for publishing
x-ref: https://github.com/vercel/swr/actions/runs/4014957543/jobs/6896111847