### PR TITLE
build: dynamically add token and depend on test workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 
 on:
+  workflows_run:
+    workflow: [Lint and Test]
+    types:
+      - completed
   push:
     tags:
       - v*
@@ -16,7 +20,7 @@ jobs:
         uses: ./.github/workflows/install
 
       - name: Publish
-        run: npm publish --access public
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - run: npm publish --access public
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: TypeCheck, Lint, and Test
+name: Lint and Test
 
 on:
   push:


### PR DESCRIPTION
Append auth token to npmrc 
x-ref: https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow#create-and-check-in-a-project-specific-npmrc-file

Also add dependency for test workflow