### PR TITLE
fix: Ensure hydration matches the SSR result during streaming

### DIFF
--- a/_internal/utils/helper.ts
+++ b/_internal/utils/helper.ts
@@ -2,6 +2,7 @@ import { SWRGlobalState } from './global-state'
 import type { Cache, State, GlobalState } from '../types'
 
 const EMPTY_CACHE = {}
+const INITIAL_CACHE: Record<string, any> = {}
 export const noop = () => {}
 
 // Using noop() as the undefined value as undefined can be replaced
@@ -40,10 +41,27 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
     (info: T) => {
       if (!isUndefined(key)) {
         const prev = cache.get(key)
+
+        // Before writing to the store, we keep the value in the initial cache
+        // if it's not there yet.
+        if (!(key in INITIAL_CACHE)) {
+          INITIAL_CACHE[key] = prev
+        }
+
         state[5](key, mergeObjects(prev, info), prev || EMPTY_CACHE)
       }
     },
     // Subscriber
-    state[6]
+    state[6],
+    // Get server cache snapshot
+    () => {
+      if (!isUndefined(key)) {
+        // If the cache was updated on the client, we return the stored initial value.
+        if (key in INITIAL_CACHE) return INITIAL_CACHE[key]
+      }
+
+      // If we haven't done any client-side updates, we return the current value.
+      return (cache.get(key) || EMPTY_CACHE) as T
+    }
   ] as const
 }

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -164,6 +164,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // unnecessary re-renders, we keep the previous snapshot and use deep
     // comparison to check if we need to return a new one.
     let memorizedSnapshot = getSelectedCache(getCache())
+    const memorizedInitialSnapshot = getSelectedCache(getInitialCache())
 
     return [
       () => {
@@ -172,7 +173,7 @@ export const useSWRHandler = <Data = any, Error = any>(
           ? memorizedSnapshot
           : (memorizedSnapshot = newSnapshot)
       },
-      () => getSelectedCache(getInitialCache())
+      () => memorizedInitialSnapshot
     ]
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cache, key])

--- a/test/use-swr-streaming-ssr.test.tsx
+++ b/test/use-swr-streaming-ssr.test.tsx
@@ -1,0 +1,81 @@
+import React, { Suspense } from 'react'
+import useSWR from 'swr'
+import {
+  createKey,
+  createResponse,
+  renderWithConfig,
+  hydrateWithConfig,
+  mockConsoleForHydrationErrors,
+  sleep
+} from './utils'
+
+describe('useSWR - streaming', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+    jest.restoreAllMocks()
+  })
+
+  it('should match ssr result when hydrating', async () => {
+    const ensureAndUnmock = mockConsoleForHydrationErrors()
+
+    const key = createKey()
+
+    // A block fetches the data and updates the cache.
+    function Block() {
+      const { data } = useSWR(key, () => createResponse('SWR', { delay: 10 }))
+      return <div>{data || 'undefined'}</div>
+    }
+
+    const container = document.createElement('div')
+    container.innerHTML = '<div>undefined</div>'
+    await hydrateWithConfig(<Block />, container)
+    ensureAndUnmock()
+  })
+
+  // NOTE: this test is skipped because it's not possible to test this behavior
+  // in JSDOM. We need to test this in a real browser.
+  it.skip('should match the ssr result when streaming and partially hydrating', async () => {
+    const key = createKey()
+
+    const dataDuringHydration = {}
+
+    // A block fetches the data and updates the cache.
+    function Block({ suspense, delay, id }) {
+      const { data } = useSWR(key, () => createResponse('SWR', { delay }), {
+        suspense
+      })
+
+      // The first render is always hydration in our case.
+      if (!dataDuringHydration[id]) {
+        dataDuringHydration[id] = data || 'undefined'
+      }
+
+      return <div>{data || 'undefined'}</div>
+    }
+
+    // In this example, a will be hydrated first and b will still be streamed.
+    // When a is hydrated, it will update the client cache to SWR, and when
+    // b is being hydrated, it should NOT read that cache.
+    renderWithConfig(
+      <>
+        <Block id="a" suspense={false} delay={10} />
+        <Suspense fallback={null}>
+          <Block id="b" suspense={true} delay={20} />
+        </Suspense>
+      </>
+    )
+
+    // The SSR result will always be 2 undefined values because data fetching won't
+    // happen on the server:
+    //   <div>undefined</div>
+    //   <div>undefined</div>
+
+    // Wait for streaming to finish.
+    await sleep(50)
+
+    expect(dataDuringHydration).toEqual({
+      a: 'undefined',
+      b: 'undefined'
+    })
+  })
+})

--- a/test/use-swr-streaming-ssr.test.tsx
+++ b/test/use-swr-streaming-ssr.test.tsx
@@ -32,50 +32,53 @@ describe('useSWR - streaming', () => {
     ensureAndUnmock()
   })
 
-  // NOTE: this test is skipped because it's not possible to test this behavior
+  // NOTE: this test is failing because it's not possible to test this behavior
   // in JSDOM. We need to test this in a real browser.
-  it.skip('should match the ssr result when streaming and partially hydrating', async () => {
-    const key = createKey()
+  it.failing(
+    'should match the ssr result when streaming and partially hydrating',
+    async () => {
+      const key = createKey()
 
-    const dataDuringHydration = {}
+      const dataDuringHydration = {}
 
-    // A block fetches the data and updates the cache.
-    function Block({ suspense, delay, id }) {
-      const { data } = useSWR(key, () => createResponse('SWR', { delay }), {
-        suspense
-      })
+      // A block fetches the data and updates the cache.
+      function Block({ suspense, delay, id }) {
+        const { data } = useSWR(key, () => createResponse('SWR', { delay }), {
+          suspense
+        })
 
-      // The first render is always hydration in our case.
-      if (!dataDuringHydration[id]) {
-        dataDuringHydration[id] = data || 'undefined'
+        // The first render is always hydration in our case.
+        if (!dataDuringHydration[id]) {
+          dataDuringHydration[id] = data || 'undefined'
+        }
+
+        return <div>{data || 'undefined'}</div>
       }
 
-      return <div>{data || 'undefined'}</div>
+      // In this example, a will be hydrated first and b will still be streamed.
+      // When a is hydrated, it will update the client cache to SWR, and when
+      // b is being hydrated, it should NOT read that cache.
+      renderWithConfig(
+        <>
+          <Block id="a" suspense={false} delay={10} />
+          <Suspense fallback={null}>
+            <Block id="b" suspense={true} delay={20} />
+          </Suspense>
+        </>
+      )
+
+      // The SSR result will always be 2 undefined values because data fetching won't
+      // happen on the server:
+      //   <div>undefined</div>
+      //   <div>undefined</div>
+
+      // Wait for streaming to finish.
+      await sleep(50)
+
+      expect(dataDuringHydration).toEqual({
+        a: 'undefined',
+        b: 'undefined'
+      })
     }
-
-    // In this example, a will be hydrated first and b will still be streamed.
-    // When a is hydrated, it will update the client cache to SWR, and when
-    // b is being hydrated, it should NOT read that cache.
-    renderWithConfig(
-      <>
-        <Block id="a" suspense={false} delay={10} />
-        <Suspense fallback={null}>
-          <Block id="b" suspense={true} delay={20} />
-        </Suspense>
-      </>
-    )
-
-    // The SSR result will always be 2 undefined values because data fetching won't
-    // happen on the server:
-    //   <div>undefined</div>
-    //   <div>undefined</div>
-
-    // Wait for streaming to finish.
-    await sleep(50)
-
-    expect(dataDuringHydration).toEqual({
-      a: 'undefined',
-      b: 'undefined'
-    })
-  })
+  )
 })


### PR DESCRIPTION
## Problem

Here's a diagram explaining the problem:

![image](https://user-images.githubusercontent.com/3676859/215219059-7c601b3b-3abe-4a89-a5ec-a7bd5264f96f.png)

First, In SSR, the `data` will always be `undefined` for any `useSWR` hook, because `useEffect` never runs during SSR. Same for streaming SSR because it's still SSR, but with some components being delayed a bit.

So, to make sure client hydration matches the SSR result, all `useSWR` hooks should return `undefined` during their hydration render. That's easy when we hydrate all things together, because the cache is always empty initially, and the hydration process will finish before any data fetching happens.

However, with streaming SSR React can partially hydrate a part of the app. In the example above, the first `useSWR` hook was hydrated first, and the second is still pending due to slow network or a suspense boundary. After the hydration of the first `useSWR` hook, it fetches the data and updates the global cache on the client. And then, the second one hydrates. During its hydration render, it already reads the updated cache, instead of `undefined`. This causes a hydration mismatch.

The fix is to pass a server snapshot to `useSyncExternalStore`, so React will use that snapshot during hydration renders. And all we need to do is to make sure that we store the initial cache value somewhere before any write happens on the client, and return that initial cache as the server snapshot.

## Reproduction

It's very tricky to reproduce and test this problem in our Jest setup. So I made this Sandbox to test: https://codesandbox.io/p/sandbox/swr-ssr-forked-tlgw5b?file=%2Fapp%2Fpage.js

Hydration mismatch in [current `swr@latest`](https://tlgw5b-3000.preview.csb.app/):

<img width="1364" alt="CleanShot 2023-01-27 at 23 24 35@2x" src="https://user-images.githubusercontent.com/3676859/215217546-88fabcec-dab1-481b-883e-aa8ed105f256.png">

Works fine [with this fix](https://nf5eeu-3000.preview.csb.app/):

<img width="1364" alt="CleanShot 2023-01-27 at 23 25 16@2x" src="https://user-images.githubusercontent.com/3676859/215217731-e9328143-a0d2-4a8e-907e-4350a223e520.png">
