### PR TITLE
test: fix an act warning

### DIFF
--- a/test/use-swr-streaming-ssr.test.tsx
+++ b/test/use-swr-streaming-ssr.test.tsx
@@ -1,3 +1,4 @@
+import { act } from '@testing-library/react'
 import React, { Suspense } from 'react'
 import useSWR from 'swr'
 import {
@@ -73,7 +74,7 @@ describe('useSWR - streaming', () => {
       //   <div>undefined</div>
 
       // Wait for streaming to finish.
-      await sleep(50)
+      await act(() => sleep(50))
 
       expect(dataDuringHydration).toEqual({
         a: 'undefined',


### PR DESCRIPTION
This fixes the warning

>  console.error
  Warning: An update to Block inside a test was not wrapped in act(...).

https://github.com/vercel/swr/actions/runs/4036621392/jobs/6939344509