### PR TITLE
feat: add the parallel option in useSWRInfinite

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -57,7 +57,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       revalidateAll = false,
       persistSize = false,
       revalidateFirstPage = true,
-      revalidateOnMount = false
+      revalidateOnMount = false,
+      parallel = false
     } = config
 
     // The serialized key of the first page. This key will be used to store
@@ -138,9 +139,13 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
         const pageSize = resolvePageSize()
 
+        const revalidates = []
+
         let previousPageData = null
         for (let i = 0; i < pageSize; ++i) {
-          const [pageKey, pageArg] = serialize(getKey(i, previousPageData))
+          const [pageKey, pageArg] = serialize(
+            getKey(i, parallel ? null : previousPageData)
+          )
 
           if (!pageKey) {
             // `pageKey` is falsy, stop fetching new pages.
@@ -173,11 +178,27 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
               !config.compare(originalData[i], pageData))
 
           if (fn && shouldFetchPage) {
-            pageData = await fn(pageArg)
-            setSWRCache({ data: pageData, _k: pageArg })
+            const revalidate = async () => {
+              pageData = await fn(pageArg)
+              setSWRCache({ data: pageData, _k: pageArg })
+              data[i] = pageData
+            }
+            if (parallel) {
+              revalidates.push(revalidate)
+            } else {
+              await revalidate()
+            }
+          } else {
+            data[i] = pageData
           }
-          data.push(pageData)
-          previousPageData = pageData
+          if (!parallel) {
+            previousPageData = pageData
+          }
+        }
+
+        // flush all revalidateions in parallel
+        if (parallel) {
+          await Promise.all(revalidates.map(r => r()))
         }
 
         // once we executed the data fetching based on the context, clear the context

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -139,7 +139,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
         const pageSize = resolvePageSize()
 
-        const revalidates = []
+        const revalidators = []
 
         let previousPageData = null
         for (let i = 0; i < pageSize; ++i) {
@@ -184,7 +184,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
               data[i] = pageData
             }
             if (parallel) {
-              revalidates.push(revalidate)
+              revalidators.push(revalidate)
             } else {
               await revalidate()
             }
@@ -198,7 +198,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
         // flush all revalidateions in parallel
         if (parallel) {
-          await Promise.all(revalidates.map(r => r()))
+          await Promise.all(revalidators.map(r => r()))
         }
 
         // once we executed the data fetching based on the context, clear the context

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -32,6 +32,7 @@ export interface SWRInfiniteConfiguration<
   revalidateAll?: boolean
   persistSize?: boolean
   revalidateFirstPage?: boolean
+  parallel?: boolean
   fetcher?: Fn
 }
 

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1692,4 +1692,29 @@ describe('useSWRInfinite', () => {
     await screen.findByText(`size: 2`)
     await screen.findByText(`swr: ${key}-2,`)
   })
+
+  it('should support the parallel option', async () => {
+    // mock api
+    const pageData = ['apple', 'banana', 'pineapple']
+
+    const key = createKey()
+    function Page() {
+      const { data } = useSWRInfinite(
+        index => [key, index],
+        ([_, index]) => createResponse(`${pageData[index]}, `, { delay: 100 }),
+        {
+          initialSize: 3,
+          parallel: true
+        }
+      )
+
+      return <div>data:{data}</div>
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('data:')
+
+    await act(() => sleep(150))
+    screen.getByText('data:apple, banana, pineapple,')
+  })
 })

--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1714,6 +1714,7 @@ describe('useSWRInfinite', () => {
     renderWithConfig(<Page />)
     screen.getByText('data:')
 
+    // If SWR sends requests sequentially, it takes 150ms at least
     await act(() => sleep(100))
     screen.getByText('data:apple, banana, pineapple,')
   })
@@ -1739,6 +1740,7 @@ describe('useSWRInfinite', () => {
     renderWithConfig(<Page />)
     screen.getByText('data:')
 
+    // If SWR sends requests sequentially, it takes 150ms at least
     await act(() => sleep(100))
     screen.getByText('data:')
     await act(() => sleep(200))
@@ -1765,6 +1767,7 @@ describe('useSWRInfinite', () => {
     renderWithConfig(<Page />)
     screen.getByText('data:')
 
+    // If SWR sends requests sequentially, it takes 150ms at least
     await act(() => sleep(100))
     screen.getByText('data:')
     await act(() => sleep(200))
@@ -1797,6 +1800,7 @@ describe('useSWRInfinite', () => {
     renderWithConfig(<Page />)
     screen.getByText('data:')
 
+    // If SWR sends requests sequentially, it takes 150ms at least
     await act(() => sleep(100))
     screen.getByText('data:apple, banana, pineapple,')
     expect(previousPageDataLogs.every(d => d === null)).toBeTruthy()


### PR DESCRIPTION
This PR adds the `parallel` option into `useSWRInfinite` to make revalidations in parallel.

```jsx
useSWRInfinite(getKey, fetcher, { parallel: true })
```

The default value is `false`.

## Motivation

When I revalidate multiple pages with `useSWRInfinite`, `useSWRInfinte` sends the revalidation requests sequentially, which is slow when we have many pages to revalidate. This especially becomes a problem when revalidations happen frequently.

```
// without parallel
page1 ====> page2 ====> page3 ====> done

// parallel
page1
page2 ====> done 
page3
```

## Limitation

The `parallel` option doesn't work with cursor-based APIs because cursor-based APIs send the next request based on the cursor value returned from the current request.

https://swr.vercel.app/docs/pagination#example-2-cursor-or-offset-based-paginated-api

With the `parallel` option, `useSWRInfinite` can't get the `previousPageData` because requests happen in parallel. The current implementation passes `null` as `previousPageData` with the `parallel` option. 
TODO: infer the type of `previousPageData` based on the `parallel` option.

## Alternative

I've also considered the `concurrency = 1` option to be able to handle revalidations more flexibly. But I had to handle `previousPageData` differently based on whether revalidations are sequential or parallel. I think the `parallel` option is not more flexible than the `concurrency` option, but it's clearer than the `concurrency` option.