### PR TITLE
fix: ensure initCache setter function stays within bounds of subscriptions

### DIFF
--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -63,12 +63,10 @@ export const initCache = <Data = any>(
     }
     const setter = (key: string, value: any, prev: any) => {
       provider.set(key, value)
-      if (subscriptions[key]) {
-        // Make a copy of subscriptions to avoid mutations of subscriptions to affect
-        // the array while looping
-        const subs = subscriptions[key].slice()
-        for (let i = subs.length; i--; ) {
-          subs[i](value, prev)
+      const subs = subscriptions[key]
+      if (subs) {
+        for (const fn of subs) {
+          fn(value, prev)
         }
       }
     }

--- a/_internal/utils/cache.ts
+++ b/_internal/utils/cache.ts
@@ -63,8 +63,10 @@ export const initCache = <Data = any>(
     }
     const setter = (key: string, value: any, prev: any) => {
       provider.set(key, value)
-      const subs = subscriptions[key]
-      if (subs) {
+      if (subscriptions[key]) {
+        // Make a copy of subscriptions to avoid mutations of subscriptions to affect
+        // the array while looping
+        const subs = subscriptions[key].slice()
         for (let i = subs.length; i--; ) {
           subs[i](value, prev)
         }


### PR DESCRIPTION
This PR closes #2357, by creating a copy of the `subscriptions[key]` array in the `setter` function for `initCache`. By doing this we avoid an intermittent bug where `subscriptions[key]` is mutated while the for-loop is running, potentially causing an out of bounce lookup.

By copying the object, mutations of the original object will not affect the `setter` function while executing. Alternatively we could lock write operation while running the read operation. Or use a different iterator method, that make it's own copy instead of a vanilla for-loop.

This is somewhat hard bug to reproduce, as it's highly intermittent.