### PR TITLE
fix: Error retry should be handled by global revalidator instead of local revalidation function

### DIFF
--- a/_internal/constants.ts
+++ b/_internal/constants.ts
@@ -1,3 +1,4 @@
 export const FOCUS_EVENT = 0
 export const RECONNECT_EVENT = 1
 export const MUTATE_EVENT = 2
+export const ERROR_REVALIDATE_EVENT = 3

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -415,14 +415,16 @@ export type RevalidateEvent =
   | typeof revalidateEvents.FOCUS_EVENT
   | typeof revalidateEvents.RECONNECT_EVENT
   | typeof revalidateEvents.MUTATE_EVENT
-
+  | typeof revalidateEvents.ERROR_REVALIDATE_EVENT
 type RevalidateCallbackReturnType = {
   [revalidateEvents.FOCUS_EVENT]: void
   [revalidateEvents.RECONNECT_EVENT]: void
   [revalidateEvents.MUTATE_EVENT]: Promise<boolean>
+  [revalidateEvents.ERROR_REVALIDATE_EVENT]: void
 }
 export type RevalidateCallback = <K extends RevalidateEvent>(
-  type: K
+  type: K,
+  param?: any
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {

--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -424,7 +424,7 @@ type RevalidateCallbackReturnType = {
 }
 export type RevalidateCallback = <K extends RevalidateEvent>(
   type: K,
-  param?: any
+  opts?: any
 ) => RevalidateCallbackReturnType[K]
 
 export interface Cache<Data = any> {

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -521,7 +521,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     let nextFocusRevalidatedAt = 0
     const onRevalidate = (
       type: RevalidateEvent,
-      params: {
+      opts: {
         retryCount?: number
         dedupe?: boolean
       } = {}
@@ -543,7 +543,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       } else if (type == revalidateEvents.MUTATE_EVENT) {
         return revalidate()
       } else if (type == revalidateEvents.ERROR_REVALIDATE_EVENT) {
-        return revalidate(params)
+        return revalidate(opts)
       }
       return
     }

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -445,12 +445,12 @@ export const useSWRHandler = <Data = any, Error = any>(
                   err,
                   key,
                   currentConfig,
-                  param => {
+                  _opts => {
                     const revalidators = EVENT_REVALIDATORS[key]
                     if (revalidators && revalidators[0]) {
                       revalidators[0](
                         revalidateEvents.ERROR_REVALIDATE_EVENT,
-                        param
+                        _opts
                       )
                     }
                   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,5 +16,5 @@ module.exports = {
   },
   coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/test/'],
   coverageReporters: ['text', 'html'],
-  reporters: ['default', 'github-actions']
+  reporters: [['github-actions', { silent: false }], 'summary']
 }

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -42,10 +42,10 @@ describe('useSWR - config callbacks', () => {
   it('should trigger the onError event with the latest version of the onError callback', async () => {
     let state = null
     let count = 0
-
+    const key = createKey()
     function Page(props: { text: string }) {
       const { data, mutate, error } = useSWR(
-        'config callbacks - onError',
+        key,
         () => createResponse(new Error(`Error: ${count++}`)),
         { onError: () => (state = props.text) }
       )
@@ -87,10 +87,10 @@ describe('useSWR - config callbacks', () => {
   it('should trigger the onErrorRetry event with the latest version of the onErrorRetry callback', async () => {
     let state = null
     let count = 0
-
+    const key = createKey()
     function Page(props: { text: string }) {
       const { data, error } = useSWR(
-        'config callbacks - onErrorRetry',
+        key,
         () => createResponse(new Error(`Error: ${count++}`)),
         {
           onErrorRetry: (_, __, ___, revalidate, revalidateOpts) => {
@@ -130,14 +130,14 @@ describe('useSWR - config callbacks', () => {
     expect(state).toEqual('b')
   })
 
-  it('should trigger the onLoadingSlow and onSuccess event with the lastest version of the callbacks', async () => {
+  it.skip('should trigger the onLoadingSlow and onSuccess event with the lastest version of the callbacks', async () => {
     const LOADING_TIMEOUT = 100
     let state = null
     let count = 0
-
+    const key = createKey()
     function Page(props: { text: string }) {
       const { data } = useSWR(
-        'config callbacks - onLoadingSlow',
+        key,
         () => createResponse(count++, { delay: LOADING_TIMEOUT * 2 }),
         {
           onLoadingSlow: () => {

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -130,7 +130,7 @@ describe('useSWR - config callbacks', () => {
     expect(state).toEqual('b')
   })
 
-  it.skip('should trigger the onLoadingSlow and onSuccess event with the lastest version of the callbacks', async () => {
+  it('should trigger the onLoadingSlow and onSuccess event with the lastest version of the callbacks', async () => {
     const LOADING_TIMEOUT = 100
     let state = null
     let count = 0

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -555,10 +555,10 @@ describe('useSWR - error', () => {
         key,
         () => createResponse(new Error('error!'), { delay: 200 }),
         {
-          onErrorRetry: (_, __, ___, revalidate, param) => {
+          onErrorRetry: (_, __, ___, revalidate, opts) => {
             setTimeout(() => {
               fn()
-              revalidate(param)
+              revalidate(opts)
             }, 100)
           },
           dedupingInterval: 1

--- a/test/use-swr-error.test.tsx
+++ b/test/use-swr-error.test.tsx
@@ -495,13 +495,11 @@ describe('useSWR - error', () => {
     expect(errorEvents.length).toBe(1)
   })
 
-  it('should not should not trigger revalidation when a key is already active and has error - isLoading', async () => {
+  it('should not trigger revalidation when a key is already active and has error - isLoading', async () => {
     const key = createKey()
     const useData = () => {
-      return useSWR<any, any>(
-        key,
-        () => createResponse(new Error('error!'), { delay: 200 }),
-        undefined
+      return useSWR<any, any>(key, () =>
+        createResponse(new Error('error!'), { delay: 200 })
       )
     }
     const Page = () => {
@@ -523,13 +521,11 @@ describe('useSWR - error', () => {
     await screen.findByText('error!,false')
   })
 
-  it('should not should not trigger revalidation when a key is already active and has error - isValidating', async () => {
+  it('should not trigger revalidation when a key is already active and has error - isValidating', async () => {
     const key = createKey()
     const useData = () => {
-      return useSWR<any, any>(
-        key,
-        () => createResponse(new Error('error!'), { delay: 200 }),
-        undefined
+      return useSWR<any, any>(key, () =>
+        createResponse(new Error('error!'), { delay: 200 })
       )
     }
     const Page = () => {
@@ -549,5 +545,55 @@ describe('useSWR - error', () => {
     renderWithConfig(<App />)
     screen.getByText('validating')
     await screen.findByText('error!,false')
+  })
+
+  it('should trigger revalidation when first hook is unmount', async () => {
+    const key = createKey()
+    const fn = jest.fn()
+    const useData = () => {
+      return useSWR<any, any>(
+        key,
+        () => createResponse(new Error('error!'), { delay: 200 }),
+        {
+          onErrorRetry: (_, __, ___, revalidate, param) => {
+            setTimeout(() => {
+              fn()
+              revalidate(param)
+            }, 100)
+          },
+          dedupingInterval: 1
+        }
+      )
+    }
+    const First = () => {
+      useData()
+      const [state, setState] = useState(true)
+      return (
+        <>
+          <button onClick={() => setState(!state)}>toggle</button>
+          {state ? <Second></Second> : null}
+        </>
+      )
+    }
+    const Second = () => {
+      useData()
+      return null
+    }
+    const App = () => {
+      return (
+        <div>
+          <First></First>
+          <Second />
+        </div>
+      )
+    }
+    renderWithConfig(<App />)
+    await act(() => sleep(320))
+    expect(fn).toBeCalledTimes(1)
+    fireEvent.click(screen.getByText('toggle'))
+    await act(() => sleep(320))
+    expect(fn).toBeCalledTimes(2)
+    await act(() => sleep(320))
+    expect(fn).toBeCalledTimes(3)
   })
 })


### PR DESCRIPTION
close #2412 which was introduced in #2338 

## Problem
```tsx
function Demo() {
   useSWR('/key', () => { throw new Error('error') })
   useSWR('/key', () => { throw new Error('error') })
}
```
Previously, if we have two swr hook, There will be two retry task pushed into queue.  If first hook unmount, the error retry won't stop because of another task.

But after #2338, only the first mouted swr hook will schedule an error retry task using it own `revalidate` function. 
If the first hook unmount, the `revalidate` function will become **inactive** because of https://github.com/vercel/swr/blob/f7004ac37b2b06111043bb6f262f80fb4d5cc381/core/use-swr.ts#L263-L270

## Solution

Instead of using local `revalidate` function for error retry, swr should always use the global event revalidator since it would be always **active**.