### PR TITLE
refactor: remove useless dataRef, always compare cached data

### DIFF
--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -126,9 +126,9 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     const shouldRevalidateOnMount = revalidateOnMount && !didMountRef.current
 
     // Actual SWR hook to load all pages in one fetcher.
-    const swr = useSWRNext<Data[], Error>(
+    const swr = useSWRNext(
       infiniteKey,
-      async _infiniteKey => {
+      async key => {
         // get the revalidate context
         const forceRevalidateAll = get()._i
 
@@ -139,7 +139,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
         const [getCache] = createCacheHelper<
           Data,
           SWRInfiniteCacheValue<Data[], any>
-        >(cache, _infiniteKey)
+        >(cache, key)
         const cacheData = getCache().data
 
         const revalidators = []

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -254,9 +254,9 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
           previousPageData = pageData
         }
         return data
-        // exclude getKey from the dependencies, which isn't allowed to change during the lifecycle
-        // eslint-disable-next-line react-hooks/exhaustive-deps
       },
+      // exclude getKey from the dependencies, which isn't allowed to change during the lifecycle
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       [cache]
     )
     // Extend the SWR API

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -288,7 +288,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
           // Get the cached page data.
           const pageData = pageKey ? getCache().data : UNDEFINED
 
-          // Return the current data if we can't get it from the cache.
+          // Call `mutate` with infinte cache data if we can't get it from the page cache.
           if (isUndefined(pageData)) {
             return mutate(getInfiniteCache().data)
           }

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -26,7 +26,8 @@ import type {
   SWRInfiniteHook,
   SWRInfiniteKeyLoader,
   SWRInfiniteFetcher,
-  SWRInfiniteCacheValue
+  SWRInfiniteCacheValue,
+  SWRInfiniteCompareFn
 } from './types'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
@@ -313,5 +314,6 @@ export {
   SWRInfiniteResponse,
   SWRInfiniteHook,
   SWRInfiniteKeyLoader,
-  SWRInfiniteFetcher
+  SWRInfiniteFetcher,
+  SWRInfiniteCompareFn
 }

--- a/infinite/types.ts
+++ b/infinite/types.ts
@@ -23,16 +23,21 @@ export type SWRInfiniteKeyLoader<
   Args extends Arguments = Arguments
 > = (index: number, previousPageData: Data | null) => Args
 
+export interface SWRInfiniteCompareFn<Data = any> {
+  (a: Data | undefined, b: Data | undefined): boolean
+  (a: Data[] | undefined, b: Data[] | undefined): boolean
+}
 export interface SWRInfiniteConfiguration<
   Data = any,
   Error = any,
   Fn extends SWRInfiniteFetcher<Data> = BareFetcher<Data>
-> extends SWRConfiguration<Data[], Error> {
+> extends Omit<SWRConfiguration<Data[], Error>, 'compare'> {
   initialSize?: number
   revalidateAll?: boolean
   persistSize?: boolean
   revalidateFirstPage?: boolean
   fetcher?: Fn
+  compare?: SWRInfiniteCompareFn<Data>
 }
 
 export interface SWRInfiniteResponse<Data = any, Error = any>


### PR DESCRIPTION
Previously, we store all page data with `inifinite-${firstPageKey}` and individual page with `${pagekey}` into cache, and sync all page data into dataRef.  

During the revalidation or mutation, we will compare dataRef with individual page to update the result.
However, we could just compare cached data directly then we don't need to store an extra copy of page data

i also update the signature of `compareFn` for `useSWRInfinite`