### PR TITLE
ci: fix publish workflow

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -26,6 +26,7 @@ runs:
       with:
         node-version: 18
         cache: pnpm
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
       shell: bash


### PR DESCRIPTION
Previously, we did not setup registry-url, so `setup-node` would not craete a `.npmrc` file.

https://github.com/actions/setup-node/blob/main/src/main.ts#L58-L60
https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages