### PR TITLE
Always assume subscriptions will return sub count from current key

### DIFF
--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -86,14 +86,13 @@ export const subscription = (<Data, Error>(useSWRNext: SWRHook) =>
       return () => {
         // Prevent frequent unsubscribe caused by unmount
         setTimeout(() => {
-          // TODO: Throw error during development if count is undefined.
-          const count = subscriptions.get(subscriptionKey)
-          if (count == null) return
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          const count = subscriptions.get(subscriptionKey)! - 1
 
-          subscriptions.set(subscriptionKey, count - 1)
+          subscriptions.set(subscriptionKey, count)
 
           // Dispose if it's the last one.
-          if (count === 1) {
+          if (!count) {
             const dispose = disposers.get(subscriptionKey)
             dispose?.()
           }


### PR DESCRIPTION
x-ref: revert change of  https://github.com/vercel/swr/pull/1263/commits/7963ae833a2dfb87d32a5b2c0e65aa7c36a618a5#r1118835146