### PR TITLE
fix: swr infers incorrect `data` type for default `SWRConfig` generic type

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -232,23 +232,27 @@ export interface SWRHook {
     SWRKey extends Key = StrictKey,
     SWROptions extends
       | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
-      | undefined = SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined =
+      | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined
   >(
     key: SWRKey,
-    config: SWROptions | undefined
-  ): SWRResponse<Data, Error, Required<SWROptions>>
+    config: SWROptions
+  ): SWRResponse<Data, Error, SWROptions>
   <
     Data = any,
     Error = any,
     SWRKey extends Key = StrictKey,
     SWROptions extends
       | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
-      | undefined = SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined =
+      | SWRConfiguration<Data, Error, Fetcher<Data, SWRKey>>
+      | undefined
   >(
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null,
-    config: SWROptions | undefined
-  ): SWRResponse<Data, Error, Required<SWROptions>>
+    config: SWROptions
+  ): SWRResponse<Data, Error, SWROptions>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
   <Data = any, Error = any>(
     key: Key,
@@ -259,22 +263,22 @@ export interface SWRHook {
     Error = any,
     SWROptions extends
       | SWRConfiguration<Data, Error, BareFetcher<Data>>
-      | undefined = SWRConfiguration<Data, Error, BareFetcher<Data>>
+      | undefined = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
   >(
     key: Key,
-    config: SWROptions | undefined
-  ): SWRResponse<Data, Error, Required<SWROptions>>
+    config: SWROptions
+  ): SWRResponse<Data, Error, SWROptions>
   <
     Data = any,
     Error = any,
     SWROptions extends
       | SWRConfiguration<Data, Error, BareFetcher<Data>>
-      | undefined = SWRConfiguration<Data, Error, BareFetcher<Data>>
+      | undefined = SWRConfiguration<Data, Error, BareFetcher<Data>> | undefined
   >(
     key: Key,
     fetcher: BareFetcher<Data> | null,
-    config: SWROptions | undefined
-  ): SWRResponse<Data, Error, Required<SWROptions>>
+    config: SWROptions
+  ): SWRResponse<Data, Error, SWROptions>
 }
 
 // Middleware guarantees that a SWRHook receives a key, fetcher, and config as the argument

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { Cache, SWRResponse } from 'swr'
 import useSWR, { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
-import type { FullConfiguration } from 'swr/_internal'
+import type { FullConfiguration, SWRConfiguration } from 'swr/_internal'
 import type { Equal } from '@type-challenges/utils'
 
 export function testCache() {
@@ -130,4 +130,10 @@ export function testFallbackData() {
     { fallbackData: 'fallback' }
   )
   expectType<string>(data6)
+}
+
+export function testConfigAsSWRConfiguration() {
+  const fetcher = (k: string) => Promise.resolve({ value: k })
+  const { data } = useSWR('/api', fetcher, {} as SWRConfiguration)
+  expectType<Equal<typeof data, { value: string } | undefined>>(true)
 }

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import type { Cache, SWRResponse } from 'swr'
 import useSWR, { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
-import type { FullConfiguration, SWRConfiguration } from 'swr/_internal'
+import type { FullConfiguration } from 'swr/_internal'
 import type { Equal } from '@type-challenges/utils'
 
 export function testCache() {
@@ -53,13 +53,34 @@ export function testSWRResponseCachedDataTypes() {
 }
 
 export function testSuspense() {
-  const { data: suspenseyData } = useSWR(
+  // Basic
+  const { data: data1 } = useSWR('/api', (k: string) => Promise.resolve(k), {
+    suspense: true
+  })
+  expectType<string>(data1)
+
+  // Basic(default fetcher)
+  const { data: data2 } = useSWR('/api', {
+    suspense: true
+  })
+  expectType<any>(data2)
+
+  // If a generic is explicitly passed we will lose type inference for the swr config
+  // because of partial inference limitations in typescript.
+  // https://github.com/microsoft/TypeScript/issues/26242
+  const { data: data3 } = useSWR<string>(
     '/api',
     (k: string) => Promise.resolve(k),
     { suspense: true }
   )
+  expectType<string | undefined>(data3)
 
-  expectType<string>(suspenseyData)
+  const { data: data4 } = useSWR<string, any, { suspense: true }>(
+    '/api',
+    (k: string) => Promise.resolve(k),
+    { suspense: true }
+  )
+  expectType<string>(data4)
 }
 
 export function testFallbackData() {
@@ -86,10 +107,27 @@ export function testFallbackData() {
     fallbackData: { value: 'fallback' }
   })
   expectType<{ value: string }>(data3)
-}
 
-export function testUndefinedData() {
-  const fetcher = (k: string) => Promise.resolve({ value: k })
-  const { data } = useSWR('/api', fetcher, {} as SWRConfiguration)
-  expectType<Equal<typeof data, { value: string } | undefined>>(true)
+  // Does not need specific fetcher
+
+  // Basic(default fetcher)
+  const { data: data4 } = useSWR('/api', { fallbackData: 'fallback' })
+  expectType<any>(data4)
+
+  // If a generic is explicitly passed we will lose type inference for the swr config
+  // because of partial inference limitations in typescript.
+  // https://github.com/microsoft/TypeScript/issues/26242
+  const { data: data5 } = useSWR<string>(
+    '/api',
+    (k: string) => Promise.resolve(k),
+    { fallbackData: 'fallback' }
+  )
+  expectType<string | undefined>(data5)
+
+  const { data: data6 } = useSWR<string, any, { fallbackData: 'fallback' }>(
+    '/api',
+    (k: string) => Promise.resolve(k),
+    { fallbackData: 'fallback' }
+  )
+  expectType<string>(data6)
 }

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import type { Cache, SWRResponse } from 'swr'
 import useSWR, { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
-import type {
-  BareFetcher,
-  FullConfiguration,
-  PublicConfiguration,
-  SWRConfiguration
-} from 'swr/_internal'
+import type { FullConfiguration, SWRConfiguration } from 'swr/_internal'
 import type { Equal } from '@type-challenges/utils'
 
 export function testCache() {
@@ -58,45 +53,13 @@ export function testSWRResponseCachedDataTypes() {
 }
 
 export function testSuspense() {
-  // Basic
-  const { data: data1 } = useSWR('/api', (k: string) => Promise.resolve(k), {
-    suspense: true
-  })
-  expectType<string>(data1)
-
-  // Basic(default fetcher)
-  const { data: data2 } = useSWR('/api', {
-    suspense: true
-  })
-  expectType<any>(data2)
-
-  // Generics
-  const { data: data3 } = useSWR<string>(
+  const { data: suspenseyData } = useSWR(
     '/api',
     (k: string) => Promise.resolve(k),
     { suspense: true }
   )
-  expectType<string>(data3)
 
-  // Generics(default fetcher)
-  const { data: data4 } = useSWR<string>('/api', { suspense: true })
-  expectType<string>(data4)
-
-  // Generics(SWRKey)
-  const { data: data5 } = useSWR<string, any, '/api'>(
-    '/api',
-    (k: string) => Promise.resolve(k),
-    {
-      suspense: true
-    }
-  )
-  expectType<string>(data5)
-
-  // Generics(SWRKey, default fetcher)
-  const { data: data6 } = useSWR<string, any, '/api'>('/api', {
-    suspense: true
-  })
-  expectType<string>(data6)
+  expectType<string>(suspenseyData)
 }
 
 export function testFallbackData() {
@@ -123,47 +86,6 @@ export function testFallbackData() {
     fallbackData: { value: 'fallback' }
   })
   expectType<{ value: string }>(data3)
-
-  // Does not need specific fetcher
-
-  // Basic(default fetcher)
-  const { data: data4 } = useSWR('/api', { fallbackData: 'fallback' })
-  expectType<any>(data4)
-
-  // Generics
-  const { data: data5 } = useSWR<string>(
-    '/api',
-    (k: string) => Promise.resolve(k),
-    { fallbackData: 'fallback' }
-  )
-  expectType<string>(data5)
-
-  // Generics(default fetcher)
-  const { data: data6 } = useSWR<string>('/api', { fallbackData: 'fallback' })
-  expectType<string>(data6)
-
-  // Generics(SWRKey)
-  const { data: data7 } = useSWR<string, any, '/api'>(
-    '/api',
-    (k: string) => Promise.resolve(k),
-    { fallbackData: 'fallback' }
-  )
-  expectType<string>(data7)
-
-  // Generics(SWRKey, default fetcher)
-  const { data: data8 } = useSWR<string, any, '/api'>('/api', {
-    fallbackData: 'fallback'
-  })
-  expectType<string>(data8)
-}
-export function testUndefined() {
-  // Undefined can be passed to config.
-  expectType<
-    Equal<
-      Parameters<typeof useSWR<string, any>>['2'],
-      Partial<PublicConfiguration<string, any, BareFetcher<string>>> | undefined
-    >
-  >(true)
 }
 
 export function testUndefinedData() {

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -5,7 +5,8 @@ import { expectType } from './utils'
 import type {
   BareFetcher,
   FullConfiguration,
-  PublicConfiguration
+  PublicConfiguration,
+  SWRConfiguration
 } from 'swr/_internal'
 import type { Equal } from '@type-challenges/utils'
 
@@ -163,4 +164,10 @@ export function testUndefined() {
       Partial<PublicConfiguration<string, any, BareFetcher<string>>> | undefined
     >
   >(true)
+}
+
+export function testUndefinedData() {
+  const fetcher = (k: string) => Promise.resolve({ value: k })
+  const { data } = useSWR('/api', fetcher, {} as SWRConfiguration)
+  expectType<Equal<typeof data, { value: string } | undefined>>(true)
 }


### PR DESCRIPTION
This PR resolves issue https://github.com/vercel/swr/issues/2505 by reverting PR https://github.com/vercel/swr/pull/2452, and updates the tests to better explain why this issue cannot be fixed: https://github.com/vercel/swr/issues/2396

https://github.com/vercel/swr/issues/2396 suggests that if a generic is passed to the `useSWR` hook, that the library should still infer the type of the SWRConfig passed in.  However, this isn't possible in typescript due to limitations with partial inference.  That is, typescript can either infer all generics or none at all - never some but not others.

Here's a simple example to showcase this partial inference limitation:

```ts

type Foo = <A = any, B = any, C = any>(a: A, b: B, c: C) => [A, B, C]
const foo: Foo = (a, b, c) => [a, b, c]
const bar1 = foo(1, 2, 3)
//     ^? const bar1: [number, number, number]
const bar2 = foo<number>(1, 2, 3)
//     ^? const bar2: [number, any, any]  - Passing just one explicit generic to `foo` removes type inference for the rest of the generics.
```

https://github.com/vercel/swr/pull/2452 didn't actually fix the issue https://github.com/vercel/swr/issues/2396 - it just forced it so that the default of the `SWRConfig` generic forced the type check in `BlockingData` to always evaluated to `true`.  This is now tested against in the new test case `testConfigAsSWRConfiguration`.  I also updated all of the tests added in that PR to point to some documentation explaining this typescript limitation.

Some other documentation on this issue:
https://github.com/microsoft/TypeScript/issues/26242
https://stackoverflow.com/questions/60377365/typescript-infer-type-of-generic-after-optional-first-generic