### PR TITLE
test: fix syntax error in Equal type alias implementation

### DIFF
--- a/test/type/trigger.ts
+++ b/test/type/trigger.ts
@@ -5,6 +5,9 @@ const expectType: ExpectType = () => {}
 
 type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
 
+// Test the Equal type
+expectType<Equal<number, string>>(false) // should be false
+
 export function useExtraParam() {
   useSWRMutation('/api/user', key => {
     expectType<string>(key)

--- a/test/type/trigger.ts
+++ b/test/type/trigger.ts
@@ -3,11 +3,7 @@ import useSWR from 'swr'
 type ExpectType = <T>(value: T) => void
 const expectType: ExpectType = () => {}
 
-type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B
-  ? 1
-  : 2
-  ? true
-  : false
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
 
 export function useExtraParam() {
   useSWRMutation('/api/user', key => {


### PR DESCRIPTION
This TypeScript code defining a type alias Equal<A, B>. The type alias compares two types A and B and returns a boolean value indicating whether they are equal or not.

The implementation uses a conditional type with two nested conditional type expressions. However, there is a syntax error in the implementation. The find issue text is not a valid TypeScript syntax, and it causes a syntax error.