### PR TITLE
fix: Improve useSubscription typing

### DIFF
--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -22,11 +22,13 @@ export type SWRSubscriptionResponse<Data = any, Error = any> = {
   error?: Error
 }
 
-export type SWRSubscriptionHook<Data = any, Error = any> = (
-  key: Key,
-  subscribe: SWRSubscription<Data, Error>,
-  config?: SWRConfiguration
-) => SWRSubscriptionResponse<Data, Error>
+export interface SWRSubscriptionHook {
+  <Data = any, Error = any, SWRKey extends Key = Key>(
+    key: SWRKey,
+    subscribe: SWRSubscription<Data, Error, SWRKey>,
+    config?: SWRConfiguration
+  ): SWRSubscriptionResponse<Data, Error>
+}
 
 // [subscription count, disposer]
 type SubscriptionStates = [Map<string, number>, Map<string, () => void>]

--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -8,8 +8,12 @@ import {
   createCacheHelper
 } from 'swr/_internal'
 
-export type SWRSubscription<Data = any, Error = any> = (
-  key: Key,
+export type SWRSubscription<
+  Data = any,
+  Error = any,
+  SWRKey extends Key = Key
+> = (
+  key: SWRKey,
   { next }: { next: (err?: Error | null, data?: Data) => void }
 ) => () => void
 

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
+import useSWRSubscription from 'swr/subscription'
 import { expectType, truthy } from './utils'
 import type { Equal } from '@type-challenges/utils'
 
@@ -21,6 +22,21 @@ export function useDataErrorGeneric() {
       return truthy() ? 'key' : null
     },
     key => key
+  )
+  useSWRSubscription<{ id: number }, { err: string }>(
+    'key',
+    (_key, { next }) => {
+      expectType<
+        Equal<
+          (
+            err?: { err: string } | null | undefined,
+            data?: { id: number } | undefined
+          ) => void,
+          typeof next
+        >
+      >(true)
+      return () => {}
+    }
   )
 }
 

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -55,6 +55,11 @@ export function useString() {
     expectType<Equal<'/api/user', typeof key>>(true)
     return key
   })
+
+  useSWRSubscription('/ws', key => {
+    expectType<Equal<'/ws', typeof key>>(true)
+    return () => {}
+  })
 }
 
 export function useRecord() {


### PR DESCRIPTION
Fixes useSubscription typing that is not accept generics and do not inter key type.

For the generics problem, I believe that is caused by the TypeScript behind the difference between `type` and `interface`, anyway using `interface` instead of `type` solves the ploblem.

Also, I checked other hooks (`useSWR`, `useSWRInfinite`, `useSWRMutation`, `useSWRImmutable`) and they used `interface` for typing and works fine.

reproduction:
https://stackblitz.com/edit/react-ts-ur5fbw?file=App.tsx