### PR TITLE
types: improve `useSWRSubscription` types

### DIFF
--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -22,11 +22,13 @@ export type SWRSubscriptionResponse<Data = any, Error = any> = {
   error?: Error
 }
 
-export type SWRSubscriptionHook<Data = any, Error = any> = (
-  key: Key,
-  subscribe: SWRSubscription<Data, Error>,
-  config?: SWRConfiguration
-) => SWRSubscriptionResponse<Data, Error>
+export interface SWRSubscriptionHook {
+  <Data = any, Error = any, SWRKey extends Key = Key>(
+    key: SWRKey,
+    subscribe: SWRSubscription<Data, Error, SWRKey>,
+    config?: SWRConfiguration
+  ): SWRSubscriptionResponse<Data, Error>
+}
 
 // [subscription count, disposer]
 type SubscriptionStates = [Map<string, number>, Map<string, () => void>]

--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -16,7 +16,13 @@ export type SWRSubscription<
   SWRSubKey extends Key = Key,
   Data = any,
   Error = any
-> = (key: SWRSubKey, { next }: SWRSubNext<Data, Error>) => void
+> = SWRSubKey extends () => infer Arg | null | undefined | false
+  ? (key: Arg, { next }: SWRSubNext<Data, Error>) => void
+  : SWRSubKey extends null | undefined | false
+  ? never
+  : SWRSubKey extends infer Arg
+  ? (key: Arg, { next }: SWRSubNext<Data, Error>) => void
+  : never
 
 export type SWRSubscriptionResponse<Data = any, Error = any> = {
   data?: Data

--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -8,27 +8,30 @@ import {
   createCacheHelper
 } from 'swr/_internal'
 
+export type SWRSubNext<Data = any, Error = any> = {
+  next: (err?: Error | null, data?: Data) => void
+}
+
 export type SWRSubscription<
+  SWRSubKey extends Key = Key,
   Data = any,
-  Error = any,
-  SWRKey extends Key = Key
-> = (
-  key: SWRKey,
-  { next }: { next: (err?: Error | null, data?: Data) => void }
-) => () => void
+  Error = any
+> = (key: SWRSubKey, { next }: SWRSubNext<Data, Error>) => void
 
 export type SWRSubscriptionResponse<Data = any, Error = any> = {
   data?: Data
   error?: Error
 }
 
-export interface SWRSubscriptionHook {
-  <Data = any, Error = any, SWRKey extends Key = Key>(
-    key: SWRKey,
-    subscribe: SWRSubscription<Data, Error, SWRKey>,
-    config?: SWRConfiguration
-  ): SWRSubscriptionResponse<Data, Error>
-}
+export type SWRSubscriptionHook = <
+  Data = any,
+  Error = any,
+  SWRSubKey extends Key = Key
+>(
+  key: SWRSubKey,
+  subscribe: SWRSubscription<SWRSubKey, Data, Error>,
+  config?: SWRConfiguration
+) => SWRSubscriptionResponse<Data, Error>
 
 // [subscription count, disposer]
 type SubscriptionStates = [Map<string, number>, Map<string, () => void>]
@@ -36,10 +39,10 @@ const subscriptionStorage = new WeakMap<object, SubscriptionStates>()
 
 const SUBSCRIPTION_PREFIX = '$sub$'
 
-export const subscription = (<Data, Error>(useSWRNext: SWRHook) =>
+export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
   (
     _key: Key,
-    subscribe: SWRSubscription<Data, Error>,
+    subscribe: SWRSubscription<any, Data, Error>,
     config: SWRConfiguration & typeof SWRConfig.defaultValue
   ): SWRSubscriptionResponse<Data, Error> => {
     const [key] = serialize(_key)

--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -8,8 +8,12 @@ import {
   createCacheHelper
 } from 'swr/_internal'
 
-export type SWRSubscription<Data = any, Error = any> = (
-  key: Key,
+export type SWRSubscription<
+  Data = any,
+  Error = any,
+  SWRKey extends Key = Key
+> = (
+  key: SWRKey,
   { next }: { next: (err?: Error | null, data?: Data) => void }
 ) => () => void
 

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -1,5 +1,6 @@
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
+import useSWRSubscription from 'swr/subscription'
 import { expectType, truthy } from './utils'
 import type { Equal } from '@type-challenges/utils'
 
@@ -21,6 +22,21 @@ export function useDataErrorGeneric() {
       return truthy() ? 'key' : null
     },
     key => key
+  )
+  useSWRSubscription<{ id: number }, { err: string }>(
+    'key',
+    (_key, { next }) => {
+      expectType<
+        Equal<
+          (
+            err?: { err: string } | null | undefined,
+            data?: { id: number } | undefined
+          ) => void,
+          typeof next
+        >
+      >(true)
+      return () => {}
+    }
   )
 }
 

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -55,6 +55,11 @@ export function useString() {
     expectType<Equal<'/api/user', typeof key>>(true)
     return key
   })
+
+  useSWRSubscription('/ws', key => {
+    expectType<Equal<'/ws', typeof key>>(true)
+    return () => {}
+  })
 }
 
 export function useRecord() {

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -1,6 +1,5 @@
 import useSWR from 'swr'
 import useSWRInfinite from 'swr/infinite'
-import useSWRSubscription from 'swr/subscription'
 import { expectType, truthy } from './utils'
 import type { Equal } from '@type-challenges/utils'
 
@@ -23,21 +22,6 @@ export function useDataErrorGeneric() {
     },
     key => key
   )
-  useSWRSubscription<{ id: number }, { err: string }>(
-    'key',
-    (_key, { next }) => {
-      expectType<
-        Equal<
-          (
-            err?: { err: string } | null | undefined,
-            data?: { id: number } | undefined
-          ) => void,
-          typeof next
-        >
-      >(true)
-      return () => {}
-    }
-  )
 }
 
 export function useString() {
@@ -54,11 +38,6 @@ export function useString() {
   useSWR(truthy() ? '/api/user' : false, key => {
     expectType<Equal<'/api/user', typeof key>>(true)
     return key
-  })
-
-  useSWRSubscription('/ws', key => {
-    expectType<Equal<'/ws', typeof key>>(true)
-    return () => {}
   })
 }
 

--- a/test/type/sub.ts
+++ b/test/type/sub.ts
@@ -1,22 +1,95 @@
 import useSWRSubscription from 'swr/subscription'
 import type { SWRSubNext, SWRSubscription } from 'swr/subscription'
-import { expectType } from './utils'
+import { expectType, truthy } from './utils'
 
-export function useTestSubscription<T>() {
-  const { data, error } = useSWRSubscription(
-    'key',
+export function useTestSubscription() {
+  useSWRSubscription('key', (key, { next: _ }: SWRSubNext<string, Error>) => {
+    expectType<'key'>(key)
+    return () => {}
+  })
+  useSWRSubscription(
+    truthy() ? 'key' : undefined,
     (key, { next: _ }: SWRSubNext<string, Error>) => {
       expectType<'key'>(key)
       return () => {}
     }
   )
-  expectType<string | undefined>(data)
-  expectType<Error | undefined>(error)
+  useSWRSubscription(
+    ['key', 1],
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<[string, number]>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    truthy() ? ['key', 1] : undefined,
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<[string, number]>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    { foo: 'bar' },
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<{ foo: string }>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    truthy() ? { foo: 'bar' } : undefined,
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<{ foo: string }>(key)
+      return () => {}
+    }
+  )
 
-  const sub: SWRSubscription<string, T, Error> = (_, { next: __ }) => {
+  useSWRSubscription(
+    () => 'key',
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<string>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    () => (truthy() ? 'key' : undefined),
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<'key'>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    () => ['key', 1],
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<[string, number]>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    () => (truthy() ? ['key', 1] : undefined),
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<[string, number]>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    () => ({ foo: 'bar' }),
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<{ foo: string }>(key)
+      return () => {}
+    }
+  )
+  useSWRSubscription(
+    () => (truthy() ? { foo: 'bar' } : undefined),
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<{ foo: string }>(key)
+      return () => {}
+    }
+  )
+
+  const sub: SWRSubscription<string, string, Error> = (_, { next: __ }) => {
     return () => {}
   }
   const { data: data2, error: error2 } = useSWRSubscription('key', sub)
-  expectType<T | undefined>(data2)
+  expectType<string | undefined>(data2)
   expectType<Error | undefined>(error2)
 }

--- a/test/type/sub.ts
+++ b/test/type/sub.ts
@@ -1,0 +1,22 @@
+import useSWRSubscription from 'swr/subscription'
+import type { SWRSubNext, SWRSubscription } from 'swr/subscription'
+import { expectType } from './utils'
+
+export function useTestSubscription<T>() {
+  const { data, error } = useSWRSubscription(
+    'key',
+    (key, { next: _ }: SWRSubNext<string, Error>) => {
+      expectType<'key'>(key)
+      return () => {}
+    }
+  )
+  expectType<string | undefined>(data)
+  expectType<Error | undefined>(error)
+
+  const sub: SWRSubscription<string, T, Error> = (_, { next: __ }) => {
+    return () => {}
+  }
+  const { data: data2, error: error2 } = useSWRSubscription('key', sub)
+  expectType<T | undefined>(data2)
+  expectType<Error | undefined>(error2)
+}


### PR DESCRIPTION
This pr intend to improve `useSWRSubscription` types.

close #2523  
## Example

* inline subscription function
```tsx
import useSWRSubscription from 'swr/subscription'
import type { SWRSubNext } from 'swr/subscription'

const useExample = () => {
  const { data, error } = useSWRSubscription('key', 
    (key, { next }: SWRSubNext<string, Error>)) => {
     //^ key will be inferred as `key`
     //....
   })
   return {
      data,
      //^ data will be inferred as `string | undefined`
      error
      //^ error will be inferred as `Error | undefined`
   }
}
```

* declare subscription function
```tsx
import useSWRSubscription from 'swr/subscription'
import type { SWRSubscription } from 'swr/subscription'

// The first generic is Key
// The second generic is Data
// The Third generic is Error
const sub: SWRSubscription<string, string, Error> = (key, { next }) => {                         
  //......
}
const { data, error } = useSWRSubscription('key', sub)
```