### PR TITLE
feat: add name export for `useSWR`

### DIFF
--- a/core/index.ts
+++ b/core/index.ts
@@ -1,6 +1,7 @@
 // useSWR
 import useSWR from './use-swr'
 export default useSWR
+export { useSWR }
 // Core APIs
 export { SWRConfig, unstable_serialize } from './use-swr'
 export { useSWRConfig } from 'swr/_internal'


### PR DESCRIPTION
Add name export for `useSWR`, to improve auto import this hook by tsserver.