### PR TITLE
types: allow passing function as `Data` for `useSWRSubscriptionOptions`

### DIFF
--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -52,7 +52,10 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
       const [, set] = createCacheHelper<Data>(cache, subscriptionKey)
       const refCount = subscriptions.get(subscriptionKey) || 0
 
-      const next = (error?: Error | null, data?: Data) => {
+      const next: SWRSubscriptionOptions<Data, Error>['next'] = (
+        error,
+        data
+      ) => {
         if (error !== null && typeof error !== 'undefined') {
           set({ error })
         } else {

--- a/subscription/types.ts
+++ b/subscription/types.ts
@@ -1,7 +1,7 @@
-import type { Key, SWRConfiguration } from 'swr'
+import type { Key, SWRConfiguration, MutatorCallback } from 'swr'
 
 export type SWRSubscriptionOptions<Data = any, Error = any> = {
-  next: (err?: Error | null, data?: Data) => void
+  next: <T = Data>(err?: Error | null, data?: Data | MutatorCallback<T>) => void
 }
 
 export type SWRSubscription<


### PR DESCRIPTION
https://github.com/vercel/swr/blob/af90b110bd1d5cbf67b97091840e14925229a722/subscription/index.ts#L60
Current implementation has already supported this kind of usage.  So i add typescript support for this.

I will also update the docs and example later.