### PR TITLE
Examples: fix type in axios-typescript example

### DIFF
--- a/examples/axios-typescript/libs/useRequest.ts
+++ b/examples/axios-typescript/libs/useRequest.ts
@@ -30,7 +30,7 @@ export default function useRequest<Data = unknown, Error = unknown>(
     isValidating,
     mutate
   } = useSWR<AxiosResponse<Data>, AxiosError<Error>>(
-    request && JSON.stringify(request),
+    request,
     /**
      * NOTE: Typescript thinks `request` can be `null` here, but the fetcher
      * function is actually only called by `useSWR` when it isn't.
@@ -46,7 +46,7 @@ export default function useRequest<Data = unknown, Error = unknown>(
         config: request!,
         headers: {},
         data: fallbackData
-      }
+      } as AxiosResponse<Data>
     }
   )
 

--- a/examples/axios/libs/useRequest.js
+++ b/examples/axios/libs/useRequest.js
@@ -3,7 +3,7 @@ import axios from 'axios'
 
 export default function useRequest(request, { fallbackData, ...config } = {}) {
   return useSWR(
-    request && JSON.stringify(request),
+    request,
     () => axios(request || {}).then(response => response.data),
     {
       ...config,


### PR DESCRIPTION
close #2541

https://swr.vercel.app/docs/arguments#passing-objects