### PR TITLE
examples: fix invalid links

### DIFF
--- a/examples/api-hooks/pages/[user]/[repo].js
+++ b/examples/api-hooks/pages/[user]/[repo].js
@@ -5,17 +5,19 @@ export default function Repo() {
   const id = typeof window !== 'undefined' ? window.location.pathname.slice(1) : ''
   const { data } = useRepository(id)
 
-  return <div style={{ textAlign: 'center' }}>
-    <h1>{id}</h1>
-    {
-      data ? <div>
-        <p>forks: {data.forks_count}</p>
-        <p>stars: {data.stargazers_count}</p>
-        <p>watchers: {data.watchers}</p>
-      </div> : 'loading...'
-    }
-    <br />
-    <br />
-    <Link href="/"><a>Back</a></Link>
-  </div>
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h1>{id}</h1>
+      {
+        data ? <div>
+          <p>forks: {data.forks_count}</p>
+          <p>stars: {data.stargazers_count}</p>
+          <p>watchers: {data.watchers}</p>
+        </div> : 'loading...'
+      }
+      <br />
+      <br />
+      <Link href="/">Back</Link>
+    </div>
+  )
 }

--- a/examples/api-hooks/pages/index.js
+++ b/examples/api-hooks/pages/index.js
@@ -4,14 +4,16 @@ import useProjects from '../hooks/use-projects'
 export default function Index() {
   const { data } = useProjects()
 
-  return <div style={{ textAlign: 'center' }}>
-    <h1>Trending Projects</h1>
-    <div>
-    {
-      data ? data.map(project =>
-        <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}><a>{project}</a></Link></p>
-      ) : 'loading...'
-    }
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h1>Trending Projects</h1>
+      <div>
+      {
+        data ? data.map(project =>
+          <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}>{project}</Link></p>
+        ) : 'loading...'
+      }
+      </div>
     </div>
-  </div>
+  )
 }

--- a/examples/axios-typescript/pages/[user]/[repo].tsx
+++ b/examples/axios-typescript/pages/[user]/[repo].tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 
 import useRequest from '../../libs/useRequest'
@@ -29,9 +28,7 @@ export default function Repo() {
       )}
       <br />
       <br />
-      <Link href="/">
-        <a>Back</a>
-      </Link>
+      <Link href="/">Back</Link>
     </div>
   )
 }

--- a/examples/axios-typescript/pages/index.tsx
+++ b/examples/axios-typescript/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 
 import useRequest from '../libs/useRequest'
@@ -16,7 +15,7 @@ export default function Index() {
           ? data.map(project => (
               <p key={project}>
                 <Link href="/[user]/[repo]" as={`/${project}`}>
-                  <a>{project}</a>
+                  {project}
                 </Link>
               </p>
             ))

--- a/examples/axios/pages/[user]/[repo].js
+++ b/examples/axios/pages/[user]/[repo].js
@@ -31,7 +31,7 @@ export default function Repo() {
       <br />
       <br />
       <Link href="/">
-        <a>Back</a>
+        Back
       </Link>
     </div>
   )

--- a/examples/axios/pages/index.js
+++ b/examples/axios/pages/index.js
@@ -15,7 +15,7 @@ export default function Index() {
           ? data.map(project => (
               <p key={project}>
                 <Link href="/[user]/[repo]" as={`/${project}`}>
-                  <a>{project}</a>
+                  {project}
                 </Link>
               </p>
             ))

--- a/examples/basic-typescript/pages/[user]/[repo].tsx
+++ b/examples/basic-typescript/pages/[user]/[repo].tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 import fetch from '../../libs/fetch'
 
@@ -27,9 +26,7 @@ export default function Repo() {
       )}
       <br />
       <br />
-      <Link href="/">
-        <a>Back</a>
-      </Link>
+      <Link href="/">Back</Link>
     </div>
   )
 }

--- a/examples/basic-typescript/pages/index.tsx
+++ b/examples/basic-typescript/pages/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Link from 'next/link'
 import fetch from '../libs/fetch'
 
@@ -17,7 +16,7 @@ export default function HomePage() {
           ? data.map(project => (
               <p key={project}>
                 <Link href="/[user]/[repo]" as={`/${project}`}>
-                  <a>{project}</a>
+                  {project}
                 </Link>
               </p>
             ))

--- a/examples/basic/pages/[user]/[repo].js
+++ b/examples/basic/pages/[user]/[repo].js
@@ -7,17 +7,19 @@ export default function Repo() {
   const id = typeof window !== 'undefined' ? window.location.pathname.slice(1) : ''
   const { data } = useSWR('/api/data?id=' + id, fetch)
 
-  return <div style={{ textAlign: 'center' }}>
-    <h1>{id}</h1>
-    {
-      data ? <div>
-        <p>forks: {data.forks_count}</p>
-        <p>stars: {data.stargazers_count}</p>
-        <p>watchers: {data.watchers}</p>
-      </div> : 'loading...'
-    }
-    <br />
-    <br />
-    <Link href="/"><a>Back</a></Link>
-  </div>
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h1>{id}</h1>
+      {
+        data ? <div>
+          <p>forks: {data.forks_count}</p>
+          <p>stars: {data.stargazers_count}</p>
+          <p>watchers: {data.watchers}</p>
+        </div> : 'loading...'
+      }
+      <br />
+      <br />
+      <Link href="/">Back</Link>
+    </div>
+  )
 }

--- a/examples/basic/pages/index.js
+++ b/examples/basic/pages/index.js
@@ -6,14 +6,16 @@ import useSWR from 'swr'
 export default function Index() {
   const { data } = useSWR('/api/data', fetch)
 
-  return <div style={{ textAlign: 'center' }}>
-    <h1>Trending Projects</h1>
-    <div>
-    {
-      data ? data.map(project =>
-        <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}><a>{project}</a></Link></p>
-      ) : 'loading...'
-    }
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h1>Trending Projects</h1>
+      <div>
+      {
+        data ? data.map(project =>
+          <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}>{project}</Link></p>
+        ) : 'loading...'
+      }
+      </div>
     </div>
-  </div>
+  )
 }

--- a/examples/global-fetcher/pages/[user]/[repo].js
+++ b/examples/global-fetcher/pages/[user]/[repo].js
@@ -6,17 +6,19 @@ export default function Repo() {
   const id = typeof window !== 'undefined' ? window.location.pathname.slice(1) : ''
   const { data } = useSWR('/api/data?id=' + id)
 
-  return <div style={{ textAlign: 'center' }}>
-    <h1>{id}</h1>
-    {
-      data ? <div>
-        <p>forks: {data.forks_count}</p>
-        <p>stars: {data.stargazers_count}</p>
-        <p>watchers: {data.watchers}</p>
-      </div> : 'loading...'
-    }
-    <br />
-    <br />
-    <Link href="/"><a>Back</a></Link>
-  </div>
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h1>{id}</h1>
+      {
+        data ? <div>
+          <p>forks: {data.forks_count}</p>
+          <p>stars: {data.stargazers_count}</p>
+          <p>watchers: {data.watchers}</p>
+        </div> : 'loading...'
+      }
+      <br />
+      <br />
+      <Link href="/">Back</Link>
+    </div>
+  )
 }

--- a/examples/global-fetcher/pages/index.js
+++ b/examples/global-fetcher/pages/index.js
@@ -13,7 +13,7 @@ export default function Index() {
           ? data.map(project => (
               <p key={project}>
                 <Link href="/[user]/[repo]" as={`/${project}`}>
-                  <a>{project}</a>
+                  {project}
                 </Link>
               </p>
             ))

--- a/examples/prefetch-preload/pages/[user]/[repo].js
+++ b/examples/prefetch-preload/pages/[user]/[repo].js
@@ -1,6 +1,6 @@
-import React from 'react'
 import Head from "next/head"
 import Link from 'next/link'
+import React from 'react'
 import fetch from '../../libs/fetch'
 
 import useSWR, { mutate } from 'swr'
@@ -42,7 +42,7 @@ export default function Repo() {
         }
         <br />
         <br />
-        <Link href="/"><a onMouseEnter={handleMouseEnter}>Back</a></Link>
+        <Link href="/" onMouseEnter={handleMouseEnter}>Back</Link>
       </div>
     </>
   )

--- a/examples/prefetch-preload/pages/index.js
+++ b/examples/prefetch-preload/pages/index.js
@@ -57,8 +57,8 @@ export default function Index() {
         {
           data ? data.map(project =>
             <p key={project}>
-              <Link href='/[user]/[repo]' as={`/${project}`}>
-                <a onMouseEnter={handleMouseEnter}>{project}</a>
+              <Link href='/[user]/[repo]' as={`/${project}`} onMouseEnter={handleMouseEnter}>
+                {project}
               </Link>
             </p>
           ) : 'loading...'

--- a/examples/server-render/pages/[pokemon].js
+++ b/examples/server-render/pages/[pokemon].js
@@ -30,7 +30,7 @@ export default function Pokemon({ pokemon, fallbackData }) {
       <br />
       <br />
       <Link href="/">
-        <a>Back</a>
+        Back
       </Link>
     </div>
   )

--- a/examples/server-render/pages/index.js
+++ b/examples/server-render/pages/index.js
@@ -16,7 +16,7 @@ export default function Home({ fallbackData }) {
           ? data.results.map(pokemon => (
               <p key={pokemon.name}>
                 <Link href="/[pokemon]" as={`/${pokemon.name}`}>
-                  <a>{pokemon.name}</a>
+                  {pokemon.name}
                 </Link>
               </p>
             ))

--- a/examples/suspense/pages/[user]/[repo].js
+++ b/examples/suspense/pages/[user]/[repo].js
@@ -40,7 +40,7 @@ export default function Repo() {
       <br />
       <br />
       <Link href="/">
-        <a>Back</a>
+        Back
       </Link>
     </div>
   )

--- a/examples/suspense/pages/index.js
+++ b/examples/suspense/pages/index.js
@@ -14,7 +14,7 @@ const Repos = () => {
       {data.map(project => (
         <p key={project}>
           <Link href="/[user]/[repo]" as={`/${project}`}>
-            <a>{project}</a>
+            {project}
           </Link>
         </p>
       ))}


### PR DESCRIPTION
Removing all `a` tag from `link` tags as they are no longer supported in nextjs@13: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor