### PR TITLE
types: Allow auto-import by improving generated types

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -693,4 +693,6 @@ export const unstable_serialize = (key: Key) => serialize(key)[0]
  * }
  * ```
  */
-export default withArgs<SWRHook>(useSWRHandler)
+const useSWR = withArgs<SWRHook>(useSWRHandler)
+
+export default useSWR

--- a/immutable/index.ts
+++ b/immutable/index.ts
@@ -10,4 +10,6 @@ export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
   return useSWRNext(key, fetcher, config)
 }
 
-export default withMiddleware(useSWR, immutable)
+const useSWRImmutable = withMiddleware(useSWR, immutable)
+
+export default useSWRImmutable

--- a/infinite/index.ts
+++ b/infinite/index.ts
@@ -324,7 +324,9 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
     }
   }) as unknown as Middleware
 
-export default withMiddleware(useSWR, infinite) as SWRInfiniteHook
+const useSWRInfinite = withMiddleware(useSWR, infinite) as SWRInfiniteHook
+
+export default useSWRInfinite
 
 export {
   SWRInfiniteConfiguration,

--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -146,7 +146,12 @@ const mutation = (<Data, Error>() =>
  * } = useSWRMutation(key, fetcher, options?)
  * ```
  */
-export default withMiddleware(useSWR, mutation) as unknown as SWRMutationHook
+const useSWRMutation = withMiddleware(
+  useSWR,
+  mutation
+) as unknown as SWRMutationHook
+
+export default useSWRMutation
 
 export {
   SWRMutationConfiguration,


### PR DESCRIPTION
NOTE: This is NOT to add or change API or exports and all changes is about code styling that should not effect actual behavior

The changes let tsc emit types with the hook function name not `_default` so we can auto-import by that function name (even default exported).

#### How types change
Now:

```.d.ts
declare const _default: SWRHook;

export { SWRConfig, _default as default, unstable_serialize };
```

With the changes:

```.d.ts
declare const useSWR: SWRHook;

export { SWRConfig, useSWR as default, unstable_serialize };
```

Also, this is done in [`useSWRSubscription`](https://github.com/vercel/swr/blob/9371f1d0632fe7d9c7ce65608cf1c1119cca01fd/subscription/index.ts#L124-L129) and [its types](https://unpkg.com/browse/swr@2.1.3/subscription/dist/index.d.ts) is exporting `useSWRSubscription as default`. So we can already auto-import `useSWRSubscription` today.

#### Related issues and prs
- #1889
- #2546
- #2379