### PR TITLE
fix: Fix dependency tracking and useSES bug

### DIFF
--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -116,11 +116,11 @@ export const useSWRHandler = <Data = any, Error = any>(
     for (const _ in stateDependencies) {
       const t = _ as keyof StateDependencies
       if (t === 'data') {
-        if (!compare(current[t], prev[t])) {
+        if (!compare(prev[t], current[t])) {
           if (!isUndefined(prev[t])) {
             return false
           }
-          if (!compare(current[t], cachedDataWithLaggyAndFallback)) {
+          if (!compare(cachedDataWithLaggyAndFallback, current[t])) {
             return false
           }
         }

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -172,7 +172,18 @@ export const useSWRHandler = <Data = any, Error = any>(
       () => {
         const newSnapshot = getSelectedCache(getCache())
         const compareResult = isEqual(newSnapshot, memorizedSnapshot)
+
         if (compareResult) {
+          // Mentally, we should always return the `memorizedSnapshot` here
+          // as there's no change between the new and old snapshots.
+          // However, since the `isEqual` function only compares selected fields,
+          // the values of the unselected fields might be changed. That's
+          // simply because we didn't track them.
+          // To support the case in https://github.com/vercel/swr/pull/2576,
+          // we need to update these fields in the `memorizedSnapshot` too
+          // with direct mutations to ensure the snapshot is always up-to-date
+          // even for the unselected fields, but only trigger re-renders when
+          // the selected fields are changed.
           memorizedSnapshot.data = newSnapshot.data
           memorizedSnapshot.isLoading = newSnapshot.isLoading
           memorizedSnapshot.isValidating = newSnapshot.isValidating

--- a/examples/basic/pages/index.js
+++ b/examples/basic/pages/index.js
@@ -1,21 +1,49 @@
-import Link from 'next/link'
-import fetch from '../libs/fetch'
+// import Link from 'next/link'
+// import fetch from '../libs/fetch'
+
+// import useSWR from 'swr'
+
+// export default function Index() {
+//   const { data } = useSWR('/api/data', fetch)
+
+//   return (
+//     <div style={{ textAlign: 'center' }}>
+//       <h1>Trending Projects</h1>
+//       <div>
+//       {
+//         data ? data.map(project =>
+//           <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}>{project}</Link></p>
+//         ) : 'loading...'
+//       }
+//       </div>
+//     </div>
+//   )
+// }
 
 import useSWR from 'swr'
+import React, { useState, useEffect } from 'react'
 
-export default function Index() {
-  const { data } = useSWR('/api/data', fetch)
+const sleep = ms =>
+  new Promise(resolve => {
+    setTimeout(() => resolve('foo'), ms)
+  })
 
-  return (
-    <div style={{ textAlign: 'center' }}>
-      <h1>Trending Projects</h1>
-      <div>
-      {
-        data ? data.map(project =>
-          <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}>{project}</Link></p>
-        ) : 'loading...'
-      }
-      </div>
-    </div>
-  )
+export default function App() {
+  const [state, setState] = useState(false)
+  useEffect(() => {
+    let timeout = setTimeout(() => {
+      setState(true)
+    }, 2000)
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [])
+
+  const joke = useSWR('joke', () => sleep(1000))
+
+  if (!state || !joke.data) {
+    return <div>loading</div>
+  }
+
+  return <div>{joke.data}</div>
 }

--- a/examples/basic/pages/index.js
+++ b/examples/basic/pages/index.js
@@ -1,49 +1,21 @@
-// import Link from 'next/link'
-// import fetch from '../libs/fetch'
-
-// import useSWR from 'swr'
-
-// export default function Index() {
-//   const { data } = useSWR('/api/data', fetch)
-
-//   return (
-//     <div style={{ textAlign: 'center' }}>
-//       <h1>Trending Projects</h1>
-//       <div>
-//       {
-//         data ? data.map(project =>
-//           <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}>{project}</Link></p>
-//         ) : 'loading...'
-//       }
-//       </div>
-//     </div>
-//   )
-// }
+import Link from 'next/link'
+import fetch from '../libs/fetch'
 
 import useSWR from 'swr'
-import React, { useState, useEffect } from 'react'
 
-const sleep = ms =>
-  new Promise(resolve => {
-    setTimeout(() => resolve('foo'), ms)
-  })
+export default function Index() {
+  const { data } = useSWR('/api/data', fetch)
 
-export default function App() {
-  const [state, setState] = useState(false)
-  useEffect(() => {
-    let timeout = setTimeout(() => {
-      setState(true)
-    }, 2000)
-    return () => {
-      clearTimeout(timeout)
-    }
-  }, [])
-
-  const joke = useSWR('joke', () => sleep(1000))
-
-  if (!state || !joke.data) {
-    return <div>loading</div>
-  }
-
-  return <div>{joke.data}</div>
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <h1>Trending Projects</h1>
+      <div>
+      {
+        data ? data.map(project =>
+          <p key={project}><Link href='/[user]/[repo]' as={`/${project}`}>{project}</Link></p>
+        ) : 'loading...'
+      }
+      </div>
+    </div>
+  )
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@type-challenges/utils": "0.1.1",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",
-    "@types/react": "^18.0.27",
+    "@types/react": "^18.0.38",
     "@types/use-sync-external-store": "^0.0.3",
     "@typescript-eslint/eslint-plugin": "5.49.0",
     "@typescript-eslint/parser": "5.49.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
       '@type-challenges/utils': 0.1.1
       '@types/jest': ^29.4.0
       '@types/node': ^18.11.18
-      '@types/react': ^18.0.27
+      '@types/react': ^18.0.38
       '@types/use-sync-external-store': ^0.0.3
       '@typescript-eslint/eslint-plugin': 5.49.0
       '@typescript-eslint/parser': 5.49.0
@@ -46,7 +46,7 @@ importers:
       '@type-challenges/utils': 0.1.1
       '@types/jest': 29.4.0
       '@types/node': 18.11.18
-      '@types/react': 18.0.27
+      '@types/react': 18.0.38
       '@types/use-sync-external-store': 0.0.3
       '@typescript-eslint/eslint-plugin': 5.49.0_iu322prlnwsygkcra5kbpy22si
       '@typescript-eslint/parser': 5.49.0_7uibuqfxkfaozanbtbziikiqje
@@ -1413,11 +1413,11 @@ packages:
   /@types/react-dom/18.0.6:
     resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
     dependencies:
-      '@types/react': 18.0.27
+      '@types/react': 18.0.38
     dev: true
 
-  /@types/react/18.0.27:
-    resolution: {integrity: sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==}
+  /@types/react/18.0.38:
+    resolution: {integrity: sha512-ExsidLLSzYj4cvaQjGnQCk4HFfVT9+EZ9XZsQ8Hsrcn8QNgXtpZ3m9vSIC2MWtx7jHictK6wYhQgGh6ic58oOw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2

--- a/test/use-swr-integration.test.tsx
+++ b/test/use-swr-integration.test.tsx
@@ -592,4 +592,36 @@ describe('useSWR', () => {
       ]
     `)
   })
+
+  // Test for https://github.com/vercel/swr/issues/2446
+  it('should return latest data synchronously after accessing getter', async () => {
+    const fetcher = async () => {
+      await sleep(10)
+      return 'value'
+    }
+    const key = createKey()
+
+    const logs = []
+
+    function Page() {
+      const swr = useSWR(key, fetcher)
+      const [show, setShow] = useState(false)
+      useEffect(() => {
+        setTimeout(() => {
+          setShow(true)
+        }, 100)
+      }, [])
+      if (!show) return null
+      logs.push(swr.data)
+      return <p>data:{swr.data}</p>
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data:value')
+    expect(logs).toMatchInlineSnapshot(`
+      [
+        "value",
+      ]
+    `)
+  })
 })

--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -322,11 +322,18 @@ describe('useSWR - refresh', () => {
           undefined,
         ],
         [
-          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
+          undefined,
+        ],
+        [
+          {
+            "timestamp": 1,
+            "version": "1.0",
+          },
+          undefined,
         ],
         [
           {
@@ -391,11 +398,18 @@ describe('useSWR - refresh', () => {
           undefined,
         ],
         [
+          {
+            "timestamp": 1,
+            "version": "1.0",
+          },
           undefined,
+        ],
+        [
           {
             "timestamp": 1,
             "version": "1.0",
           },
+          undefined,
         ],
         [
           {
@@ -459,11 +473,11 @@ describe('useSWR - refresh', () => {
         ],
         [
           {
-            "timestamp": 1,
+            "timestamp": 2,
             "version": "1.0",
           },
           {
-            "timestamp": 2,
+            "timestamp": 1,
             "version": "1.0",
           },
         ],

--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -308,32 +308,32 @@ describe('useSWR - refresh', () => {
           },
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
           {
@@ -384,32 +384,32 @@ describe('useSWR - refresh', () => {
           },
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
+          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-          undefined,
         ],
         [
           {
@@ -463,21 +463,21 @@ describe('useSWR - refresh', () => {
         ],
         [
           {
-            "timestamp": 2,
+            "timestamp": 1,
             "version": "1.0",
           },
           {
-            "timestamp": 1,
+            "timestamp": 2,
             "version": "1.0",
           },
         ],
         [
           {
-            "timestamp": 2,
+            "timestamp": 1,
             "version": "1.0",
           },
           {
-            "timestamp": 1,
+            "timestamp": 2,
             "version": "1.0",
           },
         ],

--- a/test/use-swr-refresh.test.tsx
+++ b/test/use-swr-refresh.test.tsx
@@ -322,18 +322,11 @@ describe('useSWR - refresh', () => {
           },
         ],
         [
-          undefined,
           {
             "timestamp": 1,
             "version": "1.0",
           },
-        ],
-        [
           undefined,
-          {
-            "timestamp": 1,
-            "version": "1.0",
-          },
         ],
         [
           {
@@ -398,18 +391,11 @@ describe('useSWR - refresh', () => {
           },
         ],
         [
+          {
+            "timestamp": 1,
+            "version": "1.0",
+          },
           undefined,
-          {
-            "timestamp": 1,
-            "version": "1.0",
-          },
-        ],
-        [
-          undefined,
-          {
-            "timestamp": 1,
-            "version": "1.0",
-          },
         ],
         [
           {
@@ -473,11 +459,11 @@ describe('useSWR - refresh', () => {
         ],
         [
           {
-            "timestamp": 1,
+            "timestamp": 2,
             "version": "1.0",
           },
           {
-            "timestamp": 2,
+            "timestamp": 1,
             "version": "1.0",
           },
         ],


### PR DESCRIPTION
Fixes #2446. CC @promer94.

The overall idea of `useSES` is that state changes are triggered from the external. It works in a pipeline of "external state change → compare it with local state's snapshot → trigger re-render and update local state". The main catch here is that SWR's dependency tracking system (`stateDependencies.data = true`) isn't considered as a state in that loop. But then, even if we put `stateDependencies` part of the state and compare/update it through `useSES`, we can't do a synchronous read of the snapshot which is required as we use a getter:

```js
get data() {
  // Trigger a re-render synchronously with the updated snapshot
  setCache({ stateDependencies_data: true })

  return returnData
},
```

Mentally this should work (similar to [this example](https://legacy.reactjs.org/docs/hooks-faq.html#how-do-i-implement-getderivedstatefromprops)) but it doesn't seem to with `useSES`.

So in this PR, an extra ref `latestComparedState` is added to track the latest snapshot that `useSES` received inside, and return that state if possible. This shouldn't cause any problem in concurrent rendering because the process should happen in the same component instance and tick as `useSES`'s returned state, but as a complete state.

This way we are still managing the state via `useSES` but only re-renders it when necessary.

Here's a diagram explaining the idea:

![image](https://user-images.githubusercontent.com/3676859/233799136-39fef3ab-71ab-4444-9ff0-97c5ef2c4f5c.png)


### codesandbox ci
https://codesandbox.io/s/2446-grkt00?file=/src/App.js
https://codesandbox.io/s/swr-re-render-dn2whh?file=/src/App.tsx
