### PR TITLE
deps: update @testing-library/react to v14

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@swc/core": "^1.3.29",
     "@swc/jest": "0.2.24",
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@type-challenges/utils": "0.1.1",
     "@types/jest": "^29.4.0",
     "@types/node": "^18.11.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ importers:
       '@swc/core': ^1.3.29
       '@swc/jest': 0.2.24
       '@testing-library/jest-dom': ^5.16.5
-      '@testing-library/react': ^13.4.0
+      '@testing-library/react': ^14.0.0
       '@type-challenges/utils': 0.1.1
       '@types/jest': ^29.4.0
       '@types/node': ^18.11.18
@@ -42,7 +42,7 @@ importers:
       '@swc/core': 1.3.29
       '@swc/jest': 0.2.24_@swc+core@1.3.29
       '@testing-library/jest-dom': 5.16.5
-      '@testing-library/react': 13.4.0_biqbaboplfbrettd7655fr4n2y
+      '@testing-library/react': 14.0.0_biqbaboplfbrettd7655fr4n2y
       '@type-challenges/utils': 0.1.1
       '@types/jest': 29.4.0
       '@types/node': 18.11.18
@@ -1282,6 +1282,20 @@ packages:
       pretty-format: 27.5.1
     dev: true
 
+  /@testing-library/dom/9.2.0:
+    resolution: {integrity: sha512-xTEnpUKiV/bMyEsE5bT4oYA0x0Z/colMtxzUY8bKyPXBNLn/e0V4ZjBZkEhms0xE4pv9QsPfSRu9AWS4y5wGvA==}
+    engines: {node: '>=14'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/runtime': 7.18.9
+      '@types/aria-query': 5.0.1
+      aria-query: 5.0.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.14
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+    dev: true
+
   /@testing-library/jest-dom/5.16.5:
     resolution: {integrity: sha512-N5ixQ2qKpi5OLYfwQmUb/5mSV9LneAcaUfp32pn4yCnpb8r/Yz0pXFPck21dIicKmi+ta5WRAknkZCfA8refMA==}
     engines: {node: '>=8', npm: '>=6', yarn: '>=1'}
@@ -1297,15 +1311,15 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react/13.4.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==}
-    engines: {node: '>=12'}
+  /@testing-library/react/14.0.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-S04gSNJbYE30TlIMLTzv6QCTzt9AqIF5y6s6SzVFILNcNvbV/jU96GeiTPillGQo+Ny64M/5PV7klNYYgv5Dfg==}
+    engines: {node: '>=14'}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
     dependencies:
       '@babel/runtime': 7.18.9
-      '@testing-library/dom': 8.16.0
+      '@testing-library/dom': 9.2.0
       '@types/react-dom': 18.0.6
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1322,6 +1336,10 @@ packages:
 
   /@types/aria-query/4.2.2:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
+    dev: true
+
+  /@types/aria-query/5.0.1:
+    resolution: {integrity: sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==}
     dev: true
 
   /@types/babel__core/7.1.19:
@@ -3864,6 +3882,11 @@ packages:
 
   /lz-string/1.4.4:
     resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
+    hasBin: true
+    dev: true
+
+  /lz-string/1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
     dev: true
 

--- a/test/use-swr-key.test.tsx
+++ b/test/use-swr-key.test.tsx
@@ -1,13 +1,7 @@
 import { act, fireEvent, screen } from '@testing-library/react'
 import React, { useState, useEffect } from 'react'
 import useSWR from 'swr'
-import {
-  createKey,
-  createResponse,
-  executeWithoutBatching,
-  renderWithConfig,
-  sleep
-} from './utils'
+import { createKey, createResponse, renderWithConfig, sleep } from './utils'
 
 describe('useSWR - key', () => {
   it('should respect requests after key has changed', async () => {
@@ -132,16 +126,10 @@ describe('useSWR - key', () => {
     }
 
     renderWithConfig(<Page />)
-    const closureSpy = jest.spyOn(closureFunctions, 'first')
-
     await screen.findByText(`${baseKey}-first`)
-    expect(closureSpy).toHaveBeenCalledTimes(1)
 
-    // update, but don't change the id.
-    // Function identity should stay the same, and useSWR should not call the function again.
-    executeWithoutBatching(() => updateId('first'))
+    act(() => updateId('first'))
     await screen.findByText(`${baseKey}-first`)
-    expect(closureSpy).toHaveBeenCalledTimes(1)
 
     act(() => updateId('second'))
     await screen.findByText(`${baseKey}-second`)


### PR DESCRIPTION
This PR updates `@testing-library/react` to v14.

In this PR, I've also removed an assertion that seems to be incorrect.
https://github.com/vercel/swr/commit/d95428ca65a556e3e31ae301ea09450928ea1c4d

I think SWR always calls the `key` function even if the identity is the same. The test was passed because it was asserted before re-rendering caused by an update by `updateId('first')`.