### PR TITLE
test: add a new test setting to run tests with build files

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -23,6 +23,7 @@ jobs:
           pnpm run-all-checks
           pnpm clean
           pnpm build
+          pnpm test:build
   e2e:
     runs-on: ubuntu-latest
     container:

--- a/jest.config.build.js
+++ b/jest.config.build.js
@@ -1,0 +1,6 @@
+const config = require("./jest.config");
+module.exports = {
+  ...config,
+  // override to use build files
+  moduleNameMapper: {}
+}

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "coverage": "jest --coverage",
     "test-typing": "tsc --noEmit -p test/type/tsconfig.json && tsc --noEmit -p test/tsconfig.json",
     "test": "jest",
+    "test:build": "jest --config jest.config.build.js",
     "test:e2e": "playwright test",
     "run-all-checks": "pnpm types:check && pnpm lint && pnpm test && pnpm test-typing"
   },


### PR DESCRIPTION
#2580 only happens with build files, so it's hard to detect the bug before releasing a new version. We have some e2e tests, unfortunately, they are not failed because of the build setting.
To avoid that, I've added a new setting to run existing tests with build files.
This doesn't pass with v2.1.4. 