### PR TITLE
feat: pass arg on options.onSuccess of `useSWRMutation` and `useSWR`

### DIFF
--- a/_internal/types.ts
+++ b/_internal/types.ts
@@ -162,7 +162,8 @@ export interface PublicConfiguration<
   onSuccess: (
     data: Data,
     key: string,
-    config: Readonly<PublicConfiguration<Data, Error, Fn>>
+    config: Readonly<PublicConfiguration<Data, Error, Fn>>,
+    arg: any
   ) => void
   /**
    * callback function when a request returns an error

--- a/core/use-swr.ts
+++ b/core/use-swr.ts
@@ -434,7 +434,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         // Trigger the successful callback if it's the original request.
         if (shouldStartNewRequest) {
           if (callbackSafeguard()) {
-            getConfig().onSuccess(newData, key, config)
+            getConfig().onSuccess(newData, key, config, fnArg)
           }
         }
       } catch (err: any) {

--- a/mutation/index.ts
+++ b/mutation/index.ts
@@ -77,7 +77,7 @@ const mutation = (<Data, Error>() =>
           // If it's reset after the mutation, we don't broadcast any state change.
           if (ditchMutationsUntilRef.current <= mutationStartedAt) {
             setState({ data, isMutating: false, error: undefined })
-            options.onSuccess?.(data as Data, serializedKey, options)
+            options.onSuccess?.(data as Data, serializedKey, options, arg)
           }
           return data
         } catch (error) {

--- a/mutation/types.ts
+++ b/mutation/types.ts
@@ -38,7 +38,8 @@ export type SWRMutationConfiguration<
     key: string,
     config: Readonly<
       SWRMutationConfiguration<Data, Error, ExtraArg, SWRMutationKey, SWRData>
-    >
+    >,
+    arg: any
   ) => void
   onError?: (
     err: Error,


### PR DESCRIPTION
It's useful when you build your custom hook with `useSWRMutation`. 

```javascript
const useUpdatePost = () => {
  const { trigger, isMutating } = useSWRMutation(
    key,
    (url, { arg }) => fetch(url, { method: "POST", body: arg }),
    {
      onSuccess: (data, key, config) => {
        // I want to do something with response data and arg here
        // but I can't access fetcher's arg
      },
    }
  );
  return { trigger, isMutating };
};
```

Currently, there is no way to access `arg` in `onSuccess`. Thus let's pass `arg` on `onSuccess`. 