### PR TITLE
build: add trigger release job

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest1
 
     environment: release-${{ github.event.inputs.releaseType }}
+    steps:
       - name: Setup node
         uses: actions/setup-node@v3
         if: ${{ steps.docs-change.outputs.docsChange == 'nope' }}

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -63,20 +63,25 @@ jobs:
 
       - run: pnpm run build
 
-      - run: |
-        git config user.name "vercel-release-bot"
-        git config user.email "infra+release@vercel.com"
+      - name: Configure git
+        run: |
+          git config user.name "vercel-release-bot"
+          git config user.email "infra+release@vercel.com"
 
-      - name: tag beta
+      - name: Tag beta
         if: ${{ github.event.inputs.releaseType === 'beta' }}
         run: npm version prerelease --preid=beta
 
-      - name: tag stable
+      - name: Tag stable
         if: ${{ github.event.inputs.releaseType === 'stable' }}
         run: npm version ${{ github.event.inputs.releaseType }}
 
-      - run: git push && git push --tags
+      - name: Git push
         env:
-          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+            RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+        run: |
+          git push origin main
+          git push origin --tags
+
 
 

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -1,0 +1,82 @@
+on:
+  workflow_dispatch:
+    inputs:
+      releaseType:
+        description: Release stable or beta?
+        required: true
+        type: choice
+        options:
+          - beta
+          - stable
+
+      semverType:
+        description: semver type?
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+    secrets:
+      RELEASE_BOT_TOKEN:
+        required: true
+
+name: Trigger Release
+
+env:
+  PNPM_VERSION: 7.26.1
+
+
+jobs:
+  start:
+    runs-on: ubuntu-latest1
+
+    environment: release-${{ github.event.inputs.releaseType }}
+      - name: Setup node
+        uses: actions/setup-node@v3
+        if: ${{ steps.docs-change.outputs.docsChange == 'nope' }}
+        with:
+          node-version: 18
+          check-latest: true
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 10
+
+      - run: npm i -g pnpm@${PNPM_VERSION}
+
+      - id: get-store-path
+        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        timeout-minutes: 5
+        id: cache-pnpm-store
+        with:
+          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
+          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-
+            pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - run: pnpm install
+
+      - run: pnpm run build
+
+      - run: |
+        git config user.name "vercel-release-bot"
+        git config user.email "infra+release@vercel.com"
+
+      - name: tag beta
+        if: ${{ github.event.inputs.releaseType === 'beta' }}
+        run: npm version prerelease --preid=beta
+
+      - name: tag stable
+        if: ${{ github.event.inputs.releaseType === 'stable' }}
+        run: npm version ${{ github.event.inputs.releaseType }}
+
+      - run: git push && git push --tags
+        env:
+          RELEASE_BOT_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+


### PR DESCRIPTION
Add new github action to trigger a release, this action will call git version command to add a new commit and tag, then it will trigger a release job. Once it can work, In the future we'll merge it with test_release job