### PR TITLE
ci: drop unused inputs and step

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -1,23 +1,8 @@
 name: 'Install'
 description: 'Set up and install dependencies'
-
-inputs:
-  fetch-depth:
-    description: 'Number of commits to fetch'
-    default: '1'
-    required: false
-  persist-credentials:
-    description: 'Whether to persist credentials'
-    default: "true"
-    required: false
-
-
 runs:
   using: composite
   steps:
-    - name: Check out
-      uses: actions/checkout@v3
-
     - name: Setup pnpm
       uses: pnpm/action-setup@v2.2.4
 


### PR DESCRIPTION
These inputs are not used within the action's steps. It's possible you meant to do:

```yaml
    - name: Check out
      uses: actions/checkout@v3
      with:
        fetch-depth: ${{ inputs.fetch-depth }}
```

But I don't see [any usages](https://github.com/search?q=repo%3Avercel%2Fswr%20workflows%2Finstall&type=code) of this action that pass any inputs.

Further, since we're not modifying fetch-depth via the input, we can also drop the redundant checkout step, since by definition we needed to have checked out the repository in the first place to call this action locally via `uses: ./.github/workflows/install`. It's not a huge deal but we're currently checking out the repository twice:

![Screenshot from 2023-05-18 09-37-29](https://github.com/vercel/swr/assets/7498009/894b8b01-3912-4f3f-b6e8-9cade323c209)

I didn't have any guesses for what `persist-credentials` was meant to do, but I dropped it since it's also unused.