### PR TITLE
build: fix bad runner

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   start:
-    runs-on: ubuntu-latest1
+    runs-on: ubuntu-latest
 
     environment: release-${{ github.event.inputs.releaseType }}
     steps:


### PR DESCRIPTION
Fix typo on the `runs-on` machine
> Requested labels: ubuntu-latest1
Job defined at: vercel/swr/.github/workflows/trigger-release.yml@refs/heads/main
Waiting for a runner to pick up this job...
Job is cancelled before starting.