### PR TITLE
ci: use gh token credentials for cloning repo

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 10
+          token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
 
       - run: npm i -g pnpm@${PNPM_VERSION}
 


### PR DESCRIPTION
[slack thred](https://vercel.slack.com/archives/C01LN7C5QR5/p1684853633599649?thread_ts=1684428058.764599&cid=C01LN7C5QR5) 