### PR TITLE
fix: do unsubscribe synchronously

### DIFF
--- a/subscription/index.ts
+++ b/subscription/index.ts
@@ -78,19 +78,16 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
       }
 
       return () => {
-        // Prevent frequent unsubscribe caused by unmount
-        setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const count = subscriptions.get(subscriptionKey)! - 1
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const count = subscriptions.get(subscriptionKey)! - 1
 
-          subscriptions.set(subscriptionKey, count)
+        subscriptions.set(subscriptionKey, count)
 
-          // Dispose if it's the last one.
-          if (!count) {
-            const dispose = disposers.get(subscriptionKey)
-            dispose?.()
-          }
-        })
+        // Dispose if it's the last one.
+        if (!count) {
+          const dispose = disposers.get(subscriptionKey)
+          dispose?.()
+        }
       }
 
       // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Currently `useSWRSubscription` does unsubscribe asynchronously, which may cause a problem if sub function only supports a singleton subscriber.

This pr fixed issue by removing the `setTimeout` in the cleanup function. 

@huozhi would love to hear you idea about this pr.



https://codesandbox.io/s/2646-lwv4yh
close: #2646 



