### PR TITLE
ci: use script to bump semver version

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -25,7 +25,8 @@ name: Trigger Release
 
 env:
   PNPM_VERSION: 7.26.1
-
+  SEMVER_TYPE: ${{ github.event.inputs.semverType }}
+  RELEASE_TYPE: ${{ github.event.inputs.releaseType }}
 
 jobs:
   start:
@@ -74,13 +75,9 @@ jobs:
           git config user.name "vercel-release-bot"
           git config user.email "infra+release@vercel.com"
 
-      - name: Tag beta
-        if: ${{ github.event.inputs.releaseType == 'beta' }}
-        run: npm version pre${{ github.event.inputs.semverType }} --preid=beta
-
-      - name: Tag stable
-        if: ${{ github.event.inputs.releaseType == 'stable' }}
-        run: npm version ${{ github.event.inputs.semverType }}
+      - name: Bump version and tag
+        run: |
+          node ./scripts/bump-next-version.js
 
       - name: Git push
         env:

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rimraf": "5.0.0",
+    "semver": "^7.5.1",
     "swr": "workspace:*",
     "typescript": "5.0.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       rimraf:
         specifier: 5.0.0
         version: 5.0.0
+      semver:
+        specifier: ^7.5.1
+        version: 7.5.1
       swr:
         specifier: workspace:*
         version: 'link:'
@@ -1547,7 +1550,7 @@ packages:
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
-      semver: 7.3.7
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -1621,7 +1624,7 @@ packages:
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.3.7
+      semver: 7.5.1
       tsutils: 3.21.0(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -1642,7 +1645,7 @@ packages:
       '@typescript-eslint/typescript-estree': 5.59.2(typescript@5.0.4)
       eslint: 8.39.0
       eslint-scope: 5.1.1
-      semver: 7.3.7
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -3650,7 +3653,7 @@ packages:
       jest-util: 29.5.0
       natural-compare: 1.4.0
       pretty-format: 29.5.0
-      semver: 7.3.7
+      semver: 7.5.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4751,8 +4754,8 @@ packages:
     hasBin: true
     dev: true
 
-  /semver@7.3.7:
-    resolution: {integrity: sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==}
+  /semver@7.5.1:
+    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:

--- a/scripts/bump-next-version.js
+++ b/scripts/bump-next-version.js
@@ -1,0 +1,44 @@
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
+const semver = require('semver')
+
+const packageJsonPath = path.join(__dirname, '../package.json')
+const packageJsonData = fs.readFileSync(packageJsonPath, 'utf8')
+const packageJson = JSON.parse(packageJsonData)
+
+let version = packageJson.version
+const releaseType = process.env.RELEASE_TYPE || 'beta'
+const semverType = process.env.SEMVER_TYPE
+
+function bumpVersion(version) {
+  if (process.env.DRY_RUN) {
+    console.log(`npm version ${version}`)
+  } else {
+    try {
+      execSync(`npm version ${version}`, { stdio: 'inherit' })
+    } catch (error) {
+      console.error('Failed to execute npm version:', error)
+      process.exit(1)
+    }
+  }
+}
+
+if (releaseType === 'beta') {
+  if (semver.prerelease(version)) {
+    version = semver.inc(version, 'prerelease')
+  } else {
+    version = semver.inc(version, 'prepatch', 'beta')
+  }
+} else if (releaseType === 'stable') {
+  if (!semverType) {
+    console.error('Missing semver type. Expected "patch", "minor" or "major".')
+    process.exit(1)
+  }
+  version = semver.inc(version, semverType)
+} else {
+  console.error('Invalid release type. Expected "beta" or "stable".')
+  process.exit(1)
+}
+
+bumpVersion(version)


### PR DESCRIPTION
Use nodejs script to bump version properly, if we target beta release, it will only add beta.0 increase the number of beta version. It won't behave like npm prerelease to change to next minor/patch with beta version