### PR TITLE
♻️ Refactor Focus Manager Event Handling for Enhanced User Experience ✨

### DIFF
--- a/_internal/src/utils/web-preset.ts
+++ b/_internal/src/utils/web-preset.ts
@@ -30,12 +30,10 @@ const initFocus = (callback: () => void) => {
   if (isDocumentDefined) {
     document.addEventListener('visibilitychange', callback)
   }
-  onWindowEvent('focus', callback)
   return () => {
     if (isDocumentDefined) {
       document.removeEventListener('visibilitychange', callback)
     }
-    offWindowEvent('focus', callback)
   }
 }
 


### PR DESCRIPTION
**As you can see**, the focus manager currently listens to both `visibilitychange` and `focus` events by default.

I believe it may be beneficial to **consider** discontinuing the listening to `focus` events and solely rely on `visibilitychange` events.

**My rationale** behind this proposal is that we might be supporting both events primarily for historical reasons. It is worth noting that `visibilitychange` was not fully supported in older browsers that are no longer relevant (e.g., IE11).

The `focus` event has proven to have various pitfalls, as it can be triggered in the following scenarios:

1. Navigating between the application and DevTools.
2. Closing an alert or confirm dialog.
3. Interacting with a file upload dialog.
4. Interacting with an iframe.

These scenarios have the potential to result in a suboptimal user experience.

*This pull request is inspired by [this reference PR](https://github.com/TanStack/query/pull/4805).*