### PR TITLE
build: fix conflict types for index and index.react-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "@types/use-sync-external-store": "^0.0.3",
     "@typescript-eslint/eslint-plugin": "5.59.8",
     "@typescript-eslint/parser": "5.59.8",
-    "bunchee": "3.4.0",
+    "bunchee": "3.4.1",
     "eslint": "8.42.0",
     "eslint-config-prettier": "8.8.0",
     "eslint-plugin-jest-dom": "5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: 5.59.8
         version: 5.59.8(eslint@8.42.0)(typescript@5.1.3)
       bunchee:
-        specifier: 3.4.0
-        version: 3.4.0(typescript@5.1.3)
+        specifier: 3.4.1
+        version: 3.4.1(typescript@5.1.3)
       eslint:
         specifier: 8.42.0
         version: 8.42.0
@@ -1995,8 +1995,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /bunchee@3.4.0(typescript@5.1.3):
-    resolution: {integrity: sha512-tu0n1RYQFVcmjZiKbceekWJYBQn1wqKnUcjGVVlILu3JInElpBL3q83/w90KJluntGWdjewCqRexNbkyumoK0A==}
+  /bunchee@3.4.1(typescript@5.1.3):
+    resolution: {integrity: sha512-iyIrtXftVahdMV5r7iInyloUpqVXqfTdLUGn4l/GAy6evWE0zQLVhoPPJ8b1ghFpJYVYdHdCwEQd/u45aYtnvw==}
     engines: {node: '>= 16'}
     hasBin: true
     peerDependencies:


### PR DESCRIPTION
Fix `https://unpkg.com/browse/swr@2.2.0-beta.3/_internal/dist/index.d.ts` is missing most of the imports but used the react-server exports types