### PR TITLE
[Issue 2373] Fix SWR 2.0 bug - convert`isDocumentDefined` helper to function & add null check

### DIFF
--- a/_internal/src/utils/helper.ts
+++ b/_internal/src/utils/helper.ts
@@ -9,7 +9,7 @@ const STR_UNDEFINED = 'undefined'
 
 // NOTE: Use the function to guarantee it's re-evaluated between jsdom and node runtime for tests.
 export const isWindowDefined = typeof window != STR_UNDEFINED
-export const isDocumentDefined = typeof document != STR_UNDEFINED
+export const isDocumentDefined = (): boolean => typeof document != STR_UNDEFINED && document !== null
 export const hasRequestAnimationFrame = () =>
   isWindowDefined && typeof window['requestAnimationFrame'] != STR_UNDEFINED
 

--- a/_internal/src/utils/web-preset.ts
+++ b/_internal/src/utils/web-preset.ts
@@ -16,24 +16,25 @@ const isOnline = () => online
 const [onWindowEvent, offWindowEvent] =
   isWindowDefined && window.addEventListener
     ? [
-        window.addEventListener.bind(window),
-        window.removeEventListener.bind(window)
-      ]
+      window.addEventListener.bind(window),
+      window.removeEventListener.bind(window)
+    ]
     : [noop, noop]
 
-const isVisible = () => {
-  const visibilityState = isDocumentDefined && document.visibilityState
-  return isUndefined(visibilityState) || visibilityState !== 'hidden'
+const isVisible = (): boolean => {
+  const hasDocument = isDocumentDefined()
+  const visibilityState = document?.visibilityState
+  return hasDocument && isUndefined(visibilityState) || visibilityState !== 'hidden'
 }
 
 const initFocus = (callback: () => void) => {
   // focus revalidate
-  if (isDocumentDefined) {
+  if (isDocumentDefined()) {
     document.addEventListener('visibilitychange', callback)
   }
   onWindowEvent('focus', callback)
   return () => {
-    if (isDocumentDefined) {
+    if (isDocumentDefined()) {
       document.removeEventListener('visibilitychange', callback)
     }
     offWindowEvent('focus', callback)


### PR DESCRIPTION
Hi Vercel team this is a fix for open issue https://github.com/vercel/swr/issues/2373

I first noticed this issue appearing while running my team's frontend integration suite after fixing a separate bug in our code for one of our analytics react hooks to use a global variable instead of a `useRef`. 

Surprisingly, when running our Jest/React Testing Library suite this caused a low level error in SWR to trigger which then caused our Github Actions test runner to fail causing deploys to fail across the team. 

Here is our current relevant package suite (*we are still on `create-react-app` settings):

```
    "@testing-library/dom": "^8.20.0",
    "@testing-library/jest-dom": "^5.16.5",
    "@testing-library/react": "^13.4.0",
    "@testing-library/react-hooks": "^8.0.1",
    "@testing-library/user-event": "^14.4.3",
    "@types/jest": "^26.0.24",
    "react": "^18.2.0",
```

<img width="932" alt="image" src="https://github.com/vercel/swr/assets/5985282/263f02ea-ef10-40ab-a899-1c12b1ba4a18">

Its clear that this is getting set to `null` elsewhere (maybe node/jest setting it between tests to not get garbage collected?) but regardless, this fix ensures it is not `null` to then short circuit the `isVisible` function properly. A function is also safer here to act as a getter and ensure usage of the current value instead of a `const`

I also recommend just doing a more generic `!document` check to avoid any other possible falsy values - but figured that would require more edge case testing which I can let the internal team handle ;) 

This seems like a pretty safe fix and I believe I found all uses/imports of this helper - Our team was able to work around this for now by pulling in the https://github.com/ds300/patch-package, but this is a fairly large unnecessary bloat for us and caused a big blocker for commits today so any urgency here is much appreciated for this fix to go live. 

Please let me know if you need any additional details!
