### PR TITLE
remove the 'use client' directive and add client-only to useSWR entry.

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -12,7 +12,7 @@
   "private": true,
   "scripts": {
     "watch": "bunchee -w",
-    "build": "bunchee",
+    "build": "bunchee --external client-only",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -12,9 +12,12 @@
   "private": true,
   "scripts": {
     "watch": "bunchee -w",
-    "build": "bunchee --external client-only",
+    "build": "bunchee",
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "client-only": "*"
   },
   "peerDependencies": {
     "swr": "*",

--- a/core/package.json
+++ b/core/package.json
@@ -16,10 +16,8 @@
     "types:check": "tsc --noEmit",
     "clean": "rimraf dist"
   },
-  "dependencies": {
-    "client-only": "*"
-  },
   "peerDependencies": {
+    "client-only": "*",
     "swr": "*",
     "react": "*",
     "use-sync-external-store": "*"

--- a/core/src/env.d.ts
+++ b/core/src/env.d.ts
@@ -1,0 +1,1 @@
+declare module 'client-only'

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,4 +1,4 @@
-'use client'
+import 'client-only'
 
 // useSWR
 import useSWR from './use-swr'

--- a/immutable/src/index.ts
+++ b/immutable/src/index.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type { Middleware } from 'swr'
 import useSWR from 'swr'
 import { withMiddleware } from 'swr/_internal'

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -1,5 +1,3 @@
-'use client'
-
 // We have to several type castings here because `useSWRInfinite` is a special
 // hook where `key` and return type are not like the normal `useSWR` types.
 

--- a/mutation/src/index.ts
+++ b/mutation/src/index.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import { useCallback, useRef } from 'react'
 import useSWR, { useSWRConfig } from 'swr'
 import type { Middleware, Key } from 'swr/_internal'

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "watch": "pnpm -r run watch",
     "build": "pnpm build-package _internal && pnpm build-package core && pnpm build-package infinite && pnpm build-package immutable && pnpm build-package mutation && pnpm build-package subscription",
     "build:e2e": "pnpm next build e2e/site",
-    "build-package": "bunchee --external client-only --cwd",
+    "build-package": "bunchee --cwd",
     "types:check": "pnpm -r run types:check",
     "prepublishOnly": "pnpm clean && pnpm build",
     "publish-beta": "pnpm publish --tag beta",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "watch": "pnpm -r run watch",
     "build": "pnpm build-package _internal && pnpm build-package core && pnpm build-package infinite && pnpm build-package immutable && pnpm build-package mutation && pnpm build-package subscription",
     "build:e2e": "pnpm next build e2e/site",
-    "build-package": "bunchee --cwd",
+    "build-package": "bunchee --external client-only --cwd",
     "types:check": "pnpm -r run types:check",
     "prepublishOnly": "pnpm clean && pnpm build",
     "publish-beta": "pnpm publish --tag beta",
@@ -147,6 +147,7 @@
     "trailingComma": "none"
   },
   "dependencies": {
+    "client-only": "^0.0.1",
     "use-sync-external-store": "^1.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ importers:
 
   .:
     dependencies:
+      client-only:
+        specifier: ^0.0.1
+        version: 0.0.1
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.2.0(react@18.2.0)
@@ -2131,7 +2134,6 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-    dev: true
 
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}

--- a/subscription/src/index.ts
+++ b/subscription/src/index.ts
@@ -1,5 +1,3 @@
-'use client'
-
 import type { Key, SWRHook, Middleware, SWRConfiguration, SWRConfig } from 'swr'
 import type {
   SWRSubscriptionOptions,


### PR DESCRIPTION
According to [docs](https://react.dev/reference/react/use-client), `SWRConfig` should not be directly used in React Server Components since it has lots of non-serializable props. So we remove the 'use client' directive and add client-only to `useSWR` entry  in this pr.  