### PR TITLE
fix(cache): subscriptions not always called

### DIFF
--- a/_internal/src/utils/cache.ts
+++ b/_internal/src/utils/cache.ts
@@ -65,8 +65,12 @@ export const initCache = <Data = any>(
       provider.set(key, value)
       const subs = subscriptions[key]
       if (subs) {
-        for (const fn of subs) {
-          fn(value, prev)
+        let i = 0;
+        while (i <= subs.length) {
+          if (typeof subs[i] === 'function') {
+            subs[i](value, prev);
+          }
+          i += 1;
         }
       }
     }


### PR DESCRIPTION
since [the fix applied in 2.0.4](https://github.com/vercel/swr/commit/591726acaf78f3aba39755a8795d454ac88af42e) we had problems in our codebase with some subscriptions not being called on some of our pages, it is the opposite problem of the applied fix (where subscriptions were removed from the array during the call). We were experiencing subscription being added to the subscription list while the subscritions were called. Those subscriptions weren't called because the array was cloned and the newer subscription weren't already present. We change the approach by not cloning the subscription array and iterating over it with a while depending on the length of the subscription array and guarding the call to the subscription itself with a typeof check.