### PR TITLE
feat: add `isLoadingMore` option for useSWRInfinite

### DIFF
--- a/examples/infinite/pages/index.js
+++ b/examples/infinite/pages/index.js
@@ -9,19 +9,16 @@ export default function App() {
   const [repo, setRepo] = useState('reactjs/react-a11y')
   const [val, setVal] = useState(repo)
 
-  const { data, error, mutate, size, setSize, isValidating } = useSWRInfinite(
-    (index) =>
-      `https://api.github.com/repos/${repo}/issues?per_page=${PAGE_SIZE}&page=${
-        index + 1
-      }`,
-    fetch
-  )
+  const { data, mutate, size, setSize, isValidating, isLoadingMore } =
+    useSWRInfinite(
+      index =>
+        `https://api.github.com/repos/${repo}/issues?per_page=${PAGE_SIZE}&page=${
+          index + 1
+        }`,
+      fetch
+    )
 
   const issues = data ? [].concat(...data) : []
-  const isLoadingInitialData = !data && !error
-  const isLoadingMore =
-    isLoadingInitialData ||
-    (size > 0 && data && typeof data[size - 1] === 'undefined')
   const isEmpty = data?.[0]?.length === 0
   const isReachingEnd =
     isEmpty || (data && data[data.length - 1]?.length < PAGE_SIZE)
@@ -31,7 +28,7 @@ export default function App() {
     <div style={{ fontFamily: 'sans-serif' }}>
       <input
         value={val}
-        onChange={(e) => setVal(e.target.value)}
+        onChange={e => setVal(e.target.value)}
         placeholder="reactjs/react-a11y"
       />
       <button
@@ -63,7 +60,7 @@ export default function App() {
         </button>
       </p>
       {isEmpty ? <p>Yay, no issues found.</p> : null}
-      {issues.map((issue) => {
+      {issues.map(issue => {
         return (
           <p key={issue.id} style={{ margin: '6px 0' }}>
             - {issue.title}

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -307,6 +307,13 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       [infiniteKey, cache, mutate, resolvePageSize]
     )
 
+    // Based on https://swr.vercel.app/examples/infinite-loading
+    const isLoadingMore =
+      swr.isLoading ||
+      (resolvePageSize() > 0 &&
+        swr.data &&
+        typeof swr.data[resolvePageSize() - 1] === 'undefined')
+
     // Use getter functions to avoid unnecessary re-renders caused by triggering
     // all the getters of the returned swr object.
     return {
@@ -324,7 +331,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       },
       get isLoading() {
         return swr.isLoading
-      }
+      },
+      isLoadingMore
     }
   }) as unknown as Middleware
 

--- a/infinite/src/types.ts
+++ b/infinite/src/types.ts
@@ -47,6 +47,7 @@ export interface SWRInfiniteResponse<Data = any, Error = any>
   setSize: (
     size: number | ((_size: number) => number)
   ) => Promise<Data[] | undefined>
+  isLoadingMore: boolean | undefined
 }
 
 export interface SWRInfiniteHook {


### PR DESCRIPTION
The initiative of `isLoadingMore` feature.

### Description

Since `isLoading` is limited to the initial fetch, need a custom case for `load more` in infinite loading.

Didn't modify the current `isLoading` due to this comment:

https://github.com/vercel/swr/blob/bf1cd031ac3a24ad844569a364282d8fc50b6b5d/core/src/use-swr.ts#L379-L383

### Reference

https://swr.vercel.app/examples/infinite-loading

Fixes:
#2410