### PR TITLE
Fix the issue that useSWR revalidation isn't triggered if the useSWR call happens after mutation

### DIFF
--- a/_internal/src/utils/mutate.ts
+++ b/_internal/src/utils/mutate.ts
@@ -97,8 +97,8 @@ export async function internalMutate<Data>(
       cache
     ) as GlobalState
 
-    const revalidators = EVENT_REVALIDATORS[key]
     const startRevalidate = () => {
+      const revalidators = EVENT_REVALIDATORS[key]
       if (revalidate) {
         // Invalidate the key by deleting the concurrent request markers so new
         // requests will not be deduped.


### PR DESCRIPTION
E.g.:
```
   req------------->res
mutate------->end
```
In this case, the res would be ignored while req would not be triggered a revalidation.