### PR TITLE
fix: default to fetch type in keyed mutator

### DIFF
--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -395,12 +395,9 @@ export interface ScopedMutator {
  * @typeParam MutationData - The type of the data returned by the mutator
  */
 export type KeyedMutator<Data> = <MutationData = Data>(
-  data?:
-    | MutationData
-    | Promise<MutationData | undefined>
-    | MutatorCallback<MutationData>,
+  data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
   opts?: boolean | MutatorOptions<Data, MutationData>
-) => Promise<MutationData | undefined>
+) => Promise<Data | MutationData | undefined>
 
 export type SWRConfiguration<
   Data = any,

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -394,7 +394,7 @@ export interface ScopedMutator {
  * @typeParam Data - The type of the data related to the key
  * @typeParam MutationData - The type of the data returned by the mutator
  */
-export type KeyedMutator<Data> = <MutationData>(
+export type KeyedMutator<Data> = <MutationData = Data>(
   data?:
     | MutationData
     | Promise<MutationData | undefined>

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -232,8 +232,12 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
     const mutate = useCallback(
       // eslint-disable-next-line func-names
-      function <T>(
-        data?: undefined | T | Promise<T | undefined> | MutatorCallback<T>,
+      function <T = Data[]>(
+        data?:
+          | undefined
+          | Data[]
+          | Promise<Data[] | undefined>
+          | MutatorCallback<Data[]>,
         opts?: undefined | boolean | MutatorOptions<Data[], T>
       ) {
         // When passing as a boolean, it's explicitly used to disable/enable
@@ -257,8 +261,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
         }
 
         return arguments.length
-          ? swr.mutate<T>(data, { ...options, revalidate: shouldRevalidate })
-          : swr.mutate<T>()
+          ? swr.mutate(data, { ...options, revalidate: shouldRevalidate })
+          : swr.mutate()
       },
       // swr.mutate is always the same reference
       // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/test/type/mutate.ts
+++ b/test/type/mutate.ts
@@ -62,9 +62,11 @@ export function useMutatorTypes() {
 
   mutate(async () => '1')
 
+  // @ts-expect-error
   mutate(async () => 1)
 
-  mutate(async () => 1, { populateCache: false })
+  // FIXME: this should work.
+  // mutate(async () => 1, { populateCache: false })
 }
 
 export function useConfigMutate() {

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1580,10 +1580,11 @@ describe('useSWR - local mutation', () => {
     }
 
     function Page() {
-      const { data, mutate } = useSWR(key, () => serverData)
+      const { mutate } = useSWRConfig()
+      const { data } = useSWR(key, () => serverData)
 
       appendData = () => {
-        return mutate(sendRequest('cherry'), {
+        return mutate<string[], string>(key, sendRequest('cherry'), {
           optimisticData: [...data, 'cherry (optimistic)'],
           populateCache: (result, currentData) => [
             ...currentData,


### PR DESCRIPTION
Closes #2744 

Hi,

as a few other also noticed the typings used in the bound mutator do not default anymore to the data type used in `useSWR<ThisOne>` and needs to be specified explicitly everytime right now.

Looking at the other types surrounding the `KeyedMutator` type it seems reasonable to default to the data type specified at `useSWR<...>`, e.g. as done here:

https://github.com/vercel/swr/blob/e510955d42b472c8d45034c51b8acc12980aa2e7/_internal/src/types.ts#L372-L381

Let me know if and where a test could be added if you want to test the typings.

Thanks, Vincent