### PR TITLE
feat: Use custom functions to hash arguments

### DIFF
--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -194,7 +194,11 @@ export interface PublicConfiguration<
   /**
    * comparison function used to detect when returned data has changed, to avoid spurious rerenders. By default, [stable-hash](https://github.com/shuding/stable-hash) is used.
    */
-  compare: (a: Data | undefined, b: Data | undefined) => boolean
+  compare: (
+    a: Data | undefined,
+    b: Data | undefined,
+    customHashes?: CustomHashes
+  ) => boolean
   /**
    * isOnline and isVisible are functions that return a boolean, to determine if the application is "active". By default, SWR will bail out a revalidation if these conditions are not met.
    * @link https://swr.vercel.app/docs/advanced/react-native#customize-focus-and-reconnect-events
@@ -205,6 +209,7 @@ export interface PublicConfiguration<
    * @link https://swr.vercel.app/docs/advanced/react-native#customize-focus-and-reconnect-events
    */
   isVisible: () => boolean
+  customHashes?: CustomHashes
 }
 
 export type FullConfiguration<

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -304,6 +304,7 @@ export type Arguments =
   | undefined
   | false
 export type Key = Arguments | (() => Arguments)
+export type CustomHashes = Array<(arg: unknown) => string>
 export type StrictTupleKey = ArgumentsTuple | null | undefined | false
 type StrictKey = StrictTupleKey | (() => StrictTupleKey)
 export type MutatorCallback<Data = any> = (

--- a/_internal/src/utils/config.ts
+++ b/_internal/src/utils/config.ts
@@ -1,16 +1,17 @@
 import type {
-  PublicConfiguration,
+  Cache,
+  CustomHashes,
   FullConfiguration,
-  RevalidatorOptions,
+  PublicConfiguration,
   Revalidator,
-  ScopedMutator,
-  Cache
+  RevalidatorOptions,
+  ScopedMutator
 } from '../types'
-import { stableHash } from './hash'
 import { initCache } from './cache'
-import { preset } from './web-preset'
 import { slowConnection } from './env'
-import { isUndefined, noop, mergeObjects } from './shared'
+import { stableHash } from './hash'
+import { isUndefined, mergeObjects, noop } from './shared'
+import { preset } from './web-preset'
 
 // error retry
 const onErrorRetry = (
@@ -37,12 +38,13 @@ const onErrorRetry = (
   setTimeout(revalidate, timeout, opts)
 }
 
-const compare = (currentData: any, newData: any) =>
-  stableHash(currentData) == stableHash(newData)
+const compare = (currentData: any, newData: any, customHashes?: CustomHashes) =>
+  stableHash(currentData, customHashes) == stableHash(newData, customHashes)
+const customHashes = [] as CustomHashes
 
 // Default cache provider
 const [cache, mutate] = initCache(new Map()) as [Cache<any>, ScopedMutator]
-export { cache, mutate, compare }
+export { cache, compare, mutate }
 
 // Default config
 export const defaultConfig: FullConfiguration = mergeObjects(
@@ -71,7 +73,8 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     isPaused: () => false,
     cache,
     mutate,
-    fallback: {}
+    fallback: {},
+    customHashes
   },
   // use web preset by default
   preset

--- a/_internal/src/utils/hash.ts
+++ b/_internal/src/utils/hash.ts
@@ -1,4 +1,5 @@
-import { OBJECT, isUndefined } from './shared'
+import { type CustomHashes } from '..'
+import { OBJECT, isNil, isUndefined } from './shared'
 
 // use WeakMap to store the object->key mapping
 // so the objects can be garbage collected.
@@ -17,19 +18,21 @@ let counter = 0
 //
 // This is not a serialization function, and the result is not guaranteed to be
 // parsable.
-export const stableHash = (arg: any): string => {
+export const stableHash = (arg: any, customHashes?: CustomHashes): string => {
   const type = typeof arg
   const constructor = arg && arg.constructor
   const isDate = constructor == Date
 
-  let result: any
-  let index: any
+  let result: string | number | undefined = undefined
+  let isCustomHashed = false
+  let arrayIndex: number
+  let objectIndex: string
 
   if (OBJECT(arg) === arg && !isDate && constructor != RegExp) {
     // Object/function, not null/date/regexp. Use WeakMap to store the id first.
     // If it's already hashed, directly return the result.
     result = table.get(arg)
-    if (result) return result
+    if (result) return String(result)
 
     // Store the hash first for circular reference detection before entering the
     // recursive `stableHash` calls.
@@ -40,18 +43,29 @@ export const stableHash = (arg: any): string => {
     if (constructor == Array) {
       // Array.
       result = '@'
-      for (index = 0; index < arg.length; index++) {
-        result += stableHash(arg[index]) + ','
+      for (arrayIndex = 0; arrayIndex < arg.length; arrayIndex++) {
+        result += stableHash(arg[arrayIndex], customHashes) + ','
       }
       table.set(arg, result)
     }
-    if (constructor == OBJECT) {
+    if (!isNil(customHashes)) {
+      for (const customHash of customHashes) {
+        const hashed = customHash(arg)
+        if (!isNil(hashed)) {
+          result = hashed
+          table.set(arg, hashed)
+          isCustomHashed = true
+        }
+      }
+    }
+    if (!isCustomHashed && constructor == OBJECT) {
       // Object, sort keys.
       result = '#'
       const keys = OBJECT.keys(arg).sort()
-      while (!isUndefined((index = keys.pop() as string))) {
-        if (!isUndefined(arg[index])) {
-          result += index + ':' + stableHash(arg[index]) + ','
+      while (!isUndefined((objectIndex = keys.pop() as string))) {
+        if (!isUndefined(arg[objectIndex])) {
+          result +=
+            objectIndex + ':' + stableHash(arg[objectIndex], customHashes) + ','
         }
       }
       table.set(arg, result)
@@ -66,5 +80,5 @@ export const stableHash = (arg: any): string => {
       : '' + arg
   }
 
-  return result
+  return String(result)
 }

--- a/_internal/src/utils/preload.ts
+++ b/_internal/src/utils/preload.ts
@@ -1,15 +1,15 @@
+import { INFINITE_PREFIX } from '../constants'
 import type {
-  Middleware,
-  Key,
   BareFetcher,
+  FetcherResponse,
   GlobalState,
-  FetcherResponse
+  Key,
+  Middleware
 } from '../types'
-import { serialize } from './serialize'
 import { cache } from './config'
 import { SWRGlobalState } from './global-state'
+import { serialize } from './serialize'
 import { isUndefined } from './shared'
-import { INFINITE_PREFIX } from '../constants'
 // Basically same as Fetcher but without Conditional Fetching
 type PreloadFetcher<
   Data = unknown,
@@ -45,7 +45,7 @@ export const middleware: Middleware =
     const fetcher =
       fetcher_ &&
       ((...args: any[]) => {
-        const [key] = serialize(key_)
+        const [key] = serialize(key_, config.customHashes)
         const [, , , PRELOAD] = SWRGlobalState.get(cache) as GlobalState
 
         if (key.startsWith(INFINITE_PREFIX)) {

--- a/_internal/src/utils/serialize.ts
+++ b/_internal/src/utils/serialize.ts
@@ -1,9 +1,12 @@
 import { stableHash } from './hash'
 import { isFunction } from './shared'
 
-import type { Key, Arguments } from '../types'
+import type { Arguments, CustomHashes, Key } from '../types'
 
-export const serialize = (key: Key): [string, Arguments] => {
+export const serialize = (
+  key: Key,
+  customHashes?: CustomHashes
+): [string, Arguments] => {
   if (isFunction(key)) {
     try {
       key = key()
@@ -22,7 +25,7 @@ export const serialize = (key: Key): [string, Arguments] => {
     typeof key == 'string'
       ? key
       : (Array.isArray(key) ? key.length : key)
-      ? stableHash(key)
+      ? stableHash(key, customHashes)
       : ''
 
   return [key, args]

--- a/_internal/src/utils/shared.ts
+++ b/_internal/src/utils/shared.ts
@@ -11,6 +11,8 @@ export const UNDEFINED = (/*#__NOINLINE__*/ noop()) as undefined
 export const OBJECT = Object
 
 export const isUndefined = (v: any): v is undefined => v === UNDEFINED
+export const isNil = (v: unknown): v is undefined | null =>
+  v === undefined || v === null
 export const isFunction = <
   T extends (...args: any[]) => any = (...args: any[]) => any
 >(

--- a/core/src/serialize.ts
+++ b/core/src/serialize.ts
@@ -1,4 +1,5 @@
-import type { Key } from 'swr/_internal'
+import type { CustomHashes, Key } from 'swr/_internal'
 import { serialize } from 'swr/_internal'
 
-export const unstable_serialize = (key: Key) => serialize(key)[0]
+export const unstable_serialize = (key: Key, customHashes?: CustomHashes) =>
+  serialize(key, customHashes)[0]

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -1,40 +1,40 @@
 // We have to several type castings here because `useSWRInfinite` is a special
 // hook where `key` and return type are not like the normal `useSWR` types.
 
-import { useRef, useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import type { SWRConfig } from 'swr'
 import useSWR from 'swr'
-import {
-  isUndefined,
-  isFunction,
-  UNDEFINED,
-  createCacheHelper,
-  useIsomorphicLayoutEffect,
-  serialize,
-  withMiddleware,
-  INFINITE_PREFIX,
-  SWRGlobalState,
-  cache as defaultCache
-} from 'swr/_internal'
 import type {
   BareFetcher,
-  SWRHook,
-  MutatorCallback,
+  GlobalState,
   Middleware,
+  MutatorCallback,
   MutatorOptions,
-  GlobalState
+  SWRHook
 } from 'swr/_internal'
-import type {
-  SWRInfiniteConfiguration,
-  SWRInfiniteResponse,
-  SWRInfiniteHook,
-  SWRInfiniteKeyLoader,
-  SWRInfiniteFetcher,
-  SWRInfiniteCacheValue,
-  SWRInfiniteCompareFn
-} from './types'
+import {
+  INFINITE_PREFIX,
+  SWRGlobalState,
+  UNDEFINED,
+  createCacheHelper,
+  cache as defaultCache,
+  isFunction,
+  isUndefined,
+  serialize,
+  useIsomorphicLayoutEffect,
+  withMiddleware
+} from 'swr/_internal'
 import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { getFirstPageKey } from './serialize'
+import type {
+  SWRInfiniteCacheValue,
+  SWRInfiniteCompareFn,
+  SWRInfiniteConfiguration,
+  SWRInfiniteFetcher,
+  SWRInfiniteHook,
+  SWRInfiniteKeyLoader,
+  SWRInfiniteResponse
+} from './types'
 
 // const INFINITE_PREFIX = '$inf$'
 const EMPTY_PROMISE = Promise.resolve() as Promise<undefined>
@@ -64,7 +64,8 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
       persistSize = false,
       revalidateFirstPage = true,
       revalidateOnMount = false,
-      parallel = false
+      parallel = false,
+      customHashes = []
     } = config
     const [, , , PRELOAD] = SWRGlobalState.get(defaultCache) as GlobalState
 
@@ -186,7 +187,7 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
             shouldRevalidateOnMount ||
             (cacheData &&
               !isUndefined(cacheData[i]) &&
-              !config.compare(cacheData[i], pageData))
+              !config.compare(cacheData[i], pageData, customHashes))
           if (fn && shouldFetchPage) {
             const revalidate = async () => {
               const hasPreloadedRequest = pageKey in PRELOAD
@@ -342,10 +343,10 @@ const useSWRInfinite = withMiddleware(useSWR, infinite) as SWRInfiniteHook
 export default useSWRInfinite
 
 export {
+  SWRInfiniteCompareFn,
   SWRInfiniteConfiguration,
-  SWRInfiniteResponse,
+  SWRInfiniteFetcher,
   SWRInfiniteHook,
   SWRInfiniteKeyLoader,
-  SWRInfiniteFetcher,
-  SWRInfiniteCompareFn
+  SWRInfiniteResponse
 }

--- a/test/unit/utils.test.tsx
+++ b/test/unit/utils.test.tsx
@@ -1,8 +1,8 @@
 import {
   stableHash as hash,
-  serialize,
+  mergeConfigs,
   normalize,
-  mergeConfigs
+  serialize
 } from 'swr/_internal'
 
 describe('Utils', () => {
@@ -113,9 +113,46 @@ describe('Utils', () => {
       /@\d+~,1,"key",null,#x:1,,/
     )
 
+    class Todo {
+      constructor(
+        private name: string,
+        private isCompleted: boolean,
+        private createdAt: Date
+      ) {}
+
+      get message() {
+        return `Todo: ${this.name} created at ${this.createdAt}, ${
+          this.isCompleted ? 'complete.' : 'not completed.'
+        }`
+      }
+    }
+
     // Stable hash
     expect(hash([{ x: 1, y: 2, z: undefined }])).toMatch(
       hash([{ z: undefined, y: 2, x: 1 }])
+    )
+    expect(
+      hash(
+        [new Todo('Go to gym', false, new Date('2023-08-24'))],
+        [
+          arg => {
+            if (arg instanceof Todo) {
+              return arg.message
+            }
+          }
+        ]
+      )
+    ).toMatch(
+      hash(
+        [new Todo('Go to gym', false, new Date('2023-08-24'))],
+        [
+          arg => {
+            if (arg instanceof Todo) {
+              return arg.message
+            }
+          }
+        ]
+      )
     )
     expect(hash([{ x: 1, y: { a: 1, b: 2 }, z: undefined }])).toMatch(
       hash([{ y: { b: 2, a: 1 }, x: 1 }])


### PR DESCRIPTION
## Description

- Hash arguments with custom functions for some constructors.
  - Prevent converting instances to ascending numbers like `9~`.

- Can inject functions in SWR config
```tsx
<SWRConfig
  value={{
    customHashes: [
      // functions to serialize instances
    ],
  }}
>
  <Component {...pageProps} />
</SWRConfig>
```
- Tests for custom hash functions

## Discussions Previously Registered

https://github.com/vercel/swr/discussions/2685