### PR TITLE
fix: remove permissive type

### DIFF
--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -231,6 +231,10 @@ export interface SWRHook {
     key: SWRKey,
     fetcher: Fetcher<Data, SWRKey> | null
   ): SWRResponse<Data, Error>
+  <Data = any, Error = any, SWRKey extends Key = Key>(
+    key: SWRKey,
+    fetcher: Fetcher<Data, SWRKey> | null
+  ): SWRResponse<Data, Error>
   <
     Data = any,
     Error = any,
@@ -259,10 +263,6 @@ export interface SWRHook {
     config: SWROptions
   ): SWRResponse<Data, Error, SWROptions>
   <Data = any, Error = any>(key: Key): SWRResponse<Data, Error>
-  <Data = any, Error = any>(
-    key: Key,
-    fetcher: BareFetcher<Data> | null
-  ): SWRResponse<Data, Error>
   <
     Data = any,
     Error = any,

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -6,6 +6,8 @@ import type { Equal } from '@type-challenges/utils'
 export function useDataErrorGeneric() {
   useSWR<{ id: number }>('/api/', () => ({ id: 123 }))
   useSWR<string, any>('/api/', (key: string) => key)
+  const fetcher = ({ url }: { url: string }) => url
+  useSWR({ url: '/api' }, fetcher)
   useSWRInfinite<string[], any>(
     (index, previousPageData) => {
       expectType<Equal<number, typeof index>>(true)


### PR DESCRIPTION
Resolve #2758 by remove permissive type. Because BaseFetcher allows `(...args: any)` when your key and fetcher key mismatch you fall through to the override:

```
<Data = any, Error = any>(
     key: Key,
     fetcher: BareFetcher<Data> | null
   ): SWRResponse<Data, Error>
```

This should instead be flagged by typescript. Removing that override broke some tests added in #1640 which appeared to be designed to allow for backwards compatible hooks that don't conform to `StrictKey` to be compatible. Specifically these two type tests:

```
useSWR<{ id: number }>('/api/', () => ({ id: 123 }))
useSWR<string, any>('/api/', (key: string) => key)
```

The new override covers these while retaining type inference by just not defaulting to `StrictKey` which appears to be the main issue.