### PR TITLE
fix: simplify `ArgumentsTuple`

### DIFF
--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -295,7 +295,7 @@ export type Middleware = (
   config: SWRConfiguration<Data, Error, BareFetcher<Data>>
 ) => SWRResponse<Data, Error>
 
-type ArgumentsTuple = [any, ...unknown[]] | readonly [any, ...unknown[]]
+type ArgumentsTuple = readonly [any, ...unknown[]]
 export type Arguments =
   | string
   | ArgumentsTuple


### PR DESCRIPTION
this was already redundant but it will actually cause problems with TS 5.3 (in the future), see: https://github.com/microsoft/TypeScript/pull/55229#issuecomment-1694383442