### PR TITLE
Remove `index.js` suffix of `use-sync-external-store/shim` to support React Native

### DIFF
--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -5,7 +5,7 @@ import ReactExports, {
   useDebugValue,
   useMemo
 } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 
 import {
   defaultConfig,

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -33,7 +33,7 @@ import type {
   SWRInfiniteCacheValue,
   SWRInfiniteCompareFn
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { getFirstPageKey } from './serialize'
 
 // const INFINITE_PREFIX = '$inf$'


### PR DESCRIPTION
This PR fixed #2402

According to [this document](https://reactnative.dev/docs/platform-specific-code#native-specific-extensions-ie-sharing-code-with-nodejs-and-web), React Native-specific code can use the '.native.js' suffix, while standard React web code uses the '.js' suffix.  By removing `index.js` suffix of `use-sync-external-store/shim`, bundling tools like Metro/Webpack could choose the right file for each platform.

I haven't tested this PR on React Native because I'm not familiar with React Native development and I have no idea how to downgrade React to 17. However, I can reproduce the issue and test the PR on [GojiJS](https://github.com/airbnb/goji-js),  which is a React-like framework based on `react-reconciler` and shares many technical specifications with React Native, including the '.native.js' suffix. It would be appreciated if anyone could help verify the changes.