### PR TITLE
feat: introduce SWRNoCacheOnMount (for suspense)

### DIFF
--- a/_internal/src/index.ts
+++ b/_internal/src/index.ts
@@ -1,8 +1,9 @@
 import SWRConfig from './utils/config-context'
 import * as revalidateEvents from './events'
 import { INFINITE_PREFIX } from './constants'
+import SWRNoCacheOnMount from './utils/nocache-context'
 
-export { SWRConfig, revalidateEvents, INFINITE_PREFIX }
+export { SWRConfig, revalidateEvents, INFINITE_PREFIX, SWRNoCacheOnMount }
 
 export { initCache } from './utils/cache'
 export { defaultConfig, cache, mutate, compare } from './utils/config'

--- a/_internal/src/index.ts
+++ b/_internal/src/index.ts
@@ -1,9 +1,17 @@
 import SWRConfig from './utils/config-context'
 import * as revalidateEvents from './events'
 import { INFINITE_PREFIX } from './constants'
-import SWRNoCacheOnMount from './utils/nocache-context'
+import SWRNoCacheOnMount, {
+  SWRNoCacheOnMountContext
+} from './utils/nocache-context'
 
-export { SWRConfig, revalidateEvents, INFINITE_PREFIX, SWRNoCacheOnMount }
+export {
+  SWRConfig,
+  revalidateEvents,
+  INFINITE_PREFIX,
+  SWRNoCacheOnMount,
+  SWRNoCacheOnMountContext
+}
 
 export { initCache } from './utils/cache'
 export { defaultConfig, cache, mutate, compare } from './utils/config'

--- a/_internal/src/types.ts
+++ b/_internal/src/types.ts
@@ -127,6 +127,11 @@ export interface PublicConfiguration<
    */
   keepPreviousData?: boolean
   /**
+   * Force fetching on mount. Only works with `suspense: true` and need to wrap react `<Suspense>` with `<SWRNoCacheOnMount>`.
+   * @defaultValue false
+   */
+  noCacheOnMount?: boolean
+  /**
    * @experimental  enable React Suspense mode
    * @defaultValue false
    * @link https://swr.vercel.app/docs/suspense

--- a/_internal/src/utils/nocache-context.ts
+++ b/_internal/src/utils/nocache-context.ts
@@ -1,0 +1,42 @@
+import { createContext, createElement, useRef } from 'react'
+
+type Context = {
+  shouldForceFetch: (params: {
+    noCacheOnMount: boolean | undefined
+    key: Key
+  }) => boolean
+}
+
+const defaultContext: Context = {
+  shouldForceFetch: () => false
+}
+
+export const SWRNoCacheOnMountContext = createContext<Context>(defaultContext)
+
+type Key = string
+
+const SWRNoCacheOnMount = () => {
+  const isFetchedMap = useRef<Record<Key, boolean>>({})
+
+  const shouldForceFetch = ({
+    noCacheOnMount,
+    key
+  }: {
+    noCacheOnMount: boolean | undefined
+    key: Key
+  }) => {
+    const result = Boolean(noCacheOnMount && !isFetchedMap.current[key])
+    if (result) {
+      isFetchedMap.current[key] = true
+    }
+    return result
+  }
+
+  return createElement(SWRNoCacheOnMountContext.Provider, {
+    value: {
+      shouldForceFetch
+    }
+  })
+}
+
+export default SWRNoCacheOnMount

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -9,6 +9,7 @@ export { unstable_serialize } from './serialize'
 export { useSWRConfig } from 'swr/_internal'
 export { mutate } from 'swr/_internal'
 export { preload } from 'swr/_internal'
+export { SWRNoCacheOnMount } from 'swr/_internal'
 
 // Types
 export type {

--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -27,7 +27,8 @@ import {
   getTimestamp,
   internalMutate,
   revalidateEvents,
-  mergeObjects
+  mergeObjects,
+  SWRNoCacheOnMountContext
 } from 'swr/_internal'
 import type {
   State,
@@ -43,7 +44,6 @@ import type {
   GlobalState,
   ReactUsePromise
 } from 'swr/_internal'
-import { SWRNoCacheOnMountContext } from '_internal/src/utils/nocache-context'
 
 const use =
   ReactExports.use ||


### PR DESCRIPTION
related issues:
- [Imposing no cache for a SWR call](https://github.com/vercel/swr/discussions/456)
- https://github.com/vercel/swr/discussions/2318

### Problem (with `suspense: true`)

Sometimes you want to start component with the latest data especially when you work with **an edit-form, which typically gives a chance to pre-fill default data only on mount.** 

So you want to force fetching on mount and not return `data` so that `<Suspense>` triggered while fetching. 

You can do something like putting a random SWR key with `useRef` **but with `suspense: true` this workaround doesn't work** because `ref` gets reset when promise is resolved which causes infinite re-render. 

### suggestion

```
<SWRNoCacheOnMount>
  <Suspense fallback={<Loader />}>
    <MyEditProfileForm>
  </Suspense>
</SWRNoCacheOnMount>
```
```
const MyEditProfileForm = () => {
  const { data } = useSWR(KEY, {
    noCacheOnMount: true,  // <-- new config
    suspense: true
  }
  // render form
}
```

EDIT: 
Meanwhile, I've written workaround: https://github.com/vercel/swr/discussions/2318#discussioncomment-7686542