### PR TITLE
Revert "Remove `index.js` suffix of `use-sync-external-store/shim` to support React Native"

### DIFF
--- a/core/src/use-swr.ts
+++ b/core/src/use-swr.ts
@@ -5,7 +5,7 @@ import ReactExports, {
   useDebugValue,
   useMemo
 } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 
 import {
   defaultConfig,

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -33,7 +33,7 @@ import type {
   SWRInfiniteCacheValue,
   SWRInfiniteCompareFn
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
 import { getFirstPageKey } from './serialize'
 
 // const INFINITE_PREFIX = '$inf$'


### PR DESCRIPTION
Removing `/index.js` broke module resolving for `use-sync-external-store/shim`

Reverts vercel/swr#2767

x-ref: #2801