### PR TITLE
Improve IDE import IntelliSense

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -3,6 +3,7 @@ import 'client-only'
 // useSWR
 import useSWR from './use-swr'
 export default useSWR
+export { useSWR }
 // Core APIs
 export { SWRConfig } from './use-swr'
 export { unstable_serialize } from './serialize'

--- a/immutable/src/index.ts
+++ b/immutable/src/index.ts
@@ -13,3 +13,4 @@ export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
 const useSWRImmutable = withMiddleware(useSWR, immutable)
 
 export default useSWRImmutable
+export { useSWRImmutable }

--- a/infinite/src/index.ts
+++ b/infinite/src/index.ts
@@ -344,8 +344,9 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 const useSWRInfinite = withMiddleware(useSWR, infinite) as SWRInfiniteHook
 
 export default useSWRInfinite
+export { useSWRInfinite }
 
-export {
+export type {
   SWRInfiniteConfiguration,
   SWRInfiniteResponse,
   SWRInfiniteHook,

--- a/mutation/src/index.ts
+++ b/mutation/src/index.ts
@@ -158,8 +158,9 @@ const useSWRMutation = withMiddleware(
 ) as unknown as SWRMutationHook
 
 export default useSWRMutation
+export { useSWRMutation }
 
-export {
+export type {
   SWRMutationConfiguration,
   SWRMutationResponse,
   SWRMutationHook,

--- a/subscription/src/index.ts
+++ b/subscription/src/index.ts
@@ -123,6 +123,7 @@ const useSWRSubscription = withMiddleware(
 ) as SWRSubscriptionHook
 
 export default useSWRSubscription
+export { useSWRSubscription }
 
 export type {
   SWRSubscription,


### PR DESCRIPTION
This PR exports the hooks as named exports as well as default exports to make VS code import easier. 

the current behavior is when writing e.g. `const {data} = useSWR` VS code doesn't suggest the default hook, but others like `useSWRConfig` (named)

I see that this issue has already been discussed and accepted https://github.com/vercel/swr/pull/56 but after some updates, the issue occurred again. 