### PR TITLE
fix: allow onErrorRetry on inactive tab without focus/reconnect revalidation

### DIFF
--- a/src/core/use-swr.ts
+++ b/src/core/use-swr.ts
@@ -495,7 +495,7 @@ export const useSWRHandler = <Data = any, Error = any>(
               (isFunction(shouldRetryOnError) &&
                 shouldRetryOnError(err as Error))
             ) {
-              if (isActive()) {
+              if (!getConfig().revalidateOnFocus || !getConfig().revalidateOnReconnect || isActive()) {
                 // If it's inactive, stop. It will auto-revalidate when
                 // refocusing or reconnecting.
                 // When retrying, deduplication is always enabled.


### PR DESCRIPTION
fix: #2543