### PR TITLE
fix: all act warnings

### DIFF
--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -564,7 +564,9 @@ describe('useSWR - local mutation', () => {
 
     // Mount
     await screen.findByText('error')
-    mutate(v => v, { revalidate: false })
+    act(() => {
+      mutate(v => v, { revalidate: false })
+    })
     await screen.findByText('data: undefined')
   })
 
@@ -1053,7 +1055,7 @@ describe('useSWR - local mutation', () => {
         optimisticData: 'bar'
       })
     )
-    await sleep(30)
+    await act(() => sleep(30))
     expect(renderedData).toEqual([undefined, 'foo', 'bar', 'baz', 'foo'])
   })
 
@@ -1079,7 +1081,7 @@ describe('useSWR - local mutation', () => {
         optimisticData: data => 'function_' + data
       })
     )
-    await sleep(30)
+    await act(() => sleep(30))
     expect(renderedData).toEqual([
       undefined,
       'foo',


### PR DESCRIPTION
Currently, we see act warnings when running unit tests. This PR fixes all warnings.

<details>
<summary>act warnings log</summary>

```
pnpm test -- --verbose 

> jest "--verbose"

  console.error
    Warning: An update to Page inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at Page (/test/use-swr-local-mutation.test.tsx:556:17)
        at value (/_internal/src/utils/config-context.ts:33:11)
        at children (/test/utils.tsx:35:28)

      245 |           key,
      246 |           (current: State<Data, any>, prev: State<Data, any>) => {
    > 247 |             if (!isEqual(prev, current)) callback()
          |                                          ^
      248 |           }
      249 |         ),
      250 |       // eslint-disable-next-line react-hooks/exhaustive-deps

      at printWarning (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at error (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at warnIfUpdatesNotWrappedWithActDEV (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:27589:9)
      at scheduleUpdateOnFiber (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:25508:5)
      at forceStoreRerender (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:16977:5)
      at handleStoreChange (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:16953:7)
      at callback (core/src/use-swr.ts:247:42)
      at Array.fn (_internal/src/utils/cache.ts:66:11)
      at _internal/src/utils/helper.ts:35:17
      at set (_internal/src/utils/mutate.ts:192:11)
      at mutateByKey (_internal/src/utils/mutate.ts:89:10)
      at core/src/use-swr.ts:554:28
      at Object.mutate (test/use-swr-local-mutation.test.tsx:567:5)

  console.error
    Warning: An update to Page inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at Page (/test/use-swr-local-mutation.test.tsx:1040:51)
        at value (/_internal/src/utils/config-context.ts:33:11)
        at children (/test/utils.tsx:35:28)

      245 |           key,
      246 |           (current: State<Data, any>, prev: State<Data, any>) => {
    > 247 |             if (!isEqual(prev, current)) callback()
          |                                          ^
      248 |           }
      249 |         ),
      250 |       // eslint-disable-next-line react-hooks/exhaustive-deps

      at printWarning (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at error (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at warnIfUpdatesNotWrappedWithActDEV (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:27589:9)
      at scheduleUpdateOnFiber (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:25508:5)
      at forceStoreRerender (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:16977:5)
      at handleStoreChange (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:16953:7)
      at callback (core/src/use-swr.ts:247:42)
      at Array.fn (_internal/src/utils/cache.ts:66:11)
      at _internal/src/utils/helper.ts:35:17
      at setCache (core/src/use-swr.ts:367:9)
      at finishRequestAndUpdateState (core/src/use-swr.ts:530:7)

  console.error
    Warning: An update to Page inside a test was not wrapped in act(...).
    
    When testing, code that causes React state updates should be wrapped into act(...):
    
    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */
    
    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act
        at Page (/test/use-swr-local-mutation.test.tsx:1066:51)
        at value (/_internal/src/utils/config-context.ts:33:11)
        at children (/test/utils.tsx:35:28)

      245 |           key,
      246 |           (current: State<Data, any>, prev: State<Data, any>) => {
    > 247 |             if (!isEqual(prev, current)) callback()
          |                                          ^
      248 |           }
      249 |         ),
      250 |       // eslint-disable-next-line react-hooks/exhaustive-deps

      at printWarning (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:86:30)
      at error (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:60:7)
      at warnIfUpdatesNotWrappedWithActDEV (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:27589:9)
      at scheduleUpdateOnFiber (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:25508:5)
      at forceStoreRerender (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:16977:5)
      at handleStoreChange (node_modules/.pnpm/react-dom@18.2.0_react@18.2.0/node_modules/react-dom/cjs/react-dom.development.js:16953:7)
      at callback (core/src/use-swr.ts:247:42)
      at Array.fn (_internal/src/utils/cache.ts:66:11)
      at _internal/src/utils/helper.ts:35:17
      at setCache (core/src/use-swr.ts:367:9)
      at finishRequestAndUpdateState (core/src/use-swr.ts:530:7)

Test Suites: 31 passed, 31 total
Tests:       4 skipped, 336 passed, 340 total
Snapshots:   5 passed, 5 total
Time:        8.15 s
Ran all test suites.

```
</details>