### PR TITLE
feat: pass a function to the revalidate option in mutate

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -315,7 +315,7 @@ export type MutatorCallback<Data = any> = (
  * @typeParam MutationData - The type of the data returned by the mutator
  */
 export type MutatorOptions<Data = any, MutationData = Data> = {
-  revalidate?: boolean
+  revalidate?: boolean | ((data: Data, key: Arguments) => boolean)
   populateCache?:
     | boolean
     | ((result: MutationData, currentData: Data | undefined) => Data)

--- a/src/_internal/utils/mutate.ts
+++ b/src/_internal/utils/mutate.ts
@@ -60,7 +60,6 @@ export async function internalMutate<Data>(
   const rollbackOnErrorOption = options.rollbackOnError
   let optimisticData = options.optimisticData
 
-  const revalidate = options.revalidate !== false
   const rollbackOnError = (error: unknown): boolean => {
     return typeof rollbackOnErrorOption === 'function'
       ? rollbackOnErrorOption(error)
@@ -99,6 +98,9 @@ export async function internalMutate<Data>(
 
     const startRevalidate = () => {
       const revalidators = EVENT_REVALIDATORS[key]
+      const revalidate = isFunction(options.revalidate)
+        ? options.revalidate(get().data, _k)
+        : options.revalidate !== false
       if (revalidate) {
         // Invalidate the key by deleting the concurrent request markers so new
         // requests will not be deduped.

--- a/src/mutation/types.ts
+++ b/src/mutation/types.ts
@@ -1,4 +1,4 @@
-import type { SWRResponse, Key } from '../core'
+import type { SWRResponse, Key, Arguments } from '../core'
 
 type FetcherResponse<Data> = Data | Promise<Data>
 
@@ -25,7 +25,7 @@ export type SWRMutationConfiguration<
   ExtraArg = any,
   SWRData = any
 > = {
-  revalidate?: boolean
+  revalidate?: boolean | ((data: Data, key: Arguments) => boolean)
   populateCache?:
     | boolean
     | ((result: Data, currentData: SWRData | undefined) => SWRData)


### PR DESCRIPTION
This PR proposes to allow us to pass a function to the `revalidate` option.

## Motivation

My main motivation is to provide a way to revalidate specific pages with `useSWRInfinite`. See more details in the section below.
refs. https://github.com/vercel/swr/issues/1590#issuecomment-1000447513, https://github.com/vercel/swr/discussions/616#discussioncomment-81971

This also allows us a conditional revalidation based on the result of the mutation.

I can implement this feature as a separate option, but I think having `revalidate` and `revalidatePage` (?) is confusing. This proposal only adds a way to pass a function to the `revalidate` option, but this gives us more capabilities.

## Interface

```diff
- revalidate?: boolean
+ revalidate?: boolean | (data: Data, key: Arguments) => boolean
```

`data` is the latest data, which means this is the mutated data if `mutate` has the `data` argument.
`key` is the `key` value bounded to the mutation. If `fetcher` accepts a function as its `key` argument, this is the return value of the function.


## with `useSWRInfinite`

If you use `mutate` returned from `useSWRInfinite`, the `revalidate` function is called with each page and `useSWRInfinite` only revalidates the pages that return `true`, which means you can revalidate specific pages. This drastically improves performance in the case we know what pages we should revalidate.

```jsx
const { mutate, size } = useSWRInfinite((index) => [`/api/?page=${index + 1}`, index + 1], fetcher);

mutate({
  // only revalidate the last page
  revalidate: (data, [_, page]) => page === size
});
```