### PR TITLE
test: run pnpm test on CI

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -23,4 +23,5 @@ jobs:
           pnpm clean
           pnpm build
           pnpm run-all-checks
+          pnpm test
           pnpm test:build

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -24,6 +24,7 @@ jobs:
           pnpm build
           pnpm run-all-checks
           pnpm attw
+          pnpm test
           pnpm test:build
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Now we run `pnpm test:build`, which uses build files for testing, and this PR also adds `pnpm test` on CI to catch mistakes for settings.