### PR TITLE
chore: update pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,8 +113,6 @@ importers:
 
   _internal: {}
 
-  core: {}
-
   immutable: {}
 
   infinite: {}


### PR DESCRIPTION
This PR is to follow up #2865
This applies the diff caused by `pnpm install`