### PR TITLE
fix: SWRConfiguration type

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "build": "bunchee",
     "build:e2e": "pnpm next build e2e/site",
     "attw": "attw --pack",
-    "types:check": "pnpm -r run types:check",
+    "types:check": "tsc --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build",
     "publish-beta": "pnpm publish --tag beta",
     "format": "prettier --write ./**/*.{ts,tsx}",

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -403,7 +403,10 @@ export type SWRConfiguration<
   Data = any,
   Error = any,
   Fn extends BareFetcher<any> = BareFetcher<any>
-> = Partial<PublicConfiguration<Data, Error, Fn>>
+> = Partial<PublicConfiguration<Data, Error, Fn>> &
+  Partial<ProviderConfiguration> & {
+    provider?: (cache: Readonly<Cache>) => Cache
+  }
 
 export type IsLoadingResponse<
   Data = any,

--- a/src/_internal/utils/config-context.ts
+++ b/src/_internal/utils/config-context.ts
@@ -11,23 +11,15 @@ import { initCache } from './cache'
 import { mergeConfigs } from './merge-config'
 import { UNDEFINED, mergeObjects, isFunction } from './shared'
 import { useIsomorphicLayoutEffect } from './env'
-import type {
-  SWRConfiguration,
-  FullConfiguration,
-  ProviderConfiguration,
-  Cache
-} from '../types'
-
-type Config = SWRConfiguration &
-  Partial<ProviderConfiguration> & {
-    provider?: (cache: Readonly<Cache>) => Cache
-  }
+import type { SWRConfiguration, FullConfiguration } from '../types'
 
 export const SWRConfigContext = createContext<Partial<FullConfiguration>>({})
 
 const SWRConfig: FC<
   PropsWithChildren<{
-    value?: Config | ((parentConfig?: Config) => Config)
+    value?:
+      | SWRConfiguration
+      | ((parentConfig?: SWRConfiguration) => SWRConfiguration)
   }>
 > = props => {
   const { value } = props

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -157,3 +157,36 @@ export function testFallbackDataConfig() {
   expectType<Equal<typeof data, { value: string }>>(true)
   expectType<Equal<typeof isLoading, boolean>>(true)
 }
+
+export function testProviderConfig() {
+  const GlobalSetting = ({ children }: { children: React.ReactNode }) => {
+    return (
+      <SWRConfig
+        value={{
+          provider: () => new Map(),
+          isOnline() {
+            /* Customize the network state detector */
+            return true
+          },
+          isVisible() {
+            /* Customize the visibility state detector */
+            return true
+          },
+          initFocus(_callback) {
+            /* Register the listener with your state provider */
+          },
+          initReconnect(_callback) {
+            /* Register the listener with your state provider */
+          }
+        }}
+      >
+        {children}
+      </SWRConfig>
+    )
+  }
+  return (
+    <GlobalSetting>
+      <div />
+    </GlobalSetting>
+  )
+}


### PR DESCRIPTION
## PR description 📖 
Fixes the type mismatch in `SWRConfiguration` with the non-exported internal `Config` type with the FC `SWRConfig` export. This was causing the following issues:

- Custom configs could not be typed with `:SWRConfiguration`
- The internal `Config` type was used but not exposted
- Aligns the documentation with `TypeScript` section and `react-native` section, as combining these two approaches produce a type error right now.

## Issue reference 🔗 

- Closes #2881 