### PR TITLE
Mark package as side-effect free

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "./dist/core/index.js",
   "module": "./dist/core/index.esm.js",
   "types": "./dist/core/index.d.ts",
+  "sideEffects": false,
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
Hi folks – thanks for making a delightful library!

This is a super small change that adds a `sideEffects` field in package.json set to `false`. 

I'm not an expert on this field, but it looks like tools such as Bundlephobia will look for it before performing things like exports analysis: https://bundlephobia.com/package/swr@2.2.5.

It looks like Vercel's own Conformance project has some documentation on this field, for reference: https://vercel.com/docs/workflow-collaboration/conformance/rules/PACKAGE_JSON_SIDE_EFFECTS_REQUIRED

Thanks again! 