### PR TITLE
chore: simplify test coverage strategy

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -24,6 +24,5 @@ jobs:
         run: |
           pnpm clean
           pnpm build
-          pnpm run-all-checks
           pnpm test
           pnpm test:build

--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Lint and test
         env:
-          REACT_CANARY: 1
+          TEST_REACT_LEGACY: 1
         run: |
           pnpm clean
           pnpm build

--- a/.github/workflows/test-legacy-react.yml
+++ b/.github/workflows/test-legacy-react.yml
@@ -18,15 +18,11 @@ jobs:
       - name: Install
         uses: ./.github/workflows/install
 
-      - name: Install Canary
-        run: corepack pnpm upgrade react@17 react-dom@17
-
-      - name: Lint and test
+      - name: Test
         env:
           TEST_REACT_LEGACY: 1
         run: |
           pnpm clean
           pnpm build
-          pnpm run-all-checks
           pnpm test
           pnpm test:build

--- a/.github/workflows/test-legacy-react.yml
+++ b/.github/workflows/test-legacy-react.yml
@@ -1,0 +1,32 @@
+name: Test React 17
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install
+        uses: ./.github/workflows/install
+
+      - name: Install Canary
+        run: corepack pnpm upgrade react@17 react-dom@17
+
+      - name: Lint and test
+        env:
+          REACT_LEGACY: 1
+        run: |
+          pnpm clean
+          pnpm build
+          pnpm run-all-checks
+          pnpm test
+          pnpm test:build

--- a/.github/workflows/test-legacy-react.yml
+++ b/.github/workflows/test-legacy-react.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Lint and test
         env:
-          REACT_LEGACY: 1
+          TEST_REACT_LEGACY: 1
         run: |
           pnpm clean
           pnpm build

--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,12 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': ['@swc/jest']
   },
-  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/test/'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/', 
+    '/dist/', 
+    '/test/',
+    '<rootDir>/src/_internal/utils/env.ts',
+  ],
   coverageReporters: ['text', 'html'],
   reporters: [['github-actions', { silent: false }], 'summary']
 }

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "csb:build": "pnpm build",
     "clean": "rimraf ./dist && rimraf playwright-report test-result",
     "watch": "pnpm -r run watch",
-    "build": "__SWR_TEST_REACT_LEGACY='' __SWR_TEST_SERVER='' bunchee --env=__SWR_TEST_REACT_LEGACY,__SWR_TEST_SERVER",
+    "build": "bunchee",
     "build:e2e": "pnpm next build e2e/site",
     "attw": "attw --pack",
     "types:check": "tsc --noEmit",
@@ -115,8 +115,7 @@
     "coverage": "jest --coverage",
     "test-typing": "tsc --noEmit -p test/type/tsconfig.json && tsc --noEmit -p test/tsconfig.json",
     "test": "jest",
-    "test-canary": "REACT_CANARY=1 jest",
-    "test:build": "__SWR_TEST_BUILD=1 jest --config jest.config.build.js",
+    "test:build": "jest --config jest.config.build.js",
     "test:e2e": "playwright test",
     "run-all-checks": "pnpm types:check && pnpm lint && pnpm test-typing"
   },

--- a/src/_internal/utils/env.ts
+++ b/src/_internal/utils/env.ts
@@ -1,11 +1,9 @@
 import React, { useEffect, useLayoutEffect } from 'react'
 import { hasRequestAnimationFrame, isWindowDefined } from './helper'
 
-export const IS_REACT_LEGACY =
-  process.env.__SWR_TEST_REACT_LEGACY || !React.useId
+export const IS_REACT_LEGACY = !React.useId
 
-export const IS_SERVER =
-  process.env.__SWR_TEST_SERVER || !isWindowDefined || 'Deno' in window
+export const IS_SERVER = !isWindowDefined || 'Deno' in window
 
 // Polyfill requestAnimationFrame
 export const rAF = (

--- a/test/use-swr-legacy-react.test.tsx
+++ b/test/use-swr-legacy-react.test.tsx
@@ -7,13 +7,7 @@ jest.mock('react', () => jest.requireActual('react'))
 
 async function withLegacyReact(runner: () => Promise<void>) {
   await jest.isolateModulesAsync(async () => {
-    process.env.__SWR_TEST_REACT_LEGACY = '1'
-
-    try {
-      await runner()
-    } finally {
-      process.env.__SWR_TEST_REACT_LEGACY = ''
-    }
+    await runner()
   })
 }
 

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -62,7 +62,12 @@ export const hydrateWithConfig = (
   const TestSWRConfig = ({ children }: { children: React.ReactNode }) => (
     <SWRConfig value={{ provider, ...config }}>{children}</SWRConfig>
   )
-  return render(element, { container, wrapper: TestSWRConfig, hydrate: true })
+  return render(element, {
+    container,
+    wrapper: TestSWRConfig,
+    hydrate: true,
+    legacyRoot: process.env.TEST_REACT_LEGACY === '1'
+  })
 }
 
 export const mockVisibilityHidden = () => {


### PR DESCRIPTION
Follow up of #2903 

- Use separate test job to coverage legacy react build (react 17)
- Ignore env.ts since it's not necessary to be covered