### PR TITLE
Drop client-only

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,1 +1,0 @@
-declare module 'client-only'

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "trailingComma": "none"
   },
   "dependencies": {
-    "client-only": "^0.0.1",
     "use-sync-external-store": "^1.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,16 +1,9 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
     dependencies:
-      client-only:
-        specifier: ^0.0.1
-        version: 0.0.1
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.2.0(react@18.2.0)
@@ -2339,6 +2332,7 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: true
 
   /cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
@@ -5686,3 +5680,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,3 @@
-import 'client-only'
-
 // useSWR
 import useSWR from './use-swr'
 export default useSWR


### PR DESCRIPTION
Since we've already have `react-server` condition, `client-only` doesn't help much as we're always picking up `react-server` condition in RSC bundling layer, default condition is always bundled into client layers