### PR TITLE
fix: check if config.fallback is undefined

### DIFF
--- a/src/core/use-swr.ts
+++ b/src/core/use-swr.ts
@@ -144,7 +144,11 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   // Resolve the fallback data from either the inline option, or the global provider.
   // If it's a promise, we simply let React suspend and resolve it for us.
-  let fallback = isUndefined(fallbackData) ? config.fallback[key] : fallbackData
+  let fallback = isUndefined(fallbackData)
+    ? isUndefined(config.fallback)
+      ? undefined
+      : config.fallback[key]
+    : fallbackData
   if (fallback && isPromiseLike(fallback)) {
     fallback = use(fallback)
   }

--- a/src/core/use-swr.ts
+++ b/src/core/use-swr.ts
@@ -146,7 +146,7 @@ export const useSWRHandler = <Data = any, Error = any>(
   // If it's a promise, we simply let React suspend and resolve it for us.
   let fallback = isUndefined(fallbackData)
     ? isUndefined(config.fallback)
-      ? undefined
+      ? UNDEFINED
       : config.fallback[key]
     : fallbackData
   if (fallback && isPromiseLike(fallback)) {

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -184,4 +184,23 @@ describe('useSWR - configs', () => {
     expect(config.fallback).toEqual({ a: 2, c: 2 })
     expect(config.use).toEqual([middleware2])
   })
+
+  it('should not occur error when fallback is undefined', async () => {
+    const key = createKey()
+    const fetcher = () => 'data'
+
+    function Page() {
+      const { data } = useSWR(key)
+      return <div>data: {data}</div>
+    }
+
+    renderWithConfig(<Page />, {
+      fetcher,
+      fallback: undefined
+    })
+    // hydration
+    screen.getByText('data:')
+    // mount
+    await screen.findByText('data: data')
+  })
 })


### PR DESCRIPTION
# PR description

Check if config.fallback is undefined.
If config.fallback is undefined, don't access to config.fallback[key].

# Issue reference
- Closes #2912 