### PR TITLE
fix: Replace the deprecated 'window' with 'globalThis' for Deno

### DIFF
--- a/src/_internal/utils/env.ts
+++ b/src/_internal/utils/env.ts
@@ -3,7 +3,7 @@ import { hasRequestAnimationFrame, isWindowDefined } from './helper'
 
 export const IS_REACT_LEGACY = !React.useId
 
-export const IS_SERVER = !isWindowDefined || 'Deno' in window
+export const IS_SERVER = !isWindowDefined || 'Deno' in globalThis
 
 // Polyfill requestAnimationFrame
 export const rAF = (


### PR DESCRIPTION
The `window` object became deprecated in Deno (https://github.com/denoland/deno/pull/22057). Instead, they recommend us to use `globalThis` or `self`. For the change, I also referred to here (https://deno.land/x/udibo_react_app@0.3.3/env.ts?source=#L7)