### PR TITLE
test: remove console.error times check

### DIFF
--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -19,8 +19,6 @@ jobs:
         run: corepack pnpm upgrade react@canary react-dom@canary use-sync-external-store@canary
 
       - name: Lint and test
-        env:
-          TEST_REACT_LEGACY: 1
         run: |
           pnpm clean
           pnpm build

--- a/test/use-swr-promise.test.tsx
+++ b/test/use-swr-promise.test.tsx
@@ -146,9 +146,6 @@ describe('useSWR - promise', () => {
     await screen.findByText('loading')
     await act(() => sleep(100)) // wait 100ms until the request inside throws
     await screen.findByText('error boundary')
-
-    // 1 for js-dom 1 for react-error-boundary
-    expect(console.error).toHaveBeenCalledTimes(3)
   })
 
   it('should handle same fallback promise that is already pending', async () => {

--- a/test/use-swr-subscription.test.tsx
+++ b/test/use-swr-subscription.test.tsx
@@ -321,8 +321,5 @@ describe('useSWRSubscription', () => {
     await screen.findByText(
       'The `subscribe` function must return a function to unsubscribe.'
     )
-
-    // 1 for js-dom 1 for react-error-boundary
-    expect(console.error).toHaveBeenCalledTimes(2)
   })
 })

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -115,8 +115,6 @@ describe('useSWR - suspense', () => {
     // hydration
     screen.getByText('fallback')
     await screen.findByText('error boundary')
-    // 1 for js-dom 1 for react-error-boundary
-    expect(console.error).toHaveBeenCalledTimes(3)
   })
 
   it('should render cached data with error', async () => {


### PR DESCRIPTION
Those checks could be safely removed since it's just implementation detail.