### PR TITLE
fix: fix the type of the argument of `KeyedMutator` for `populateCache`

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -395,9 +395,12 @@ export interface ScopedMutator {
  * @typeParam MutationData - The type of the data returned by the mutator
  */
 export type KeyedMutator<Data> = <MutationData = Data>(
-  data?: Data | Promise<Data | undefined> | MutatorCallback<Data>,
+  data?:
+    | MutationData
+    | Promise<MutationData | undefined>
+    | MutatorCallback<MutationData>,
   opts?: boolean | MutatorOptions<Data, MutationData>
-) => Promise<Data | MutationData | undefined>
+) => Promise<MutationData | undefined>
 
 export type SWRConfiguration<
   Data = any,

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -383,11 +383,11 @@ export interface ScopedMutator {
    * @typeParam Data - The type of the data related to the key
    * @typeParam MutationData - The type of the data returned by the mutator
    */
-  <Data = any, T = Data>(
+  <Data = any, MutationData = Data>(
     key: Arguments,
-    data?: T | Promise<T> | MutatorCallback<T>,
-    opts?: boolean | MutatorOptions<Data, T>
-  ): Promise<T | undefined>
+    data?: MutationData | Promise<MutationData> | MutatorCallback<MutationData>,
+    opts?: boolean | MutatorOptions<Data, MutationData>
+  ): Promise<MutationData | undefined>
 }
 
 /**

--- a/src/infinite/index.ts
+++ b/src/infinite/index.ts
@@ -239,13 +239,12 @@ export const infinite = (<Data, Error>(useSWRNext: SWRHook) =>
 
     const mutate = useCallback(
       // eslint-disable-next-line func-names
-      function <T = Data[]>(
+      function <MutationData = Data[]>(
         data?:
-          | undefined
-          | Data[]
-          | Promise<Data[] | undefined>
-          | MutatorCallback<Data[]>,
-        opts?: undefined | boolean | SWRInfiniteMutatorOptions<Data[], T>
+          | MutationData
+          | Promise<MutationData | undefined>
+          | MutatorCallback<MutationData>,
+        opts?: boolean | SWRInfiniteMutatorOptions<Data[], MutationData>
       ) {
         // When passing as a boolean, it's explicitly used to disable/enable
         // revalidation.


### PR DESCRIPTION
# The Problem

I will show you the problem with this [code sandbox](https://codesandbox.io/p/sandbox/swr-mutate-with-populatecache-type-error-9h9ynk).
This container uses [code sandbox introduced in swr docs](https://swr.vercel.app/examples/optimistic-ui) with some changes.

I just added TypeScript and changed like below.

```diff
export async function addTodo(todo) {
  await delay();
  todos = [...todos, todo];
-  return todos;
+ return todo;
}

```

In this codesandbox, there is an serious type error:
```
Argument of type 'Promise<ToDo>' is not assignable to parameter of type 'ToDo[] | Promise<ToDo[] | undefined> | MutatorCallback<ToDo[]> | undefined'.
  Type 'Promise<ToDo>' is not assignable to type 'Promise<ToDo[] | undefined>'.
    Type 'ToDo' is missing the following properties from type 'ToDo[]': length, pop, push, concat, and 25 more.
```
in the source code:
```ts
await mutate(addTodo(newTodo.text), {
  optimisticData: [...(data ?? []), newTodo],
  populateCache: (updatedTodo, todos) => [
    ...(todos ?? []),
    updatedTodo,
  ],
  revalidate: false,
});
```

I referred to [this article](https://github.com/vercel/swr/issues/1817).

In this article, the example written in JavaScript uses bound `mutate` to make `addToDo` return just one updated item, rather than multiple updated items. 
However, when used in TypeScript like the codesandbox I suggested, this results in a type error.
For instance, when useSWR fetches an API that returns a `ToDo[]` type, the first argument of `mutate` is expected to be of type `ToDo[]`.
This works fine in JavaScript, but the issue arises only when it's converted to TypeScript.

# What this PR does
This PR fixes a type error problem related to `populateCache` and bound `mutate`.

Now, the first argument of bound `mutate` only accepts a type of data fetched by `useSWR`.

But in order to make use of `populateCache`, the first argument of `mutate` should accept any type of API fetching result. 

So I changed the type of the first argument from `Data` (which is the type of data `useSWR` fetches) into `MutationData` (which is the type of the data returned by the mutator)

In addition, I changed types in `infinite` since it had error when I changed the type of `KeyedMutator` .
