### PR TITLE
Export ScopedMutator type

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -25,5 +25,6 @@ export type {
   MutatorOptions,
   Middleware,
   Arguments,
-  State
+  State,
+  ScopedMutator
 } from '../_internal'


### PR DESCRIPTION
It would be helpful to have access to the ScopedMutator, so that API helper functions can easily specify a `useSWRConfig` `mutate` function as a parameter. For example:

```tsx
import { ScopedMutator, useSWRConfig } from 'swr';

async function myMultiStepApiTask(mutate: ScopedMutator) {
  await postToKey1();
  await mutate(key1);
  await postToKey2();
  await mutate(key2);
}

function MyMultiStepButton() {
  const { mutate } = useSWRConfig();

  return <button type="button" onClick={() => myMultiStepApiTask(mutate)}>Go</button>;
}
```