### PR TITLE
feat: modify cache type to allow generic usage

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -377,7 +377,7 @@ export type MutatorConfig = {
 }
 
 export type Broadcaster<Data = any, Error = any> = (
-  cache: Cache<Data>,
+  cache: Cache,
   key: string,
   data: Data,
   error?: Error,
@@ -509,10 +509,10 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
   opts?: any
 ) => RevalidateCallbackReturnType[K]
 
-export interface Cache<Data = any> {
+export interface Cache {
   keys(): IterableIterator<string>
-  get(key: string): State<Data> | undefined
-  set(key: string, value: State<Data>): void
+  get<T = any>(key: string): State<T> | undefined
+  set<T = any>(key: string, value: State<T>): void
   delete(key: string): void
 }
 


### PR DESCRIPTION

Sure! Here’s a formal pull request description in English that you can use:

Title: Enable Generic Type Definitions for cache.get in SWRConfig

Description:

Current Issue:
The current implementation of cache.get does not support explicit type definitions, which limits type safety and can lead to potential issues with type inference. Here's how it's currently implemented:

```
const { cache } = useSWRConfig();
const data = cache.get('key');  // data: any
```

Proposed Changes:
This pull request modifies cache.get to accept generic type parameters, enhancing type safety by allowing developers to specify the expected return type. The modified implementation is as follows:

```
const { cache } = useSWRConfig();
const data = cache.get<KeyType>('key'); // data:KeyType
```

This update ensures better type checking and integration with TypeScript projects, aligning with modern development practices in type-safe applications.

