### PR TITLE
feat: modify cache type to allow generic usage

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -511,8 +511,8 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 
 export interface Cache<Data = any> {
   keys(): IterableIterator<string>
-  get(key: string): State<Data> | undefined
-  set(key: string, value: State<Data>): void
+  get<T = Data>(key: string): State<T> | undefined
+  set<T = Data>(key: string, value: State<T>): void
   delete(key: string): void
 }
 


### PR DESCRIPTION
Current Issue:
The current implementation of cache.get does not support explicit type definitions, which limits type safety and can lead to potential issues with type inference. Here's how it's currently implemented:

```
const { cache } = useSWRConfig();
const data = cache.get('key'); 
```
Proposed Changes:
This pull request modifies cache.get to accept generic type parameters, enhancing type safety by allowing developers to specify the expected return type. The modified implementation is as follows:

```
const { cache } = useSWRConfig();
const data = cache.get<KeyType>('key');
```
This update ensures better type checking and integration with TypeScript projects, aligning with modern development practices in type-safe applications.