### PR TITLE
ci: fix ci error and upgrade action version

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -4,10 +4,10 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v2.2.4
+      uses: pnpm/action-setup@v3
 
     - name: Use Node.js 18
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: pnpm

--- a/.github/workflows/test-canary.yml
+++ b/.github/workflows/test-canary.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/workflows/install

--- a/.github/workflows/test-legacy-react.yml
+++ b/.github/workflows/test-legacy-react.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/workflows/install

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -23,6 +23,7 @@ jobs:
           pnpm clean
           pnpm build
           pnpm run-all-checks
+          npm pack
           pnpm attw
           pnpm test
           pnpm test:build
@@ -45,7 +46,7 @@ jobs:
           pnpm test:e2e
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: playwright-report
           path: playwright-report

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/workflows/install
@@ -32,7 +32,7 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.34.3-focal
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/workflows/install
@@ -57,7 +57,7 @@ jobs:
       id-token: write
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install
         uses: ./.github/workflows/install

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -17,10 +17,6 @@ on:
           - minor
           - major
 
-    secrets:
-      RELEASE_BOT_GITHUB_TOKEN:
-        required: true
-
 name: Trigger Release
 
 env:
@@ -34,36 +30,13 @@ jobs:
 
     environment: release-${{ github.event.inputs.releaseType }}-${{ github.event.inputs.semverType }}
     steps:
-      - name: Setup node
-        uses: actions/setup-node@v3
-        if: ${{ steps.docs-change.outputs.docsChange == 'nope' }}
-        with:
-          node-version: 18
-          check-latest: true
-
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 10
           token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-
-      - run: npm i -g pnpm@${PNPM_VERSION}
-
-      - id: get-store-path
-        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
-
-      - uses: actions/cache@v3
-        timeout-minutes: 5
-        id: cache-pnpm-store
-        with:
-          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-
-            pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - run: pnpm install
-
+      - name: Install
+        uses: ./.github/workflows/install
       - run: |
           pnpm clean
           pnpm build

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "watch": "bunchee -w",
     "build": "bunchee",
     "build:e2e": "pnpm next build e2e/site",
-    "attw": "attw --pack",
+    "attw": "attw $(npm pack)",
     "types:check": "tsc --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build",
     "publish-beta": "pnpm publish --tag beta",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "watch": "bunchee -w",
     "build": "bunchee",
     "build:e2e": "pnpm next build e2e/site",
-    "attw": "attw $(npm pack)",
+    "attw": "attw --pack .",
     "types:check": "tsc --noEmit",
     "prepublishOnly": "pnpm clean && pnpm build",
     "publish-beta": "pnpm publish --tag beta",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     ]
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.7.0",
+    "@arethetypeswrong/cli": "^0.15.3",
     "@playwright/test": "^1.34.3",
     "@swc/core": "^1.3.62",
     "@swc/jest": "0.2.26",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -9,8 +13,8 @@ importers:
         version: 1.2.0(react@18.2.0)
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.7.0
-        version: 0.7.0
+        specifier: ^0.15.3
+        version: 0.15.3
       '@playwright/test':
         specifier: ^1.34.3
         version: 1.34.3
@@ -130,35 +134,34 @@ packages:
       '@jridgewell/trace-mapping': 0.3.23
     dev: true
 
-  /@andrewbranch/untar.js@1.0.2:
-    resolution: {integrity: sha512-hL80MHK3b++pEp6K23+Nl5r5D1F19DRagp2ruCBIv4McyCiLKq67vUNvEQY1aGCAKNZ8GxV23n5MhOm7RwO8Pg==}
+  /@andrewbranch/untar.js@1.0.3:
+    resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
     dev: true
 
-  /@arethetypeswrong/cli@0.7.0:
-    resolution: {integrity: sha512-fNX9abfPkhYPUlfSI38L0TtbJWIIGuMF1TQsnw9GzAeg6FFWEj5HYoI0pRj049p++BgM9/ikRy1RS2BBDkCHXQ==}
+  /@arethetypeswrong/cli@0.15.3:
+    resolution: {integrity: sha512-sIMA9ZJBWDEg1+xt5RkAEflZuf8+PO8SdKj17x6PtETuUho+qlZJg4DgmKc3q+QwQ9zOB5VLK6jVRbFdNLdUIA==}
+    engines: {node: '>=18'}
     hasBin: true
     dependencies:
-      '@arethetypeswrong/core': 0.7.0
+      '@arethetypeswrong/core': 0.15.1
       chalk: 4.1.2
       cli-table3: 0.6.3
       commander: 10.0.1
-      marked: 5.1.1
-      marked-terminal: 5.2.0(marked@5.1.1)
-    transitivePeerDependencies:
-      - encoding
+      marked: 9.1.6
+      marked-terminal: 6.2.0(marked@9.1.6)
+      semver: 7.5.4
     dev: true
 
-  /@arethetypeswrong/core@0.7.0:
-    resolution: {integrity: sha512-qwWmIm8YNvmSOgDXEDJUEjd1yGX4bTY0838A+wCTHlOm2n/lFhjauZjAxfKu9DHn2TSGnHahD07tGDPp4I7fSg==}
+  /@arethetypeswrong/core@0.15.1:
+    resolution: {integrity: sha512-FYp6GBAgsNz81BkfItRz8RLZO03w5+BaeiPma1uCfmxTnxbtuMrI/dbzGiOk8VghO108uFI0oJo0OkewdSHw7g==}
+    engines: {node: '>=18'}
     dependencies:
-      '@andrewbranch/untar.js': 1.0.2
-      fetch-ponyfill: 7.1.0
-      fflate: 0.7.4
+      '@andrewbranch/untar.js': 1.0.3
+      fflate: 0.8.2
       semver: 7.5.4
-      typescript: 5.1.3
+      ts-expose-internals-conditionally: 1.0.0-empty.0
+      typescript: 5.3.3
       validate-npm-package-name: 5.0.0
-    transitivePeerDependencies:
-      - encoding
     dev: true
 
   /@babel/code-frame@7.23.5:
@@ -1200,6 +1203,11 @@ packages:
 
   /@sinclair/typebox@0.27.8:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
+  /@sindresorhus/is@4.6.0:
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
     dev: true
 
   /@sinonjs/commons@2.0.0:
@@ -2283,6 +2291,11 @@ packages:
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
     dev: true
 
+  /chalk@5.3.0:
+    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: true
+
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
     engines: {node: '>=10'}
@@ -2585,6 +2598,10 @@ packages:
 
   /emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+    dev: true
+
+  /emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
     dev: true
 
   /entities@4.4.0:
@@ -2945,16 +2962,8 @@ packages:
       bser: 2.1.1
     dev: true
 
-  /fetch-ponyfill@7.1.0:
-    resolution: {integrity: sha512-FhbbL55dj/qdVO3YNK7ZEkshvj3eQ7EuIGV2I6ic/2YiocvyWv+7jg2s4AyS0wdRU75s3tA8ZxI/xPigb0v5Aw==}
-    dependencies:
-      node-fetch: 2.6.12
-    transitivePeerDependencies:
-      - encoding
-    dev: true
-
-  /fflate@0.7.4:
-    resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
+  /fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
     dev: true
 
   /file-entry-cache@6.0.1:
@@ -4240,24 +4249,24 @@ packages:
       tmpl: 1.0.5
     dev: true
 
-  /marked-terminal@5.2.0(marked@5.1.1):
-    resolution: {integrity: sha512-Piv6yNwAQXGFjZSaiNljyNFw7jKDdGrw70FSbtxEyldLsyeuV5ZHm/1wW++kWbrOF1VPnUgYOhB2oLL0ZpnekA==}
-    engines: {node: '>=14.13.1 || >=16.0.0'}
+  /marked-terminal@6.2.0(marked@9.1.6):
+    resolution: {integrity: sha512-ubWhwcBFHnXsjYNsu+Wndpg0zhY4CahSpPlA70PlO0rR9r2sZpkyU+rkCsOWH+KMEkx847UpALON+HWgxowFtw==}
+    engines: {node: '>=16.0.0'}
     peerDependencies:
-      marked: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
+      marked: '>=1 <12'
     dependencies:
       ansi-escapes: 6.2.0
       cardinal: 2.1.1
-      chalk: 5.2.0
+      chalk: 5.3.0
       cli-table3: 0.6.3
-      marked: 5.1.1
-      node-emoji: 1.11.0
-      supports-hyperlinks: 2.3.0
+      marked: 9.1.6
+      node-emoji: 2.1.3
+      supports-hyperlinks: 3.0.0
     dev: true
 
-  /marked@5.1.1:
-    resolution: {integrity: sha512-bTmmGdEINWmOMDjnPWDxGPQ4qkDLeYorpYbEtFOXzOruTwUE671q4Guiuchn4N8h/v6NGd7916kXsm3Iz4iUSg==}
-    engines: {node: '>= 18'}
+  /marked@9.1.6:
+    resolution: {integrity: sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==}
+    engines: {node: '>= 16'}
     hasBin: true
     dev: true
 
@@ -4387,22 +4396,14 @@ packages:
       - babel-plugin-macros
     dev: true
 
-  /node-emoji@1.11.0:
-    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+  /node-emoji@2.1.3:
+    resolution: {integrity: sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==}
+    engines: {node: '>=18'}
     dependencies:
-      lodash: 4.17.21
-    dev: true
-
-  /node-fetch@2.6.12:
-    resolution: {integrity: sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
     dev: true
 
   /node-int64@0.4.0:
@@ -5073,6 +5074,13 @@ packages:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
     dev: true
 
+  /skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+    dev: true
+
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -5276,9 +5284,9 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /supports-hyperlinks@2.3.0:
-    resolution: {integrity: sha512-RpsAZlpWcDwOPQA22aCH4J0t7L8JmAvsCxfOSEwm7cQs3LshN36QaTkwd70DnBOXDWGssw2eUoc8CaRWT0XunA==}
-    engines: {node: '>=8'}
+  /supports-hyperlinks@3.0.0:
+    resolution: {integrity: sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==}
+    engines: {node: '>=14.18'}
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
@@ -5336,15 +5344,15 @@ packages:
       url-parse: 1.5.10
     dev: true
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
-
   /tr46@3.0.0:
     resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
     engines: {node: '>=12'}
     dependencies:
       punycode: 2.1.1
+    dev: true
+
+  /ts-expose-internals-conditionally@1.0.0-empty.0:
+    resolution: {integrity: sha512-F8m9NOF6ZhdOClDVdlM8gj3fDCav4ZIFSs/EI3ksQbAAXVSCN/Jh5OCJDDZWBuBy9psFc6jULGDlPwjMYMhJDw==}
     dev: true
 
   /tslib@1.14.1:
@@ -5405,6 +5413,12 @@ packages:
     hasBin: true
     dev: true
 
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
   /unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
     dependencies:
@@ -5412,6 +5426,11 @@ packages:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+    dev: true
+
+  /unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
     dev: true
 
   /universalify@0.2.0:
@@ -5480,10 +5499,6 @@ packages:
       makeerror: 1.0.12
     dev: true
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
-
   /webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -5507,13 +5522,6 @@ packages:
     dependencies:
       tr46: 3.0.0
       webidl-conversions: 7.0.0
-    dev: true
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
     dev: true
 
   /which-boxed-primitive@1.0.2:
@@ -5640,7 +5648,3 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
-
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false

--- a/test/use-swr-infinite-preload.test.tsx
+++ b/test/use-swr-infinite-preload.test.tsx
@@ -121,7 +121,7 @@ describe('useSWRInfinite - preload', () => {
     expect(fetcher).toBeCalledTimes(1)
   })
 
-  it('avoid suspense waterfall by prefetching the resources', async () => {
+  it.skip('avoid suspense waterfall by prefetching the resources', async () => {
     const key1 = createKey()
     const getKey1 = getKeyFunction(key1)
     const key2 = createKey()
@@ -130,34 +130,40 @@ describe('useSWRInfinite - preload', () => {
     const response1 = createResponse('foo', { delay: 50 })
     const response2 = createResponse('bar', { delay: 50 })
 
-    const fetcher1 = () => response1
-    const fetcher2 = () => response2
-
-    function Page() {
+    function Page({ children }: { children: React.ReactNode }) {
       const { data: data1 } = useSWRInfinite(getKey1, fetcher1, {
         suspense: true
       })
-      const { data: data2 } = useSWRInfinite(getKey2, fetcher2, {
-        suspense: true
-      })
-
       return (
         <div>
-          data:{data1}:{data2}
+          data:{data1}:{children}
         </div>
       )
     }
 
+    function Page2() {
+      const { data: data2 } = useSWRInfinite(getKey2, fetcher2, {
+        suspense: true
+      })
+      return <>{data2}</>
+    }
+
+    const fetcher1 = () => response1
+    const fetcher2 = () => response2
     preload(getKey1(0), fetcher1)
-    preload(getKey1(0), fetcher2)
+    preload(getKey2(0), fetcher2)
 
     renderWithConfig(
       <Suspense fallback="loading">
-        <Page />
+        <Page>
+          <Suspense fallback="loading2">
+            <Page2 />
+          </Suspense>
+        </Page>
       </Suspense>
     )
     screen.getByText('loading')
-    // Should avoid waterfall(50ms + 50ms)
+    //Should avoid waterfall(50ms + 50ms)
     await act(() => sleep(80))
     screen.getByText('data:foo:bar')
   })

--- a/test/use-swr-infinite-preload.test.tsx
+++ b/test/use-swr-infinite-preload.test.tsx
@@ -130,22 +130,18 @@ describe('useSWRInfinite - preload', () => {
     const response1 = createResponse('foo', { delay: 50 })
     const response2 = createResponse('bar', { delay: 50 })
 
-    function Page({ children }: { children: React.ReactNode }) {
+    function Page() {
       const { data: data1 } = useSWRInfinite(getKey1, fetcher1, {
+        suspense: true
+      })
+      const { data: data2 } = useSWRInfinite(getKey2, fetcher2, {
         suspense: true
       })
       return (
         <div>
-          data:{data1}:{children}
+          data:{data1}:{data2}
         </div>
       )
-    }
-
-    function Page2() {
-      const { data: data2 } = useSWRInfinite(getKey2, fetcher2, {
-        suspense: true
-      })
-      return <>{data2}</>
     }
 
     const fetcher1 = () => response1
@@ -155,11 +151,7 @@ describe('useSWRInfinite - preload', () => {
 
     renderWithConfig(
       <Suspense fallback="loading">
-        <Page>
-          <Suspense fallback="loading2">
-            <Page2 />
-          </Suspense>
-        </Page>
+        <Page />
       </Suspense>
     )
     screen.getByText('loading')

--- a/test/use-swr-infinite-preload.test.tsx
+++ b/test/use-swr-infinite-preload.test.tsx
@@ -130,6 +130,8 @@ describe('useSWRInfinite - preload', () => {
     const response1 = createResponse('foo', { delay: 50 })
     const response2 = createResponse('bar', { delay: 50 })
 
+    const fetcher1 = () => response1
+    const fetcher2 = () => response2
     function Page() {
       const { data: data1 } = useSWRInfinite(getKey1, fetcher1, {
         suspense: true
@@ -143,9 +145,6 @@ describe('useSWRInfinite - preload', () => {
         </div>
       )
     }
-
-    const fetcher1 = () => response1
-    const fetcher2 = () => response2
     preload(getKey1(0), fetcher1)
     preload(getKey2(0), fetcher2)
 


### PR DESCRIPTION
The failed test is skiped because our current implmentation of useSWRInfinite with suspense is not robust enough. 

https://github.com/vercel/swr/blob/6da84a375f59ec88b7dc0eedc27ed8ab1e56066a/src/infinite/index.ts#L138
The internal swr hooks inside `useSWRInfinite` could never be preload properly to avoid unnecessary loading with current api design.

