### PR TITLE
Add SWRInfiniteMutatorOptions type to export

### DIFF
--- a/src/infinite/index.ts
+++ b/src/infinite/index.ts
@@ -358,5 +358,6 @@ export {
   SWRInfiniteHook,
   SWRInfiniteKeyLoader,
   SWRInfiniteFetcher,
-  SWRInfiniteCompareFn
+  SWRInfiniteCompareFn,
+  SWRInfiniteMutatorOptions
 }


### PR DESCRIPTION
When using `"moduleResolution": "Bundler"` in tsconfig.json for a TypeScript project, and implicitly referencing `SWRInfiniteMutatorOptions` you get this error:

```bash
Exported variable '<redacted>' has or is using name 'SWRInfiniteMutatorOptions' from external module "/path/node_modules/swr/dist/infinite/index" but cannot be named.ts(4023)
```

These errors can be resolved by explicitly exporting these implicitly references types from `swr`. 