### PR TITLE
test: update the revalidate function test for useSWRInfinite

### DIFF
--- a/test/use-swr-infinite.test.tsx
+++ b/test/use-swr-infinite.test.tsx
@@ -1861,7 +1861,7 @@ describe('useSWRInfinite', () => {
       return (
         <div
           onClick={() => {
-            boundMutate(undefined, {
+            boundMutate(data, {
               // only revalidate 'apple' & 'pineapple' (page=2)
               revalidate: (d, [_, i]: [string, number]) => {
                 return d === 'apple' || i === 2


### PR DESCRIPTION
This test is misleading so I've updated it. In this case, we should pass the current data as the first argument.