### PR TITLE
fix: Improve comparison performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "trailingComma": "none"
   },
   "dependencies": {
+    "dequal": "^2.0.3",
     "use-sync-external-store": "^1.2.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,13 +1,12 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: false
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
     dependencies:
+      dequal:
+        specifier: ^2.0.3
+        version: 2.0.3
       use-sync-external-store:
         specifier: ^1.2.0
         version: 1.2.0(react@18.2.0)
@@ -2535,6 +2534,11 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     dev: true
+
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -5648,3 +5652,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+settings:
+  autoInstallPeers: false
+  excludeLinksFromLockfile: false

--- a/src/_internal/utils/config.ts
+++ b/src/_internal/utils/config.ts
@@ -6,11 +6,13 @@ import type {
   ScopedMutator,
   Cache
 } from '../types'
-import { stableHash } from './hash'
+
 import { initCache } from './cache'
 import { preset } from './web-preset'
 import { slowConnection } from './env'
 import { isUndefined, noop, mergeObjects } from './shared'
+
+import { dequal } from 'dequal/lite'
 
 // error retry
 const onErrorRetry = (
@@ -37,8 +39,7 @@ const onErrorRetry = (
   setTimeout(revalidate, timeout, opts)
 }
 
-const compare = (currentData: any, newData: any) =>
-  stableHash(currentData) == stableHash(newData)
+const compare = dequal
 
 // Default cache provider
 const [cache, mutate] = initCache(new Map()) as [Cache<any>, ScopedMutator]


### PR DESCRIPTION
Currently, we are using the `stableHash` utility (that we use for hashing resource keys) to handle the deep comparison task which is a great code reuse. However, in the worse case it might be a performance bottleneck when the payload is a large object but different from the previous data, as comparison cannot be done during the traversal.

This PR re-introduces `dequal/lite` as a dependency and uses that for comparison instead.