### PR TITLE
fix: Only suspend when using the `fallback`

### DIFF
--- a/src/core/use-swr.ts
+++ b/src/core/use-swr.ts
@@ -149,9 +149,6 @@ export const useSWRHandler = <Data = any, Error = any>(
       ? UNDEFINED
       : config.fallback[key]
     : fallbackData
-  if (fallback && isPromiseLike(fallback)) {
-    fallback = use(fallback)
-  }
 
   const isEqual = (prev: State<Data, any>, current: State<Data, any>) => {
     for (const _ in stateDependencies) {
@@ -269,7 +266,11 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const cachedData = cached.data
 
-  const data = isUndefined(cachedData) ? fallback : cachedData
+  const data = isUndefined(cachedData)
+    ? (fallback && isPromiseLike(fallback))
+      ? use(fallback)
+      : fallback
+    : cachedData
   const error = cached.error
 
   // Use a ref to store previously returned data. Use the initial data as its initial value.


### PR DESCRIPTION
Currently we always suspend (via `use()`) when there's a promise shape fallback provided. This is not necessary when we're not using fallback at all, like when the cache already exists.