### PR TITLE
fix: missing `throwOnError` in SWRMutationHook options

### DIFF
--- a/src/mutation/types.ts
+++ b/src/mutation/types.ts
@@ -224,7 +224,7 @@ export interface SWRMutationHook {
       SWRMutationKey,
       ExtraArg,
       SWRData
-    > & { throwOnError: boolean }
+    > & { throwOnError?: boolean }
   ): SWRMutationResponse<Data, Error, SWRMutationKey, ExtraArg>
   <
     Data = any,

--- a/src/mutation/types.ts
+++ b/src/mutation/types.ts
@@ -224,7 +224,7 @@ export interface SWRMutationHook {
       SWRMutationKey,
       ExtraArg,
       SWRData
-    > & { throwOnError: false }
+    > & { throwOnError: boolean }
   ): SWRMutationResponse<Data, Error, SWRMutationKey, ExtraArg>
   <
     Data = any,

--- a/src/mutation/types.ts
+++ b/src/mutation/types.ts
@@ -224,7 +224,7 @@ export interface SWRMutationHook {
       SWRMutationKey,
       ExtraArg,
       SWRData
-    >
+    > & { throwOnError: false }
   ): SWRMutationResponse<Data, Error, SWRMutationKey, ExtraArg>
   <
     Data = any,


### PR DESCRIPTION
Missing `throwOnError` in `SWRMutationHook`'s options.  Update code to let users pass option `throwOnError`.

Example:

```
useSWRMutation('/api/mutate-server-action', () => action(), { throwOnError: true })
```