### PR TITLE
fix: sever env detection for deno

### DIFF
--- a/src/_internal/utils/env.ts
+++ b/src/_internal/utils/env.ts
@@ -1,9 +1,9 @@
 import React, { useEffect, useLayoutEffect } from 'react'
-import { hasRequestAnimationFrame, isWindowDefined } from './helper'
+import { hasRequestAnimationFrame, isLegacyDeno, isWindowDefined } from './helper'
 
 export const IS_REACT_LEGACY = !React.useId
 
-export const IS_SERVER = !isWindowDefined || 'Deno' in globalThis
+export const IS_SERVER = !isWindowDefined || isLegacyDeno
 
 // Polyfill requestAnimationFrame
 export const rAF = (

--- a/src/_internal/utils/helper.ts
+++ b/src/_internal/utils/helper.ts
@@ -10,6 +10,8 @@ const STR_UNDEFINED = 'undefined'
 // NOTE: Use the function to guarantee it's re-evaluated between jsdom and node runtime for tests.
 export const isWindowDefined = typeof window != STR_UNDEFINED
 export const isDocumentDefined = typeof document != STR_UNDEFINED
+export const isLegacyDeno = isWindowDefined && 'Deno' in window
+
 export const hasRequestAnimationFrame = () =>
   isWindowDefined && typeof window['requestAnimationFrame'] != STR_UNDEFINED
 


### PR DESCRIPTION
In the new version of swr (2.3.0), `globalThis` is used to determine if the environment is Deno. (https://github.com/vercel/swr/pull/2915)

This will cause errors in lower version browser environments (android <=13) (ios <12) where globalThis does not exist.

Since swr is a widely used request library, we hope to ensure compatibility as much as possible.

In Deno 2, window has been removed, as discussed in this issue: https://github.com/denoland/deno/issues/13367

I have added a new method `isLegacyDeno` for this check. 🙏🏻