### PR TITLE
refactor: type improvement of `useSWRHandler`

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -729,7 +729,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     }
   }
 
-  return {
+  const swrResponse: SWRResponse<Data, Error> = {
     mutate: boundMutate,
     get data() {
       stateDependencies.data = true
@@ -747,7 +747,8 @@ export const useSWRHandler = <Data = any, Error = any>(
       stateDependencies.isLoading = true
       return isLoading
     }
-  } as SWRResponse<Data, Error>
+  }
+  return swrResponse
 }
 
 export const SWRConfig = OBJECT.defineProperty(ConfigProvider, 'defaultValue', {


### PR DESCRIPTION
Instead of using type assertion
```
return { ... } as SWRResponse<Data, Error>;
```

Creating a new object with explicit type annotation provides better type safety
```
const swrResponse: SWRResponse<Data, Error> = { ... };
return swrResponse;
```