### PR TITLE
doc: Sync `PublicConfiguration.onDiscarded` tsdoc with SWR official website

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -189,7 +189,7 @@ export interface PublicConfiguration<
     revalidateOpts: Required<RevalidatorOptions>
   ) => void
   /**
-   * callback function when a request is ignored
+   * callback function when a request is ignored due to race conditions
    */
   onDiscarded: (key: string) => void
   /**


### PR DESCRIPTION
## Problem
The TSDoc for `PublicConfiguration.onDiscarded` is inconsistent with the description on the [SWR official website](https://swr.vercel.app/docs/api).

## Changes
Updated TSDoc to match the [SWR official website](https://swr.vercel.app/docs/api):
- Original: `callback function when a request is ignored`
- Updated: `callback function when a request is ignored due to race conditions`

## Related Issues
https://github.com/vercel/swr/issues/2979