### PR TITLE
ci: update pnpm setup and lock pnpm vesion

### DIFF
--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -7,6 +7,7 @@ runs:
       uses: pnpm/action-setup@v4
 
     - name: Lock Corepack version
+      shell: bash
       run: pnpm i -g corepack@0.31.0
 
     - name: Use Node.js 18

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -5,7 +5,6 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-        version: 8.4.0
 
     - name: Use Node.js 18
       uses: actions/setup-node@v4

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -5,13 +5,11 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
-        with:
-          version: 8.4.0
 
     - name: Use Node.js 18
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
         cache: pnpm
         registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -5,6 +5,8 @@ runs:
   steps:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
+        with:
+          version: 8.4.0
 
     - name: Use Node.js 18
       uses: actions/setup-node@v4

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -6,6 +6,9 @@ runs:
     - name: Setup pnpm
       uses: pnpm/action-setup@v4
 
+    - name: Lock Corepack version
+      run: pnpm i -g corepack@0.31.0
+
     - name: Use Node.js 18
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/install/action.yml
+++ b/.github/workflows/install/action.yml
@@ -4,7 +4,8 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v4
+        version: 8.4.0
 
     - name: Use Node.js 18
       uses: actions/setup-node@v4


### PR DESCRIPTION
seeing failure ci job x-ref: https://github.com/vercel/swr/actions/runs/13147053165/job/36687350969?pr=4084

trying to lock pnpm version

Related corepack issue: https://github.com/nodejs/corepack/issues/612