### PR TITLE
(fix) keepPreviousData: return fallback instead of undefined value

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -278,7 +278,9 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const returnedData = keepPreviousData
     ? isUndefined(cachedData)
-      ? laggyDataRef.current ?? data
+      ? isUndefined(laggyDataRef.current)
+        ? data
+        : laggyDataRef.current
       : cachedData
     : data
 

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -278,6 +278,7 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const returnedData = keepPreviousData
     ? isUndefined(cachedData)
+      // checking undefined to avoid null being fallback as well
       ? isUndefined(laggyDataRef.current)
         ? data
         : laggyDataRef.current


### PR DESCRIPTION
Fix for https://github.com/vercel/swr/pull/4084. Only `undefined` values should be avoided. `null` is ok.