### PR TITLE
fix: Performance improvement by reducing calls to toString()

### DIFF
--- a/src/_internal/utils/hash.ts
+++ b/src/_internal/utils/hash.ts
@@ -6,8 +6,10 @@ import { OBJECT, isUndefined } from './shared'
 // complexity is almost O(1).
 const table = new WeakMap<object, number | string>()
 
-const isObjectType = (value: any, type: string) =>
-  OBJECT.prototype.toString.call(value) === `[object ${type}]`
+const getTypeName = (value: any) => OBJECT.prototype.toString.call(value)
+
+const isObjectTypeName = (typeName: string, type: string) =>
+  typeName === `[object ${type}]`
 
 // counter of the key
 let counter = 0
@@ -22,9 +24,10 @@ let counter = 0
 // parsable.
 export const stableHash = (arg: any): string => {
   const type = typeof arg
-  const isDate = isObjectType(arg, 'Date')
-  const isRegex = isObjectType(arg, 'RegExp')
-  const isPlainObject = isObjectType(arg, 'Object')
+  const typeName = getTypeName(arg)
+  const isDate = isObjectTypeName(typeName, 'Date')
+  const isRegex = isObjectTypeName(typeName, 'RegExp')
+  const isPlainObject = isObjectTypeName(typeName, 'Object')
   let result: any
   let index: any
 


### PR DESCRIPTION
See issue https://github.com/vercel/swr/issues/4090

This code extracts out the getting of a type name rather than repeating that 3x.

This increases performance of the hot path through the code.