### PR TITLE
fix: check "if (!error)" skip error if value is cast to false

### DIFF
--- a/test/use-swr-remote-mutation.test.tsx
+++ b/test/use-swr-remote-mutation.test.tsx
@@ -1112,4 +1112,32 @@ describe('useSWR - remote mutation', () => {
 
     expect(error.message).toBe('Can’t trigger the mutation: missing key.')
   })
+
+  it('should call `onError` and `onRejected` but do not call `onSuccess` if value an error is cast to false', async () => {
+    const key = createKey()
+    const onSuccess = jest.fn()
+    const onError = jest.fn()
+    const onRejected = jest.fn()
+
+    const fetcher = () => {
+      return new Promise((_, reject) => reject(''));
+    };
+
+    function Page() {
+      const { trigger } = useSWRMutation(key, fetcher, { onError, onSuccess })
+
+      return <button onClick={() => trigger().catch(onRejected)}>trigger</button>
+    }
+
+    render(<Page />)
+
+    await screen.findByText('trigger')
+    fireEvent.click(screen.getByText('trigger'))
+
+    await nextTick()
+
+    expect(onSuccess).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalled()
+    expect(onRejected).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
Hello!
"if (!error)" make cast value to boolean type and if value is cast to false then the error is skipped.

Sandbox: https://codesandbox.io/p/sandbox/6s9dw7

Example:

````javascript
import useSWRMutation from "swr/mutation";

const fetcher = () => {
  return new Promise((_, reject) => reject("")); // or null/undefined/false/0
};

const Component = () => {
  const { trigger } = useSWRMutation("/example", fetcher);

  const handleClick = () => {
    trigger()
      .then(() => {
        console.log("skip error");
      })
      .catch(() => {
        console.log("error");
      });
  };

  return <button onClick={handleClick}>Execute</button>;
};
```

