### PR TITLE
Skip revalidation for RSC fallback data by default

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -222,6 +222,11 @@ export interface PublicConfiguration<
    */
   revalidateIfStale: boolean
   /**
+   * automatically revalidate when data comes from RSC fallback
+   * @defaultValue false
+   */
+  revalidateOnRSCFallback?: boolean
+  /**
    * retry when fetcher has an error
    * @defaultValue true
    */

--- a/src/_internal/utils/config.ts
+++ b/src/_internal/utils/config.ts
@@ -60,6 +60,7 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     revalidateOnReconnect: true,
     revalidateIfStale: true,
     shouldRetryOnError: true,
+    revalidateOnRSCFallback: false,
 
     // timeouts
     errorRetryInterval: slowConnection ? 10000 : 5000,

--- a/src/_internal/utils/config.ts
+++ b/src/_internal/utils/config.ts
@@ -60,7 +60,6 @@ export const defaultConfig: FullConfiguration = mergeObjects(
     revalidateOnReconnect: true,
     revalidateIfStale: true,
     shouldRetryOnError: true,
-    revalidateOnRSCFallback: false,
 
     // timeouts
     errorRetryInterval: slowConnection ? 10000 : 5000,

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -368,8 +368,15 @@ export const useSWRHandler = <Data = any, Error = any>(
     if (isInitialMount && !isUndefined(revalidateOnMount))
       return revalidateOnMount
 
-    // If RSC fallback data on initial render, use revalidateOnRSCFallback config
-    if (!isUndefined(fallback) && !isUndefined(data) && !IS_SERVER && isInitialMount) return getConfig().revalidateOnRSCFallback ?? false
+    // If revalidateOnRSCFallback is explicitly configured, use it for fallback data
+    if (
+      !isUndefined(fallback) &&
+      !isUndefined(data) &&
+      !IS_SERVER &&
+      isInitialMount &&
+      !isUndefined(getConfig().revalidateOnRSCFallback)
+    )
+      return getConfig().revalidateOnRSCFallback
     // Under suspense mode, it will always fetch on render if there is no
     // stale data so no need to revalidate immediately mount it again.
     // If data exists, only revalidate if `revalidateIfStale` is true.

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -219,6 +219,14 @@ export const useSWRHandler = <Data = any, Error = any>(
         if (isInitialMount && !isUndefined(revalidateOnMount))
           return revalidateOnMount
         const data = !isUndefined(fallback) ? fallback : snapshot.data
+        // If revalidateOnRSCFallback is explicitly configured, use it for fallback data
+        if (
+          !isUndefined(fallback) &&
+          !isUndefined(data) &&
+          isInitialMount &&
+          !isUndefined(getConfig().revalidateOnRSCFallback)
+        )
+          return getConfig().revalidateOnRSCFallback
         if (suspense) return isUndefined(data) || revalidateIfStale
         return isUndefined(data) || revalidateIfStale
       })()

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -367,6 +367,9 @@ export const useSWRHandler = <Data = any, Error = any>(
     // If `revalidateOnMount` is set, we take the value directly.
     if (isInitialMount && !isUndefined(revalidateOnMount))
       return revalidateOnMount
+
+    // If RSC fallback data on initial render, use revalidateOnRSCFallback config
+    if (!isUndefined(fallback) && !isUndefined(data) && !IS_SERVER && isInitialMount) return getConfig().revalidateOnRSCFallback ?? false
     // Under suspense mode, it will always fetch on render if there is no
     // stale data so no need to revalidate immediately mount it again.
     // If data exists, only revalidate if `revalidateIfStale` is true.

--- a/test/rsc-fallback.test.tsx
+++ b/test/rsc-fallback.test.tsx
@@ -1,0 +1,47 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import useSWR, { SWRConfig } from 'swr'
+import { sleep } from './utils'
+
+describe('RSC Fallback', () => {
+  it('should not revalidate on mount with RSC fallback data by default', async () => {
+    const fetchFn = jest.fn(() => 'updated data')
+    
+    function Page() {
+      const { data } = useSWR('key', fetchFn, {
+        fallbackData: 'RSC data'
+      })
+      return <div>Data: {data}</div>
+    }
+    
+    render(<Page />)
+    
+    expect(screen.getByText('Data: RSC data')).toBeInTheDocument()
+    expect(fetchFn).not.toHaveBeenCalled()
+    
+    await sleep(50)
+    
+    expect(fetchFn).not.toHaveBeenCalled()
+  })
+  
+  it('should revalidate on mount with RSC fallback data when revalidateOnRSCFallback is true', async () => {
+    const fetchFn = jest.fn(() => 'updated data')
+    
+    function Page() {
+      const { data } = useSWR('key', fetchFn, {
+        fallbackData: 'RSC data',
+        revalidateOnRSCFallback: true
+      })
+      return <div>Data: {data}</div>
+    }
+    
+    render(<Page />)
+    
+    expect(screen.getByText('Data: RSC data')).toBeInTheDocument()    
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    
+    await sleep(50)
+      
+    expect(screen.getByText('Data: updated data')).toBeInTheDocument()
+  })
+})

--- a/test/rsc-fallback.test.tsx
+++ b/test/rsc-fallback.test.tsx
@@ -9,16 +9,23 @@ describe('RSC Fallback', () => {
     const fetchFn = jest.fn(() => 'updated data')
 
     function Page() {
-      const { data } = useSWR(key, fetchFn, {
+      const { data, isValidating, isLoading } = useSWR(key, fetchFn, {
         fallbackData: 'RSC data',
         revalidateOnRSCFallback: false
       })
-      return <div>Data: {data}</div>
+      return (
+        <div>
+          Data: {data}, isValidating: {String(isValidating)}, isLoading:{' '}
+          {String(isLoading)}
+        </div>
+      )
     }
 
     renderWithConfig(<Page />)
 
-    expect(screen.getByText('Data: RSC data')).toBeInTheDocument()
+    screen.getByText(content => content.includes('Data: RSC data'))
+    screen.getByText(content => content.includes('isValidating: false'))
+    screen.getByText(content => content.includes('isLoading: false'))
     expect(fetchFn).not.toHaveBeenCalled()
 
     await act(() => sleep(50))
@@ -46,5 +53,47 @@ describe('RSC Fallback', () => {
 
     expect(fetchFn).toHaveBeenCalledTimes(1)
     expect(screen.getByText('Data: updated data')).toBeInTheDocument()
+  })
+
+  it('should not affect existing fallback behavior when revalidateOnRSCFallback is not set', async () => {
+    const key = createKey()
+    const fetchFn = jest.fn(() => 'updated data')
+
+    function Page() {
+      const { data } = useSWR(key, fetchFn, {
+        fallbackData: 'fallback data'
+      })
+      return <div>Data: {data}</div>
+    }
+
+    renderWithConfig(<Page />)
+
+    expect(screen.getByText('Data: fallback data')).toBeInTheDocument()
+
+    // Default behavior: revalidateIfStale is true, so it should revalidate
+    await act(() => sleep(50))
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('Data: updated data')).toBeInTheDocument()
+  })
+
+  it('should work with SWRConfig provider fallback when revalidateOnRSCFallback is false', async () => {
+    const key = createKey()
+    const fetchFn = jest.fn(() => 'updated data')
+
+    function Page() {
+      const { data } = useSWR(key, fetchFn, {
+        revalidateOnRSCFallback: false
+      })
+      return <div>Data: {data}</div>
+    }
+
+    renderWithConfig(<Page />, { fallback: { [key]: 'provider fallback' } })
+
+    expect(screen.getByText('Data: provider fallback')).toBeInTheDocument()
+
+    await act(() => sleep(50))
+
+    expect(fetchFn).not.toHaveBeenCalled()
   })
 })

--- a/test/rsc-fallback.test.tsx
+++ b/test/rsc-fallback.test.tsx
@@ -1,47 +1,50 @@
-import { act, fireEvent, render, screen } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import React from 'react'
-import useSWR, { SWRConfig } from 'swr'
-import { sleep } from './utils'
+import useSWR from 'swr'
+import { createKey, renderWithConfig, sleep } from './utils'
 
 describe('RSC Fallback', () => {
-  it('should not revalidate on mount with RSC fallback data by default', async () => {
+  it('should not revalidate on mount with RSC fallback data when revalidateOnRSCFallback is false', async () => {
+    const key = createKey()
     const fetchFn = jest.fn(() => 'updated data')
-    
+
     function Page() {
-      const { data } = useSWR('key', fetchFn, {
-        fallbackData: 'RSC data'
+      const { data } = useSWR(key, fetchFn, {
+        fallbackData: 'RSC data',
+        revalidateOnRSCFallback: false
       })
       return <div>Data: {data}</div>
     }
-    
-    render(<Page />)
-    
+
+    renderWithConfig(<Page />)
+
     expect(screen.getByText('Data: RSC data')).toBeInTheDocument()
     expect(fetchFn).not.toHaveBeenCalled()
-    
-    await sleep(50)
-    
+
+    await act(() => sleep(50))
+
     expect(fetchFn).not.toHaveBeenCalled()
   })
-  
+
   it('should revalidate on mount with RSC fallback data when revalidateOnRSCFallback is true', async () => {
+    const key = createKey()
     const fetchFn = jest.fn(() => 'updated data')
-    
+
     function Page() {
-      const { data } = useSWR('key', fetchFn, {
+      const { data } = useSWR(key, fetchFn, {
         fallbackData: 'RSC data',
         revalidateOnRSCFallback: true
       })
       return <div>Data: {data}</div>
     }
-    
-    render(<Page />)
-    
-    expect(screen.getByText('Data: RSC data')).toBeInTheDocument()    
+
+    renderWithConfig(<Page />)
+
+    expect(screen.getByText('Data: RSC data')).toBeInTheDocument()
+
+    await act(() => sleep(50))
+
     expect(fetchFn).toHaveBeenCalledTimes(1)
-    
-    await sleep(50)
-      
     expect(screen.getByText('Data: updated data')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Add configuration option `revalidateOnRSCFallback` (default: `false`) to eliminate redundant network request since data is already fresh when using SWR with RSC.

## Changes

- Added configuration option `revalidateOnRSCFallback` to `PublicConfiguration`
- Updated revalidation logic to detect fallback data from RSC context
- Set default value to `false`
- Added test

## Related Issues

Fixes #4065