### PR TITLE
fix: Optimize the revalidation logic for same key requests.

### DIFF
--- a/e2e/site/app/perf/page.tsx
+++ b/e2e/site/app/perf/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+import { useState } from 'react'
+import useSWR from 'swr'
+
+const elementCount = 10_000
+const useData = () => {
+  return useSWR('1', async (url: string) => {
+    return 1
+  })
+}
+
+const HookUser = () => {
+  const { data } = useData()
+  return <div>{data}</div>
+}
+/**
+ * This renders 10,000 divs and is used to compare against the render performance
+ * when using swr.
+ */
+const CheapComponent = () => {
+  const cheapComponents = Array.from({ length: elementCount }, (_, i) => (
+    <div key={i}>{i}</div>
+  ))
+  return (
+    <div>
+      <h2>Cheap Component</h2>
+      {cheapComponents}
+    </div>
+  )
+}
+
+/**
+ * This renders 10,000 divs, each of which uses the same swr hook.
+ */
+const ExpensiveComponent = () => {
+  const hookComponents = Array.from({ length: elementCount }, (_, i) => (
+    <HookUser key={i} />
+  ))
+  return (
+    <div>
+      <h2>Expensive Component</h2>
+      {hookComponents}
+    </div>
+  )
+}
+
+export default function PerformancePage() {
+  const [renderExpensive, setRenderExpensive] = useState(false)
+  return (
+    <div>
+      <h1>Performance Page</h1>
+      <label>
+        <input
+          type="checkbox"
+          checked={renderExpensive}
+          onChange={e => setRenderExpensive(e.target.checked)}
+        />
+        Render with swr
+      </label>
+      {!renderExpensive ? <CheapComponent /> : <ExpensiveComponent />}
+    </div>
+  )
+}

--- a/e2e/test/perf.test.ts
+++ b/e2e/test/perf.test.ts
@@ -1,0 +1,115 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('performance', () => {
+  test('should render expensive component within 1 second after checkbox click', async ({
+    page
+  }) => {
+    // Navigate to the perf page
+    await page.goto('./perf', { waitUntil: 'load' })
+
+    // Inject performance measurement into the page
+    await page.evaluate(() => {
+      const checkboxInput = document.querySelector(
+        'input[type="checkbox"]'
+      ) as HTMLInputElement
+      let expensiveComponentContainer: HTMLElement | null = null
+      const targetChildCount = 10_000
+      let startTime = 0
+
+      // Track when React starts and completes rendering
+      const observer = new MutationObserver(mutations => {
+        for (const mutation of mutations) {
+          const addedNodes = Array.from(mutation.addedNodes)
+          for (const node of addedNodes) {
+            if (node instanceof HTMLElement) {
+              const h2 = node.querySelector?.('h2')
+              if (h2?.textContent === 'Expensive Component') {
+                expensiveComponentContainer = node
+                console.log('Found Expensive Component container')
+              }
+            }
+          }
+
+          if (expensiveComponentContainer) {
+            const renderedComponents =
+              expensiveComponentContainer.querySelectorAll('div > div').length
+
+            if (renderedComponents % 1000 === 0 && renderedComponents > 0) {
+              console.log(`Rendered ${renderedComponents} components...`)
+            }
+
+            if (renderedComponents >= targetChildCount) {
+              console.log(`All ${renderedComponents} components rendered!`)
+
+              // Use requestAnimationFrame to ensure the browser has painted
+              requestAnimationFrame(() => {
+                requestAnimationFrame(() => {
+                  // Double RAF to ensure we're after the paint
+                  window.performance.mark('expensive-component-painted')
+                  const paintTime = performance.now() - startTime
+                  console.log(
+                    `Total time including paint: ${paintTime.toFixed(2)}ms`
+                  )
+                })
+              })
+
+              observer.disconnect()
+            }
+          }
+        }
+      })
+
+      observer.observe(document.body, { childList: true, subtree: true })
+
+      // Capture more precise timing
+      checkboxInput.addEventListener(
+        'click',
+        () => {
+          startTime = performance.now()
+          window.performance.mark('state-change-start')
+          console.log('Checkbox clicked, state change started')
+        },
+        { once: true }
+      )
+    })
+
+    // Find and click the checkbox
+    const checkbox = page.locator('input[type="checkbox"]')
+    await checkbox.click()
+
+    // Wait for the expensive component to be fully rendered
+    const expensiveComponentHeading = page.locator(
+      'h2:has-text("Expensive Component")'
+    )
+    await expect(expensiveComponentHeading).toBeVisible({ timeout: 60_000 })
+
+    // Wait for all components and paint to complete
+    await page.waitForFunction(
+      () => {
+        return (
+          window.performance.getEntriesByName('expensive-component-painted')
+            .length > 0
+        )
+      },
+      { timeout: 5000 }
+    )
+
+    // Get the render time from state change to paint
+    const renderTime = await page.evaluate(() => {
+      const startMark =
+        window.performance.getEntriesByName('state-change-start')[0]
+      const paintMark = window.performance.getEntriesByName(
+        'expensive-component-painted'
+      )[0]
+
+      if (!startMark || !paintMark) {
+        throw new Error('Performance marks not found')
+      }
+
+      return paintMark.startTime - startMark.startTime
+    })
+
+    // Assert that the rendering took less than 1 second (1000ms)
+    expect(renderTime).toBeLessThan(1000)
+  })
+})

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -278,8 +278,8 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const returnedData = keepPreviousData
     ? isUndefined(cachedData)
-      // checking undefined to avoid null being fallback as well
-      ? isUndefined(laggyDataRef.current)
+      ? // checking undefined to avoid null being fallback as well
+        isUndefined(laggyDataRef.current)
         ? data
         : laggyDataRef.current
       : cachedData
@@ -639,13 +639,17 @@ export const useSWRHandler = <Data = any, Error = any>(
 
     // Trigger a revalidation
     if (shouldDoInitialRevalidation) {
-      if (isUndefined(data) || IS_SERVER) {
-        // Revalidate immediately.
-        softRevalidate()
-      } else {
-        // Delay the revalidate if we have data to return so we won't block
-        // rendering.
-        rAF(softRevalidate)
+      // Performance optimization: if a request is already in progress for this key,
+      // skip the revalidation to avoid redundant work
+      if (!FETCH[key]) {
+        if (isUndefined(data) || IS_SERVER) {
+          // Revalidate immediately.
+          softRevalidate()
+        } else {
+          // Delay the revalidate if we have data to return so we won't block
+          // rendering.
+          rAF(softRevalidate)
+        }
       }
     }
 


### PR DESCRIPTION
# Problem

The SWR hook was experiencing performance issues due to inefficient request deduplication logic, causing unnecessary re-renders and redundant API calls when multiple components used the same key.

# Solution

Added a performance optimization at line 644 that checks if a request is already in progress before initiating a new one:

```ts
  // Performance optimization: if a request is already in progress for this key,
  // skip the revalidation to avoid redundant work
  if (!FETCH[key]) {
    if (isUndefined(data) || IS_SERVER) {
      // Revalidate immediately.
      softRevalidate()
    } else {
      // Delay the revalidate if we have data to return so we won't block
      // rendering.
      rAF(softRevalidate)
    }
  }
```

## Key Changes

- Deduplication Check: Before triggering initial revalidation, the code now checks if `FETCH[key]` exists, preventing duplicate revalidations for the same key

This optimization ensures that when multiple components request the same data simultaneously, only one actual fetch request is made, improving overall application performance.

## Testing

@gdborton created the `e2e/site/app/perf/page.tsx` as an example of the problem.  I then created a playwright test that asserts that the "Expensive Component" should be rendered under 1 second.

**Before the fix**

<details>
<summary>
$ pnpm test:e2e perf --repeat-each 10 -j 1
</summary>

```sh
$ pnpm test:e2e perf --repeat-each 10 -j 1 

> swr@2.3.3 test:e2e /Users/agadzik/Developer/swr
> playwright test "perf" "--repeat-each" "10" "-j" "1"


Running 10 tests using 1 worker
  1) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1241

  2) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1218.7000000029802

  3) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1233.3999999985099

  4) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1209.6000000014901

  5) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1254

  6) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1216.6000000014901

  7) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1256.699999999255

  8) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1230.7000000029802

  9) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1200.800000000745

  10) test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 

    Error: expect(received).toBeLessThan(expected)

    Expected: < 1000
    Received:   1227.199999999255

  10 failed
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click 
    test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
```
</details>

**After the fix**

<details>
<summary>
$ pnpm test:e2e perf --repeat-each 10 -j 1
</summary>

```sh
$ pnpm test:e2e perf --repeat-each 10 -j 1 

> swr@2.3.3 test:e2e /Users/agadzik/Developer/swr
> playwright test "perf" "--repeat-each" "10" "-j" "1"


Running 10 tests using 1 worker
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 215.90ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 217.80ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 215.00ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 216.30ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 213.90ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 220.80ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 215.80ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 216.40ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 215.30ms
test/perf.test.ts:4:7 › performance › should render expensive component within 1 second after checkbox click
Expensive Component fully rendered and painted in 217.50ms
  10 passed (9.0s)
```
</details>

**(Mobile) Deployments List page testing (before and after)**

https://github.com/user-attachments/assets/2e418d30-dc93-4913-8099-254dda3e782b

**(Desktop) Deployments List page testing (before and after)**

https://github.com/user-attachments/assets/af0b4f83-f1ff-4dd4-b329-6c6d099224a7

