### PR TITLE
fix(types): export FetcherResponse type 

### DIFF
--- a/src/index/index.ts
+++ b/src/index/index.ts
@@ -32,5 +32,6 @@ export type {
   Middleware,
   Arguments,
   State,
-  ScopedMutator
+  ScopedMutator,
+  FetcherResponse
 } from '../_internal'


### PR DESCRIPTION
This PR exports the `FetcherResponse` type from the main `swr` package. 
Currently, `FetcherResponse` is only accessible via `swr/_internal`, which is not intended for public consumption. 
This change allows developers to properly type `preload` function returns without relying on internal imports.

Fixes #3038