### PR TITLE
fix(loading): Prevent isLoading from being true with fallbackData

### DIFF
--- a/src/index/index.ts
+++ b/src/index/index.ts
@@ -32,5 +32,6 @@ export type {
   Middleware,
   Arguments,
   State,
-  ScopedMutator
+  ScopedMutator,
+  FetcherResponse
 } from '../_internal'

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -195,7 +195,7 @@ export const useSWRHandler = <Data = any, Error = any>(
 
       return {
         isValidating: true,
-        isLoading: isUndefined(fallback),
+        isLoading: true,
         ...snapshot
       }
     }
@@ -278,8 +278,8 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const returnedData = keepPreviousData
     ? isUndefined(cachedData)
-      ? // checking undefined to avoid null being fallback as well
-        isUndefined(laggyDataRef.current)
+      // checking undefined to avoid null being fallback as well
+      ? isUndefined(laggyDataRef.current)
         ? data
         : laggyDataRef.current
       : cachedData
@@ -390,7 +390,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       const initialState: State<Data, Error> = { isValidating: true }
       // It is in the `isLoading` state, if and only if there is no cached data.
       // This bypasses fallback data and laggy data.
-      if (isUndefined(getCache().data) && isUndefined(fallback)) {
+      if (isUndefined(getCache().data)) {
         initialState.isLoading = true
       }
       try {

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -195,7 +195,7 @@ export const useSWRHandler = <Data = any, Error = any>(
 
       return {
         isValidating: true,
-        isLoading: true,
+        isLoading: isUndefined(fallback),
         ...snapshot
       }
     }
@@ -278,8 +278,8 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const returnedData = keepPreviousData
     ? isUndefined(cachedData)
-      // checking undefined to avoid null being fallback as well
-      ? isUndefined(laggyDataRef.current)
+      ? // checking undefined to avoid null being fallback as well
+        isUndefined(laggyDataRef.current)
         ? data
         : laggyDataRef.current
       : cachedData

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -195,7 +195,7 @@ export const useSWRHandler = <Data = any, Error = any>(
 
       return {
         isValidating: true,
-        isLoading: true,
+        isLoading: isUndefined(fallback),
         ...snapshot
       }
     }
@@ -278,8 +278,8 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const returnedData = keepPreviousData
     ? isUndefined(cachedData)
-      // checking undefined to avoid null being fallback as well
-      ? isUndefined(laggyDataRef.current)
+      ? // checking undefined to avoid null being fallback as well
+        isUndefined(laggyDataRef.current)
         ? data
         : laggyDataRef.current
       : cachedData
@@ -390,7 +390,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       const initialState: State<Data, Error> = { isValidating: true }
       // It is in the `isLoading` state, if and only if there is no cached data.
       // This bypasses fallback data and laggy data.
-      if (isUndefined(getCache().data)) {
+      if (isUndefined(getCache().data) && isUndefined(fallback)) {
         initialState.isLoading = true
       }
       try {


### PR DESCRIPTION
This PR addresses an issue where `isLoading` was incorrectly set to `true` even when `fallbackData` was provided, particularly in SSR scenarios. This led to a "flash of skeleton" UI, which is undesirable when initial data is already available.

The change modifies the logic to ensure that `isLoading` remains `false` when `fallbackData` is present, while `isValidating` correctly reflects the background revalidation process. This allows the initial server-cached data to be displayed immediately, providing a smoother user experience.

Fixes #3046
