### PR TITLE
Revert "feat: modify cache type to allow generic usage"

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -518,8 +518,8 @@ export type RevalidateCallback = <K extends RevalidateEvent>(
 
 export interface Cache<Data = any> {
   keys(): IterableIterator<string>
-  get<T = Data>(key: string): State<T> | undefined
-  set<T = Data>(key: string, value: State<T>): void
+  get(key: string): State<Data> | undefined
+  set(key: string, value: State<Data>): void
   delete(key: string): void
 }
 


### PR DESCRIPTION
Reverts vercel/swr#2947 as the types checking are failing

x-ref: https://github.com/vercel/swr/actions/runs/16391924632/job/46319031893