### PR TITLE
deps: upgrade playwright version

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -31,7 +31,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.34.3-focal
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "devDependencies": {
     "@edge-runtime/jest-environment": "^3.0.4",
     "@arethetypeswrong/cli": "^0.15.3",
-    "@playwright/test": "1.34.3",
+    "@playwright/test": "1.57.0",
     "@swc/core": "^1.3.62",
     "@swc/jest": "0.2.26",
     "@testing-library/jest-dom": "^5.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4
       '@playwright/test':
-        specifier: 1.34.3
-        version: 1.34.3
+        specifier: 1.57.0
+        version: 1.57.0
       '@swc/core':
         specifier: ^1.3.62
         version: 1.15.3(@swc/helpers@0.5.17)
@@ -92,7 +92,7 @@ importers:
         version: 13.2.2
       next:
         specifier: 15.4.4
-        version: 15.4.4(@babel/core@7.28.5)(@playwright/test@1.34.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 15.4.4(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       prettier:
         specifier: 2.8.8
         version: 2.8.8
@@ -679,10 +679,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
-  '@playwright/test@1.34.3':
-    resolution: {integrity: sha512-zPLef6w9P6T/iT6XDYG3mvGOqOyb6eHaV9XtkunYs0+OzxBtrPAAaHotc0X+PJ00WPPnLfFBTl7mf45Mn8DBmw==}
-    engines: {node: '>=14'}
-    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   '@rollup/plugin-commonjs@28.0.9':
@@ -2732,9 +2731,14 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.34.3:
-    resolution: {integrity: sha512-2pWd6G7OHKemc5x1r1rp8aQcpvDh7goMBZlJv6Co5vCNLVcQJdhxRL09SGaY6HcyHH9aT4tiynZabMofVasBYw==}
-    engines: {node: '>=14'}
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -4021,12 +4025,9 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.34.3':
+  '@playwright/test@1.57.0':
     dependencies:
-      '@types/node': 20.19.25
-      playwright-core: 1.34.3
-    optionalDependencies:
-      fsevents: 2.3.2
+      playwright: 1.57.0
 
   '@rollup/plugin-commonjs@28.0.9(rollup@4.53.3)':
     dependencies:
@@ -6269,7 +6270,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.4.4(@babel/core@7.28.5)(@playwright/test@1.34.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@15.4.4(@babel/core@7.28.5)(@playwright/test@1.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@next/env': 15.4.4
       '@swc/helpers': 0.5.15
@@ -6287,7 +6288,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.4.4
       '@next/swc-win32-arm64-msvc': 15.4.4
       '@next/swc-win32-x64-msvc': 15.4.4
-      '@playwright/test': 1.34.3
+      '@playwright/test': 1.57.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -6468,7 +6469,13 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.34.3: {}
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
the playwright version we used is deprecated now.

based on #4184 #4185 