### PR TITLE
update use-sync-external-store to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@types/jest": "^29.5.2",
     "@types/node": "^22.19.1",
     "@types/react": "^19.2.7",
-    "@types/use-sync-external-store": "^0.0.3",
+    "@types/use-sync-external-store": "^1.5.0",
     "@typescript-eslint/eslint-plugin": "8.48.0",
     "@typescript-eslint/parser": "8.48.0",
     "bunchee": "^6.6.2",
@@ -174,6 +174,6 @@
   },
   "dependencies": {
     "dequal": "^2.0.3",
-    "use-sync-external-store": "^1.4.0"
+    "use-sync-external-store": "^1.6.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       use-sync-external-store:
-        specifier: ^1.4.0
+        specifier: ^1.6.0
         version: 1.6.0(react@18.3.1)
     devDependencies:
       '@arethetypeswrong/cli':
@@ -58,8 +58,8 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7
       '@types/use-sync-external-store':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^1.5.0
+        version: 1.5.0
       '@typescript-eslint/eslint-plugin':
         specifier: 8.48.0
         version: 8.48.0(@typescript-eslint/parser@8.48.0(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1)(typescript@5.9.3)
@@ -1088,8 +1088,8 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
-  '@types/use-sync-external-store@0.0.3':
-    resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
+  '@types/use-sync-external-store@1.5.0':
+    resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -4302,7 +4302,7 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@types/use-sync-external-store@0.0.3': {}
+  '@types/use-sync-external-store@1.5.0': {}
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -1,6 +1,6 @@
 /// <reference types="react/experimental" />
 import React, { useCallback, useRef, useDebugValue, useMemo } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 
 import {
   defaultConfig,

--- a/src/infinite/index.ts
+++ b/src/infinite/index.ts
@@ -34,7 +34,7 @@ import type {
   SWRInfiniteKeyedMutator,
   SWRInfiniteMutatorOptions
 } from './types'
-import { useSyncExternalStore } from 'use-sync-external-store/shim/index.js'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 import { getFirstPageKey } from './serialize'
 
 const EMPTY_PROMISE = Promise.resolve() as Promise<undefined>


### PR DESCRIPTION
new version of `use-sync-external-store` has `exports` field so we don't need to import from `index.js` anymore