### PR TITLE
Remove deprecated downlevelIteration option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "strict": true,
     "target": "ES2018",
     "noEmitOnError": true,
-    "downlevelIteration": true,
     "incremental": true
   },
   "include": ["./src/**/*", "env.d.ts", "eslint.config.mjs", "jest.config.js"],


### PR DESCRIPTION
This option is deprecated in TypeScript 6.0. It doesn't do anything when target is es2018, so can be safely removed from this config file.