### PR TITLE
fix: Safeguard onSuccess callback to prevent errors when undefined

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -543,7 +543,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         // Trigger the successful callback if it's the original request.
         if (shouldStartNewRequest) {
           if (callbackSafeguard()) {
-            getConfig().onSuccess(newData, key, config)
+            getConfig().onSuccess?.(newData, key, config)
           }
         }
       } catch (err: any) {

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -200,6 +200,32 @@ describe('useSWR - config callbacks', () => {
     expect(discardedEvents).toEqual([key])
   })
 
+  it('should not cause infinite loading when onSuccess is undefined', async () => {
+    const key = createKey()
+    let fetchCount = 0
+    function Page() {
+      const { data, isLoading } = useSWR(
+        key,
+        () => {
+          fetchCount++
+          return createResponse('ok')
+        },
+        {
+          onSuccess: undefined
+        }
+      )
+      return <div>{isLoading ? 'loading' : `data: ${data}`}</div>
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('loading')
+
+    await screen.findByText('data: ok')
+    // Wait a bit to ensure no extra retries are triggered.
+    await act(() => sleep(100))
+    expect(fetchCount).toBe(1)
+  })
+
   it('should not trigger the onSuccess callback when discarded', async () => {
     const key = createKey()
     const discardedEvents = []


### PR DESCRIPTION
## Summary

Fixes an infinite loop caused by explicitly passing `onSuccess: undefined` in `useSWR` options.

## Problem

When `onSuccess: undefined` is passed as a config property, it overrides the default `noop` function during config merging (`mergeObjects` uses object spread). This causes `getConfig().onSuccess(...)` to throw a `TypeError`, which is caught internally and triggers an error retry, resulting in an infinite request loop.

This commonly occurs when a custom hook accepts an optional `onSuccess` callback and passes it directly to `useSWR`:

```tsx
const useMyFetch = ({ onSuccess }: { onSuccess?: (data: Data) => void }) => {
  return useSWR(key, fetcher, {
    onSuccess, // becomes undefined when the caller doesn't provide it
  });
};
```

## Fix

Added optional chaining (`?.`) to the `onSuccess` invocation in `use-swr.ts` so that an `undefined` callback is safely skipped instead of throwing.

## Related issue

Closes #4218