### PR TITLE
fix: guard against undefined global state in createCacheHelper

### DIFF
--- a/src/_internal/utils/helper.ts
+++ b/src/_internal/utils/helper.ts
@@ -1,6 +1,6 @@
 import type { Cache, State, GlobalState } from '../types'
 import { SWRGlobalState } from './global-state'
-import { isUndefined, mergeObjects } from './shared'
+import { isUndefined, mergeObjects, noop } from './shared'
 
 const EMPTY_CACHE = {}
 const INITIAL_CACHE: Record<string, any> = {}
@@ -19,7 +19,7 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
   cache: Cache,
   key: string | undefined
 ) => {
-  const state = SWRGlobalState.get(cache) as GlobalState
+  const state = SWRGlobalState.get(cache) as GlobalState | undefined
   return [
     // Getter
     () => ((!isUndefined(key) && cache.get(key)) || EMPTY_CACHE) as T,
@@ -34,11 +34,16 @@ export const createCacheHelper = <Data = any, T = State<Data, any>>(
           INITIAL_CACHE[key] = prev
         }
 
-        state[5](key, mergeObjects(prev, info), prev || EMPTY_CACHE)
+        // Guard against undefined state - can happen in React Native New
+        // Architecture where SWRGlobalState.get(cache) returns undefined
+        // during initial renders before the provider has initialized.
+        if (state) {
+          state[5](key, mergeObjects(prev, info), prev || EMPTY_CACHE)
+        }
       }
     },
     // Subscriber
-    state[6],
+    state ? state[6] : () => noop,
     // Get server cache snapshot
     () => {
       if (!isUndefined(key)) {


### PR DESCRIPTION
When using SWR with React Native's New Architecture (bridgeless mode), `SWRGlobalState.get(cache)` can return `undefined` during early renders before the provider has fully initialized. This causes a crash when `createCacheHelper` tries to destructure `state[5]` and `state[6]` from the undefined value.

This adds a simple null guard:
- The setter becomes a no-op when state is undefined (the update will happen once the provider initializes properly)  
- The subscriber falls back to a function that returns a no-op unsubscribe handler

Tested locally - all existing unit and integration tests still pass.

Closes #2986