### PR TITLE
fix(mutation): support conditional fetching by allowing falsy keys

### DIFF
--- a/src/mutation/index.ts
+++ b/src/mutation/index.ts
@@ -47,11 +47,20 @@ const mutation = (<Data, Error>() =>
 
     const trigger = useCallback(
       async (arg: any, opts?: SWRMutationConfiguration<Data, Error>) => {
-        const [serializedKey, resolvedKey] = serialize(keyRef.current)
+        //If null is received as the key, ignore it.
+        const keyVal = keyRef.current
+
+        const resolvedKeyForCheck =
+          typeof keyVal === 'function' ? keyVal() : keyVal
+
+        if (!resolvedKeyForCheck) return
+
+        const [serializedKey, resolvedKey] = serialize(keyVal)
 
         if (!fetcherRef.current) {
           throw new Error('Can’t trigger the mutation: missing fetcher.')
         }
+
         if (!serializedKey) {
           throw new Error('Can’t trigger the mutation: missing key.')
         }

--- a/test/use-swr-mutation-null-keys.test.tsx
+++ b/test/use-swr-mutation-null-keys.test.tsx
@@ -1,0 +1,16 @@
+import { renderHook } from '@testing-library/react'
+import useSWRMutation from '../src/mutation/index'
+
+describe('useSWRMutation - Null Key', () => {
+  it('should not log an error when the key is null', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+    const fetcher = jest.fn()
+
+    const { result } = renderHook(() => useSWRMutation(null, fetcher))
+
+    await result.current.trigger()
+
+    expect(consoleSpy).not.toHaveBeenCalled()
+    consoleSpy.mockRestore()
+  })
+})

--- a/test/use-swr-remote-mutation.test.tsx
+++ b/test/use-swr-remote-mutation.test.tsx
@@ -1110,7 +1110,7 @@ describe('useSWR - remote mutation', () => {
     fireEvent.click(screen.getByText('pending'))
     await waitForNextTick()
 
-    expect(error.message).toBe('Can’t trigger the mutation: missing key.')
+    expect(error).toBeNull()
   })
 
   it('should call `onError` and `onRejected` but do not call `onSuccess` if value an error is cast to false', async () => {


### PR DESCRIPTION
### Description

This PR aligns the behavior of `useSWRMutation` with `useSWR` regarding conditional fetching. 

Previously, providing a `null` key (or a function returning a falsy value) to `useSWRMutation` caused an internal `console.error` during serialization and threw a "missing key" error when calling `trigger()`. This behavior contradicted the [SWR documentation on conditional fetching](https://swr.vercel.app/docs/conditional-fetching), which states that falsy keys should simply prevent the request.

### Changes

- **Logic Fix:** Added a guard clause in the `trigger` function to return early if the resolved key is falsy. This ensures consistency across the library and prevents unhandled console errors.
- **Test Update:** Updated the legacy test case `should error when triggering an empty key` to reflect the correct documented behavior (it now expects a silent return instead of an error throw).
- **Bug Fix:** Prevented the internal `serialize` utility from being called with invalid keys, eliminating the reported console noise.

### Linked Issue

Fixes #4217

### Testing

- Verified with a new regression test for `null` keys.
- Ran the full mutation test suite: `pnpm test mutation`. All tests passed.

Cc: @SL-YutoTakagi