### PR TITLE
fix: useSWRImmutable should disable revalidation on focus

### DIFF
--- a/src/immutable/index.ts
+++ b/src/immutable/index.ts
@@ -4,11 +4,13 @@ import { withMiddleware } from '../_internal'
 
 export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
   // Always override all revalidate options.
-  config.revalidateOnFocus = false
-  config.revalidateIfStale = false
-  config.revalidateOnReconnect = false
-  config.refreshInterval = 0
-  return useSWRNext(key, fetcher, config)
+  return useSWRNext(key, fetcher, {
+    ...config,
+    revalidateOnFocus: false,
+    revalidateIfStale: false,
+    revalidateOnReconnect: false,
+    refreshInterval: 0
+  })
 }
 
 const useSWRImmutable = withMiddleware(useSWR, immutable)


### PR DESCRIPTION
## Summary

Fixes a bug where useSWRImmutable was not properly disabling revalidation on window focus.

## Problem

useSWRImmutable is documented to disable all automatic revalidation, but when the window loses and regains focus, the fetcher was being called again.

## Root Cause

The immutable middleware was mutating the config object directly, which could be overridden by merged configs.

## Fix

Updated the immutable middleware to create a new config object with explicit overrides, ensuring all revalidation flags are properly disabled:
- evalidateOnFocus`n- evalidateIfStale`n- evalidateOnReconnect`n- efreshInterval`n
## Testing

- [x] All existing tests pass
- [x] Manual testing shows no revalidation on focus

Fixes #4225