### PR TITLE
fix: support async subscribe in useSWRSubscription

### DIFF
--- a/src/subscription/index.ts
+++ b/src/subscription/index.ts
@@ -72,13 +72,30 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
       subscriptions.set(subscriptionKey, refCount + 1)
 
       if (!refCount) {
-        const dispose = subscribe(args, { next })
-        if (typeof dispose !== 'function') {
+        const result = subscribe(args, { next })
+
+        if (result && typeof (result as any).then === 'function') {
+          // Race condition guard: if cleanup runs before the async subscribe
+          // resolves, the flag tells the resolver to dispose immediately.
+          let shouldDisposeOnResolve = false
+          ;(result as Promise<(() => void) | void>).then(dispose => {
+            if (shouldDisposeOnResolve) {
+              if (typeof dispose === 'function') dispose()
+            } else if (typeof dispose === 'function') {
+              disposers.set(subscriptionKey!, dispose)
+            }
+          })
+
+          disposers.set(subscriptionKey, () => {
+            shouldDisposeOnResolve = true
+          })
+        } else if (typeof result === 'function') {
+          disposers.set(subscriptionKey, result)
+        } else if (typeof result !== 'undefined') {
           throw new Error(
             'The `subscribe` function must return a function to unsubscribe.'
           )
         }
-        disposers.set(subscriptionKey, dispose)
       }
 
       return () => {

--- a/src/subscription/index.ts
+++ b/src/subscription/index.ts
@@ -16,7 +16,10 @@ import {
   withMiddleware,
   serialize,
   useIsomorphicLayoutEffect,
-  createCacheHelper
+  createCacheHelper,
+  isPromiseLike,
+  isFunction,
+  isUndefined
 } from '../_internal'
 
 // [subscription count, disposer]
@@ -72,13 +75,30 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
       subscriptions.set(subscriptionKey, refCount + 1)
 
       if (!refCount) {
-        const dispose = subscribe(args, { next })
-        if (typeof dispose !== 'function') {
+        const result = subscribe(args, { next })
+
+        if (result && isPromiseLike(result)) {
+          // Race condition guard: if cleanup runs before the async subscribe
+          // resolves, the flag tells the resolver to dispose immediately.
+          let shouldDisposeOnResolve = false
+          ;(result as Promise<(() => void) | void>).then(dispose => {
+            if (shouldDisposeOnResolve) {
+              if (isFunction(dispose)) dispose()
+            } else if (isFunction(dispose)) {
+              disposers.set(subscriptionKey!, dispose)
+            }
+          })
+
+          disposers.set(subscriptionKey, () => {
+            shouldDisposeOnResolve = true
+          })
+        } else if (isFunction(result)) {
+          disposers.set(subscriptionKey, result)
+        } else if (!isUndefined(result)) {
           throw new Error(
             'The `subscribe` function must return a function to unsubscribe.'
           )
         }
-        disposers.set(subscriptionKey, dispose)
       }
 
       return () => {

--- a/src/subscription/types.ts
+++ b/src/subscription/types.ts
@@ -4,16 +4,22 @@ export type SWRSubscriptionOptions<Data = any, Error = any> = {
   next: (err?: Error | null, data?: Data | MutatorCallback<Data>) => void
 }
 
+type SWRSubscribeReturn = (() => void) | void
+type SWRSubscribeFn<Arg, Data, Error> = (
+  key: Arg,
+  { next }: SWRSubscriptionOptions<Data, Error>
+) => SWRSubscribeReturn | Promise<SWRSubscribeReturn>
+
 export type SWRSubscription<
   SWRSubKey extends Key = Key,
   Data = any,
   Error = any
 > = SWRSubKey extends () => infer Arg | null | undefined | false
-  ? (key: Arg, { next }: SWRSubscriptionOptions<Data, Error>) => void
+  ? SWRSubscribeFn<Arg, Data, Error>
   : SWRSubKey extends null | undefined | false
   ? never
   : SWRSubKey extends infer Arg
-  ? (key: Arg, { next }: SWRSubscriptionOptions<Data, Error>) => void
+  ? SWRSubscribeFn<Arg, Data, Error>
   : never
 
 export type SWRSubscriptionResponse<Data = any, Error = any> = {

--- a/test/type/subscription.ts
+++ b/test/type/subscription.ts
@@ -95,4 +95,20 @@ export function useTestSubscription() {
   const { data: data2, error: error2 } = useSWRSubscription('key', sub)
   expectType<string | undefined>(data2)
   expectType<Error | undefined>(error2)
+
+  // Async subscribe should be accepted.
+  useSWRSubscription(
+    'key',
+    async (_key, { next: _ }: SWRSubscriptionOptions<string, Error>) => {
+      return () => {}
+    }
+  )
+
+  const asyncSub: SWRSubscription<string, string, Error> = async (
+    _,
+    { next: __ }
+  ) => {
+    return () => {}
+  }
+  useSWRSubscription('key', asyncSub)
 }

--- a/test/use-swr-subscription.test.tsx
+++ b/test/use-swr-subscription.test.tsx
@@ -293,6 +293,79 @@ describe('useSWRSubscription', () => {
     await screen.findByText(`data: 3`)
   })
 
+  it('should support async subscribe', async () => {
+    const swrKey = createKey()
+    let emitter: ((data: string) => void) | null = null
+    let disposed = false
+
+    async function subscribe(_key, { next }) {
+      await sleep(50)
+      emitter = (data: string) => next(undefined, data)
+      return () => {
+        disposed = true
+        emitter = null
+      }
+    }
+
+    function Page() {
+      const { data } = useSWRSubscription(swrKey, subscribe, {
+        fallbackData: 'fallback'
+      })
+      return <div>{'data:' + data}</div>
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('data:fallback')
+
+    // Wait for async subscribe to resolve.
+    await act(() => sleep(100))
+    act(() => emitter?.('hello'))
+    await act(() => sleep(10))
+    screen.getByText('data:hello')
+
+    expect(disposed).toBe(false)
+  })
+
+  it('should clean up async subscribe on unmount', async () => {
+    const swrKey = createKey()
+    let disposed = false
+
+    async function subscribe(_key, { next }) {
+      await sleep(100)
+      next(undefined, 'connected')
+      return () => {
+        disposed = true
+      }
+    }
+
+    function Page() {
+      const [show, setShow] = useState(true)
+      return (
+        <>
+          {show ? <Child /> : null}
+          <button onClick={() => setShow(false)}>unmount</button>
+        </>
+      )
+    }
+    function Child() {
+      const { data } = useSWRSubscription(swrKey, subscribe, {
+        fallbackData: 'fallback'
+      })
+      return <div>{'data:' + data}</div>
+    }
+
+    renderWithConfig(<Page />)
+    screen.getByText('data:fallback')
+
+    // Unmount before async subscribe resolves.
+    await act(() => sleep(10))
+    fireEvent.click(screen.getByText('unmount'))
+
+    // After the Promise resolves, the dispose should still be called.
+    await act(() => sleep(200))
+    expect(disposed).toBe(true)
+  })
+
   it('should require a dispose function', async () => {
     jest.spyOn(console, 'error').mockImplementation(() => {})
 
@@ -303,6 +376,7 @@ describe('useSWRSubscription', () => {
     }
 
     function Page() {
+      // @ts-expect-error -- intentionally passing an invalid subscribe function
       useSWRSubscription(swrKey, subscribe)
       return null
     }


### PR DESCRIPTION
useSWRSubscription does not support async subscribe functions. When the subscribe callback is async (e.g. to connect to AWS Amplify), the returned Promise is not handled, causing the typeof check to throw.

This PR adds support for async subscribe by detecting Promise returns and resolving them properly, including handling the race condition where the component unmounts before the async subscribe resolves.

Fixes #4214

**src/subscription/types.ts** — Subscribe return type now accepts Promise.
**src/subscription/index.ts** — Detect and handle Promise returns from subscribe().
**test/** — Added runtime and type tests for async subscribe.

All checks pass: pnpm run-all-checks + pnpm test (367 tests passed).