### PR TITLE
test: cover suspense callback refresh

### DIFF
--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -1,7 +1,13 @@
 import { screen, fireEvent } from '@testing-library/react'
-import { act } from 'react'
+import { act, Suspense, useState } from 'react'
 import useSWR from 'swr'
-import { sleep, createResponse, renderWithConfig, createKey } from './utils'
+import {
+  sleep,
+  createResponse,
+  renderWithConfig,
+  createKey,
+  itShouldSkipForReactCanary
+} from './utils'
 
 describe('useSWR - config callbacks', () => {
   it('should trigger the onSuccess event with the latest version of the onSuccess callback', async () => {
@@ -38,6 +44,57 @@ describe('useSWR - config callbacks', () => {
     // the onSuccess callback should capture the latest `props.text`
     expect(state).toEqual('b')
   })
+
+  itShouldSkipForReactCanary(
+    'should trigger the onSuccess event with the latest version of the onSuccess callback in suspense mode',
+    async () => {
+      let state = null
+      const key = createKey()
+
+      function Page(props: { text: string }) {
+        const [prefix, setPrefix] = useState('a')
+        const { data } = useSWR(
+          prefix + ':' + key,
+          () => createResponse(prefix),
+          {
+            suspense: true,
+            onSuccess: () => (state = props.text)
+          }
+        )
+
+        return (
+          <div>
+            <button onClick={() => setPrefix('b')}>update</button>
+            <div>
+              hello, {data}:{key}, {props.text}
+            </div>
+          </div>
+        )
+      }
+
+      const { rerender } = renderWithConfig(
+        <Suspense fallback={<div>fallback</div>}>
+          <Page text="a" />
+        </Suspense>
+      )
+
+      screen.getByText('fallback')
+      await screen.findByText(`hello, a:${key}, a`)
+      expect(state).toEqual('a')
+
+      rerender(
+        <Suspense fallback={<div>fallback</div>}>
+          <Page text="b" />
+        </Suspense>
+      )
+      screen.getByText(`hello, a:${key}, b`)
+      expect(state).toEqual('a')
+
+      fireEvent.click(screen.getByText('update'))
+      await screen.findByText(`hello, b:${key}, b`)
+      expect(state).toEqual('b')
+    }
+  )
 
   it('should trigger the onError event with the latest version of the onError callback', async () => {
     let state = null


### PR DESCRIPTION

**Repo:** vercel/swr (⭐ 32000)
**Type:** test
**Files changed:** 1
**Lines:** +59/-2

## What
Adds a focused regression test to [`test/use-swr-config-callbacks.test.tsx`](/Users/bojun/Desktop/agent-pr-mission-v2/i/vercel-swr/test/use-swr-config-callbacks.test.tsx) to verify that `useSWR` uses the latest `onSuccess` callback after a prop update when running in suspense mode. The test rerenders with a new callback closure, changes the key to force a new suspense fetch, and asserts that the callback observes the updated prop value rather than a stale one.

## Why
The main hook implementation in [`src/index/use-swr.ts`](/Users/bojun/Desktop/agent-pr-mission-v2/i/vercel-swr/src/index/use-swr.ts) already documents lifecycle sensitivity around changing `fn` and `config`, especially in suspense usage. The existing suite covers latest callback behavior in normal mode and latest fetcher behavior in suspense mode, but it did not cover latest callback behavior in suspense mode. This test closes that gap and protects against regressions in a subtle part of the hook lifecycle.

## Testing
Intended verification: run `pnpm test -- --runInBand test/use-swr-config-callbacks.test.tsx`.
Local execution was not completed in this environment because `pnpm` attempted to write outside the sandbox and the repo clone does not include installed dependencies (`node_modules` was absent).

## Risk
Low - test-only change in an existing test file with no runtime code impact.
