### PR TITLE
fix: guard against double-unsubscribe removing wrong subscriber in cache.ts

### DIFF
--- a/src/_internal/utils/cache.ts
+++ b/src/_internal/utils/cache.ts
@@ -56,7 +56,14 @@ export const initCache = <Data = any>(
       subscriptions[key] = subs
 
       subs.push(callback)
-      return () => subs.splice(subs.indexOf(callback), 1)
+      return () => {
+        const index = subs.indexOf(callback)
+        if (index >= 0) {
+          // O(1): swap with the last element and pop
+          subs[index] = subs[subs.length - 1]
+          subs.pop()
+        }
+      }
     }
     const setter = (key: string, value: any, prev: any) => {
       provider.set(key, value)


### PR DESCRIPTION
## Summary

Fixes #4251

- `subscribe` in `src/_internal/utils/cache.ts` returned `() => subs.splice(subs.indexOf(callback), 1)`
- When the unsubscribe function was called a second time, `indexOf` returned `-1` and `splice(-1, 1)` silently removed the **last subscriber** in the array instead of being a no-op
- Fix adds an `index >= 0` guard and uses the same O(1) swap-and-pop pattern already present in `src/_internal/utils/subscribe-key.ts`

## Changes

- `src/_internal/utils/cache.ts`: align the unsubscribe logic with `subscribeCallback` in `subscribe-key.ts`

## Test plan

- [x] All existing tests pass (`pnpm test`: 360 passed, 5 skipped)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Build succeeds (`pnpm build`)