### PR TITLE
fix: ignore undefined values when merging configs

### DIFF
--- a/src/_internal/utils/merge-config.ts
+++ b/src/_internal/utils/merge-config.ts
@@ -6,7 +6,17 @@ export const mergeConfigs = (
   b?: Partial<FullConfiguration>
 ) => {
   // Need to create a new object to avoid mutating the original here.
-  const v: Partial<FullConfiguration> = mergeObjects(a, b)
+  // Skip keys whose value is `undefined` in `b` so that explicitly passing
+  // `undefined` (e.g. `onSuccess: undefined`) behaves like omitting the key
+  // and does not overwrite inherited defaults.
+  const v: Partial<FullConfiguration> = { ...a }
+  if (b) {
+    for (const k in b) {
+      if (b[k as keyof FullConfiguration] !== undefined) {
+        ;(v as any)[k] = b[k as keyof FullConfiguration]
+      }
+    }
+  }
 
   // If two configs are provided, merge their `use` and `fallback` options.
   if (b) {

--- a/test/unit/utils.test.tsx
+++ b/test/unit/utils.test.tsx
@@ -142,4 +142,21 @@ describe('Utils', () => {
       fallback: { a: 1, b: 1 }
     })
   })
+
+  it('should not overwrite inherited config with undefined values', async () => {
+    const onSuccess = () => {}
+    const onError = () => {}
+
+    // Explicit `undefined` in the user config should not overwrite the
+    // inherited callback (otherwise the call site would throw when invoking
+    // it, see https://github.com/vercel/swr/issues/4218).
+    const merged: any = mergeConfigs(
+      { onSuccess, onError, revalidateOnFocus: true } as any,
+      { onSuccess: undefined, revalidateOnFocus: false } as any
+    )
+    expect(merged.onSuccess).toBe(onSuccess)
+    expect(merged.onError).toBe(onError)
+    // But non-undefined values should still override.
+    expect(merged.revalidateOnFocus).toBe(false)
+  })
 })


### PR DESCRIPTION
Fixes #4218.

When a user explicitly passes `undefined` for an option such as `onSuccess: undefined`, the user value overwrites the inherited default (`noop` for the event callbacks). Later, when `use-swr` invokes `getConfig().onSuccess(...)`, the call throws because the value is no longer a function. That throw is caught by the request error handler, which schedules a retry via `onErrorRetry`, and the cycle repeats indefinitely. The reported repro produces a tight retry loop with no backoff cap visible to the caller.

This is annoying in practice because it commonly happens when a custom hook forwards an optional callback into `useSWR` and the caller omits it, leaving the field as `undefined` in the spread options.

The fix is in `mergeConfigs`: when merging the user-provided config on top of the inherited config, skip keys whose value is `undefined`. Non-undefined values still override as before, and the existing `use` and `fallback` merge logic is unchanged. This matches the user expectation that explicit `undefined` should be equivalent to omitting the key.

I added a unit test in `test/unit/utils.test.tsx` covering the case, and the full Jest suite plus type checks and lint all pass locally.