### PR TITLE
fix: read swr devtools on demand

### DIFF
--- a/src/_internal/utils/devtools.ts
+++ b/src/_internal/utils/devtools.ts
@@ -15,3 +15,14 @@ export const setupDevTools = () => {
     window.__SWR_DEVTOOLS_REACT__ = React
   }
 }
+
+// Due to Chrome extension limitations, the SWR DevTools extension may inject
+// `__SWR_DEVTOOLS_USE__` too late, where `enableDevtools` will always be false
+// In this case, we provide a global function `__SWR_DEVTOOLS_SETUP__` for the
+// extension to invoke when it is ready
+
+// @ts-expect-error
+window.__SWR_DEVTOOLS_SETUP__ = () => {
+  // @ts-expect-error
+  window.__SWR_DEVTOOLS_REACT__ = React
+}

--- a/src/_internal/utils/devtools.ts
+++ b/src/_internal/utils/devtools.ts
@@ -5,6 +5,7 @@ import { isWindowDefined } from './helper'
 const enableDevtools = isWindowDefined && window.__SWR_DEVTOOLS_USE__
 
 export const getDevToolsUse = () => {
+  if (!isWindowDefined) return []
   // @ts-expect-error
   return window.__SWR_DEVTOOLS_USE__ ?? []
 }
@@ -21,8 +22,10 @@ export const setupDevTools = () => {
 // In this case, we provide a global function `__SWR_DEVTOOLS_SETUP__` for the
 // extension to invoke when it is ready
 
-// @ts-expect-error
-window.__SWR_DEVTOOLS_SETUP__ = () => {
+if (isWindowDefined) {
   // @ts-expect-error
-  window.__SWR_DEVTOOLS_REACT__ = React
+  window.__SWR_DEVTOOLS_SETUP__ = () => {
+    // @ts-expect-error
+    window.__SWR_DEVTOOLS_REACT__ = React
+  }
 }

--- a/src/_internal/utils/devtools.ts
+++ b/src/_internal/utils/devtools.ts
@@ -4,10 +4,10 @@ import { isWindowDefined } from './helper'
 // @ts-expect-error
 const enableDevtools = isWindowDefined && window.__SWR_DEVTOOLS_USE__
 
-export const use = enableDevtools
-  ? // @ts-expect-error
-    window.__SWR_DEVTOOLS_USE__
-  : []
+export const getDevToolsUse = () => {
+  // @ts-expect-error
+  return window.__SWR_DEVTOOLS_USE__ ?? []
+}
 
 export const setupDevTools = () => {
   if (enableDevtools) {

--- a/src/_internal/utils/middleware-preset.ts
+++ b/src/_internal/utils/middleware-preset.ts
@@ -1,4 +1,6 @@
-import { use as devtoolsUse } from './devtools'
+import { getDevToolsUse } from './devtools'
 import { middleware as preload } from './preload'
 
-export const BUILT_IN_MIDDLEWARE = devtoolsUse.concat(preload)
+export const getBuiltinMiddleware = () => {
+  return getDevToolsUse().concat(preload)
+}

--- a/src/_internal/utils/resolve-args.ts
+++ b/src/_internal/utils/resolve-args.ts
@@ -1,7 +1,7 @@
 import { mergeConfigs } from './merge-config'
 import { normalize } from './normalize-args'
 import { useSWRConfig } from './use-swr-config'
-import { BUILT_IN_MIDDLEWARE } from './middleware-preset'
+import { getBuiltinMiddleware } from './middleware-preset'
 
 // It's tricky to pass generic types as parameters, so we just directly override
 // the types here.
@@ -19,7 +19,7 @@ export const withArgs = <SWRType>(hook: any) => {
     // Apply middleware
     let next = hook
     const { use } = config
-    const middleware = (use || []).concat(BUILT_IN_MIDDLEWARE)
+    const middleware = (use || []).concat(getBuiltinMiddleware())
     for (let i = middleware.length; i--; ) {
       next = middleware[i](next)
     }


### PR DESCRIPTION
The PR fixes: https://github.com/koba04/swr-devtools/issues/133

Due to Chrome extension limitation, the SWR DevTools may not inject `window.__SWR_DEVTOOLS_USE__` fast enough (https://github.com/koba04/swr-devtools/issues/133#issuecomment-4501453501), while SWR currently tries to read `window.__SWR_DEVTOOLS_USE__` at the module level, which is way too early. By the time the SWR DevTools extension finally injects `window.__SWR_DEVTOOLS_USE__`, SWR already sets `enableDevtools` to `false`.

Here are the PR changes:

- Now we always read `window.__SWR_DEVTOOLS_USE__` on demand instead of pre-populated
- We now expose `window.__SWR_DEVTOOLS_SETUP__` to the SWR DevTools extension, in case the SWR devtools load too slow and miss the opportunity to grab the `React` instance.

cc @koba04 @shuding @promer94 @huozhi 