### PR TITLE
fix: call onSuccess for all hook consumers sharing a deduplicated request

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -159,6 +159,9 @@ export const useSWRHandler = <Data = any, Error = any>(
   const keyRef = useRef(key)
   const fetcherRef = useRef(fetcher)
   const configRef = useRef(config)
+  // Track the startAt timestamp of the last request for which this hook
+  // already fired onSuccess, so deduped joins don't double-fire it.
+  const lastSuccessStartAtRef = useRef<number | undefined>(UNDEFINED)
   const getConfig = () => configRef.current
   const isActive = () => getConfig().isVisible() && getConfig().isOnline()
 
@@ -542,11 +545,15 @@ export const useSWRHandler = <Data = any, Error = any>(
         // cacheData might be different from newData even when compare fn returns True
         finalState.data = compare(cacheData, newData) ? cacheData : newData
 
-        // Trigger the successful callback if it's the original request.
-        if (shouldStartNewRequest) {
-          if (callbackSafeguard()) {
-            getConfig().onSuccess(newData, key, config)
-          }
+        // Trigger the successful callback. Fire for the hook that originated
+        // the request (shouldStartNewRequest) and also for hooks that joined
+        // an in-flight request from a different hook instance (deduplication
+        // across consumers). Guard with lastSuccessStartAtRef so that a
+        // polling interval that deduplicates its own in-flight request does
+        // not fire onSuccess a second time for the same request.
+        if (callbackSafeguard() && lastSuccessStartAtRef.current !== startAt) {
+          lastSuccessStartAtRef.current = startAt
+          getConfig().onSuccess(newData, key, config)
         }
       } catch (err: any) {
         cleanupState()
@@ -694,23 +701,27 @@ export const useSWRHandler = <Data = any, Error = any>(
     unmountedRef.current = false
     keyRef.current = key
     initialMountedRef.current = true
+    // Reset so a fresh request for this key always fires onSuccess.
+    lastSuccessStartAtRef.current = UNDEFINED
 
     // Keep the original key in the cache.
     setCache({ _k: fnArg })
 
     // Trigger a revalidation
     if (shouldDoInitialRevalidation) {
-      // Performance optimization: if a request is already in progress for this key,
-      // skip the revalidation to avoid redundant work
-      if (!FETCH[key]) {
-        if (isUndefined(data) || IS_SERVER) {
-          // Revalidate immediately.
-          softRevalidate()
-        } else {
-          // Delay the revalidate if we have data to return so we won't block
-          // rendering.
-          rAF(softRevalidate)
-        }
+      if (FETCH[key]) {
+        // A request is already in-flight for this key (started by another hook
+        // instance). Join it so that this hook's onSuccess/onError callbacks
+        // fire when the shared request settles, without issuing a new HTTP
+        // request.
+        softRevalidate()
+      } else if (isUndefined(data) || IS_SERVER) {
+        // Revalidate immediately.
+        softRevalidate()
+      } else {
+        // Delay the revalidate if we have data to return so we won't block
+        // rendering.
+        rAF(softRevalidate)
       }
     }
 

--- a/test/use-swr-config-callbacks.test.tsx
+++ b/test/use-swr-config-callbacks.test.tsx
@@ -200,6 +200,50 @@ describe('useSWR - config callbacks', () => {
     expect(discardedEvents).toEqual([key])
   })
 
+  it('should trigger onSuccess for all hooks sharing the same key even when request is deduplicated', async () => {
+    // https://github.com/vercel/swr/issues/1580
+    // When two components share the same key and the second one deduplicates the
+    // in-flight request started by the first, the second component's onSuccess
+    // should still be called once the shared request resolves.
+    const key = createKey()
+    const successCalls: string[] = []
+
+    function ComponentA() {
+      useSWR(key, () => createResponse('data', { delay: 50 }), {
+        onSuccess: data => {
+          successCalls.push('A:' + data)
+        }
+      })
+      return <div>A</div>
+    }
+
+    function ComponentB() {
+      useSWR(key, () => createResponse('data', { delay: 50 }), {
+        onSuccess: data => {
+          successCalls.push('B:' + data)
+        }
+      })
+      return <div>B</div>
+    }
+
+    function Page() {
+      return (
+        <>
+          <ComponentA />
+          <ComponentB />
+        </>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    await act(() => sleep(100))
+
+    // Both hooks share the same key — the request is deduplicated.
+    // Both onSuccess callbacks should still be called.
+    expect(successCalls).toContain('A:data')
+    expect(successCalls).toContain('B:data')
+  })
+
   it('should not trigger the onSuccess callback when discarded', async () => {
     const key = createKey()
     const discardedEvents = []


### PR DESCRIPTION
## Problem

When multiple components use the same SWR key and mount concurrently, only the first component's `onSuccess` callback fires. All other components that deduplicate onto the same in-flight request have their `onSuccess` silently skipped.

This is a pre-existing bug (reported in #1580). It was made more complete (the deduped hooks no longer even call `revalidate`) by the performance optimization added in #4138.

**Minimal reproduction:**
```tsx
function ComponentA() {
  useSWR('/api', fetcher, {
    onSuccess: data => console.log('A:', data)  // always fires
  })
  ...
}

function ComponentB() {
  useSWR('/api', fetcher, {
    onSuccess: data => console.log('B:', data)  // NEVER fires when A mounts first
  })
  ...
}
```

## Root cause

`#4138` added an early-exit optimization in the mount effect:

```ts
if (!FETCH[key]) {
  // start or defer softRevalidate
}
// else: silently skip — deduped consumer never calls revalidate
```

When `FETCH[key]` already exists (A's request is in-flight), component B skips `softRevalidate` entirely, so its `onSuccess` is never called.

Even before #4138, the `onSuccess` guard `if (shouldStartNewRequest)` inside `revalidate` also prevented deduped consumers from getting `onSuccess`, so the issue is two-layered.

## Fix

Two changes to `src/index/use-swr.ts`:

1. **Mount effect**: when `FETCH[key]` exists, still call `softRevalidate()` so the hook joins the in-flight request and its callbacks fire when it settles.

2. **`revalidate` function**: remove the `shouldStartNewRequest` guard from the `onSuccess` call. Instead, use a per-hook-instance `lastSuccessStartAtRef` to track which request timestamp has already fired `onSuccess` for this hook. This prevents a polling interval that deduplicates onto its own in-flight request from firing `onSuccess` a second time — while still allowing a different hook instance to fire its own `onSuccess` for the same shared request.

## Test evidence

New test added to `test/use-swr-config-callbacks.test.tsx`:

```
✓ should trigger onSuccess for all hooks sharing the same key even when request is deduplicated
```

All 361 existing tests continue to pass.

Closes #1580