### PR TITLE
fix: notify all key listeners on revalidation events

### DIFF
--- a/src/_internal/utils/cache.ts
+++ b/src/_internal/utils/cache.ts
@@ -19,7 +19,12 @@ const revalidateAllKeys = (
   type: RevalidateEvent
 ) => {
   for (const key in revalidators) {
-    if (revalidators[key][0]) revalidators[key][0](type)
+    const callbacks = revalidators[key]
+    if (callbacks) {
+      for (const callback of [...callbacks]) {
+        callback(type)
+      }
+    }
   }
 }
 

--- a/test/use-swr-focus.test.tsx
+++ b/test/use-swr-focus.test.tsx
@@ -218,6 +218,46 @@ describe('useSWR - focus', () => {
     await screen.findByText('data: 1')
   })
 
+  it('should revalidate active hooks when another hook with the same key is paused', async () => {
+    let value = 0
+    const key = createKey()
+    const fetcher = () => value++
+
+    function PausedConsumer() {
+      useSWR(key, fetcher, {
+        dedupingInterval: 0,
+        focusThrottleInterval: 0,
+        isPaused: () => true
+      })
+      return null
+    }
+
+    function ActiveConsumer() {
+      const { data } = useSWR(key, fetcher, {
+        dedupingInterval: 0,
+        focusThrottleInterval: 0
+      })
+      return <div>data: {data}</div>
+    }
+
+    function Page() {
+      return (
+        <>
+          <PausedConsumer />
+          <ActiveConsumer />
+        </>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data: 0')
+
+    await waitForNextTick()
+    await focusWindow()
+
+    await screen.findByText('data: 1')
+  })
+
   it('should not revalidate on focus when key changes in the same tick', async () => {
     const fetchLogs = []
 


### PR DESCRIPTION
Fixes #2333.

This updates global focus/reconnect revalidation dispatch so every mounted listener for a cache key receives the event instead of only the first registered listener.

Previously, if multiple hooks shared a key and the first registered hook was paused via isPaused(), focus/reconnect revalidation stopped there and active consumers with the same key could not revalidate. Each listener already checks its own config before revalidating, and request deduping still prevents duplicate fetches for active consumers sharing the same key.

Verification:
- pnpm test -- test/use-swr-focus.test.tsx --runInBand
- pnpm types:check
- pnpm exec prettier --check src/_internal/utils/cache.ts test/use-swr-focus.test.tsx
- pnpm exec eslint src/_internal/utils/cache.ts test/use-swr-focus.test.tsx