### PR TITLE
fix(mutate): roll back optimistic data when the mutator throws synchronously

### DIFF
--- a/src/_internal/utils/mutate.ts
+++ b/src/_internal/utils/mutate.ts
@@ -157,6 +157,13 @@ export async function internalMutate<Data>(
         // If it throws an error synchronously, we shouldn't update the cache.
         error = err
         isError = true
+        // Roll back the optimistic update on a synchronous throw, mirroring the
+        // async-rejection path below. Without this the optimistic value is left
+        // in the cache permanently when `revalidate` is false.
+        if (hasOptimisticData && rollbackOnError(error)) {
+          populateCache = true
+          set({ data: committedData, _c: UNDEFINED })
+        }
       }
     }
 

--- a/test/use-swr-local-mutation.test.tsx
+++ b/test/use-swr-local-mutation.test.tsx
@@ -1309,6 +1309,56 @@ describe('useSWR - local mutation', () => {
     expect(renderedData).toEqual([undefined, 0, 'bar', 0, 1])
   })
 
+  it('should rollback optimistic updates when the mutator throws synchronously', async () => {
+    const key = createKey()
+    const renderedData = []
+    let mutate
+
+    function Page() {
+      const { data, mutate: boundMutate } = useSWR(key, () =>
+        createResponse(0, { delay: 20 })
+      )
+      mutate = boundMutate
+      if (
+        !renderedData.length ||
+        renderedData[renderedData.length - 1] !== data
+      ) {
+        renderedData.push(data)
+      }
+      return <div>data: {String(data)}</div>
+    }
+
+    renderWithConfig(<Page />)
+    await screen.findByText('data: 0')
+
+    // A synchronously-throwing mutator with optimisticData. revalidate:false so
+    // no re-fetch can mask a missing rollback. The optimistic value must be
+    // rolled back to the committed value (0), same as the async-rejection path.
+    try {
+      await executeWithoutBatching(() =>
+        mutate(
+          () => {
+            throw new Error('sync-baz')
+          },
+          {
+            optimisticData: 'bar',
+            revalidate: false,
+            rollbackOnError: true
+          }
+        )
+      )
+    } catch (e) {
+      expect(e.message).toEqual('sync-baz')
+    }
+
+    await sleep(30)
+    // The optimistic update must be rolled back: the final displayed value is
+    // the committed 0, not the optimistic 'bar'. Before the fix the cache was
+    // left stuck at 'bar' (rendered sequence [undefined, 0, 'bar']).
+    expect(renderedData[renderedData.length - 1]).toEqual(0)
+    expect(renderedData).not.toContain('bar')
+  })
+
   it('should not revert to optimistic data when rolling back', async () => {
     const key = createKey()
     const renderedData = []


### PR DESCRIPTION
## Bug

When a mutator function passed to `mutate` throws **synchronously** and `optimisticData` is set, the optimistic value written to the cache is never rolled back.

The async-rejection path rolls back correctly:

```ts
} else if (isError && hasOptimisticData && rollbackOnError(error)) {
  populateCache = true
  set({ data: committedData, _c: UNDEFINED })
}
```

but that block is gated behind `if (data && isPromiseLike(data))`. On a synchronous throw, the assignment `data = (data as MutatorCallback<Data>)(committedData)` throws, so `data` is still the original **function** reference. `isPromiseLike(data)` is then `false` and the entire async block (including the rollback) is skipped. The synchronous `catch` only records the error:

```ts
} catch (err) {
  // If it throws an error synchronously, we shouldn't update the cache.
  error = err
  isError = true
  // <-- optimistic write from earlier is never rolled back
}
```

With `revalidate: false` no re-fetch can mask it, so the cache is left holding the optimistic value permanently.

## Fix

Mirror the async rollback in the synchronous `catch` block (the diff is the same 4-line rollback that already exists for the async path).

## Reproduction (added as a regression test)

`test/use-swr-local-mutation.test.tsx`:

```ts
mutate(() => { throw new Error('sync-baz') }, {
  optimisticData: 'bar',
  revalidate: false,
  rollbackOnError: true
})
```

- **Before:** the cache stays at `'bar'` (rendered sequence `[undefined, 0, 'bar']`).
- **After:** it rolls back to the committed value (rendered sequence `[undefined, 0]`; the optimistic value is reverted synchronously so it never even flashes).

## Verification (local)

- The new regression test **fails on current `main`** and **passes** with this change (confirmed by reverting/re-applying the fix).
- Full `use-swr-local-mutation` suite stays green (54 passed, 0 regressions).
- `tsc --noEmit` and `eslint` both pass.