### PR TITLE
fix(subscription): clear refcount and disposer Maps on last-subscriber teardown

### DIFF
--- a/src/subscription/index.ts
+++ b/src/subscription/index.ts
@@ -86,10 +86,17 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
 
         subscriptions.set(subscriptionKey, count)
 
-        // Dispose if it's the last one.
+        // Dispose if it's the last one, and drop both Map entries so the
+        // ref-count and disposer don't accumulate one stale entry per unique
+        // key over the lifetime of the cache. Long-lived apps with rotating
+        // subscription keys (paginated feeds, live channels, etc.) would
+        // otherwise leak proportional to the total number of keys ever seen,
+        // not the number currently active.
         if (!count) {
           const dispose = disposers.get(subscriptionKey)
           dispose?.()
+          disposers.delete(subscriptionKey)
+          subscriptions.delete(subscriptionKey)
         }
       }
     }, [subscriptionKey])


### PR DESCRIPTION
Closes #4261.

## Summary

`subscriptions` (ref-count) and `disposers` (cleanup function) Maps in `src/subscription/index.ts` live for the lifetime of the cache via `subscriptionStorage`. The previous teardown called `dispose()` on the last subscriber but never removed the now-stale entries — long-lived apps with rotating subscription keys (paginated feeds, live channels, rotating market tickers, etc.) accumulated one dead entry in each Map per unique key, plus one un-collectable dispose closure per key, growing proportional to total keys ever seen rather than currently-active ones.

## Fix

Delete both entries immediately after invoking `dispose()`:

```ts
if (!count) {
  const dispose = disposers.get(subscriptionKey)
  dispose?.()
  disposers.delete(subscriptionKey)      // ← added
  subscriptions.delete(subscriptionKey)  // ← added
}
```

Behaviour is unchanged for live subscriptions and same-key remounts — the existing `subscriptions.get(subscriptionKey) || 0` fallback in the mount path was already tolerant of zero-count stale entries, so the functional contract is preserved.

## Tests

All 7 existing `useSWRSubscription` tests pass unchanged.

I did not add a behavioural regression test: the only observable effect of the bug is `subscriptions.size` / `disposers.size` growth on the module-scoped `subscriptionStorage` WeakMap, which has no public introspection surface. Adding one would require exporting `subscriptionStorage` (with `@internal`) just for the test, which felt like a heavier change than the two-line fix warrants. Happy to add an `@internal` export and a size-tracking test if you'd prefer that shape — the repro scenario from #4261 lifts directly into a test once an introspection hook exists.

The fix is auditable by inspection against the issue's reproduction:

```tsx
function RotatingSubscription({ channel }: { channel: string }) {
  useSWRSubscription(channel, (key, { next }) => {
    const ws = new WebSocket(`wss://example.com/${key}`)
    ws.onmessage = (e) => next(null, e.data)
    return () => ws.close()
  })
  return null
}
// Mount/unmount with channel = "ch-0" ... "ch-9999"
// Before: subscriptions.size === 10000, disposers.size === 10000
// After:  both 0
```