### PR TITLE
Prevent resolved promise to suspend due to missing status

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -89,7 +89,6 @@ type DefinitelyTruthy<T> = false extends T
   ? never
   : T
 
-const resolvedUndef = Promise.resolve(UNDEFINED)
 const sub = () => noop
 /**
  * The core implementation of the useSWR hook.
@@ -790,23 +789,24 @@ export const useSWRHandler = <Data = any, Error = any>(
 
     const req = PRELOAD[key]
 
-    const mutateReq =
-      !isUndefined(req) && hasKeyButNoData ? boundMutate(req) : resolvedUndef
-    use(mutateReq)
+    if (!isUndefined(req) && hasKeyButNoData) {
+      use(boundMutate(req))
+    }
 
     if (!isUndefined(error) && hasKeyButNoData) {
       throw error
     }
-    const revalidation = hasKeyButNoData
-      ? revalidate(WITH_DEDUPE)
-      : resolvedUndef
-    if (!isUndefined(returnedData) && hasKeyButNoData) {
-      // @ts-ignore modify react promise status
-      revalidation.status = 'fulfilled'
-      // @ts-ignore modify react promise value
-      revalidation.value = true
+
+    if (hasKeyButNoData) {
+      const revalidation = revalidate(WITH_DEDUPE)
+      if (!isUndefined(returnedData)) {
+        // @ts-ignore modify react promise status
+        revalidation.status = 'fulfilled'
+        // @ts-ignore modify react promise value
+        revalidation.value = true
+      }
+      use(revalidation)
     }
-    use(revalidation)
   }
 
   const swrResponse: SWRResponse<Data, Error> = {

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -89,6 +89,13 @@ type DefinitelyTruthy<T> = false extends T
   ? never
   : T
 
+// React can only unwrap a thenable synchronously when it has React's thenable
+// status fields, so this fulfilled no-op keeps Suspense paths from waiting.
+const resolvedUndef = Promise.resolve(UNDEFINED)
+// @ts-ignore modify react promise status
+resolvedUndef.status = 'fulfilled'
+// @ts-ignore modify react promise value
+resolvedUndef.value = UNDEFINED
 const sub = () => noop
 /**
  * The core implementation of the useSWR hook.
@@ -789,24 +796,23 @@ export const useSWRHandler = <Data = any, Error = any>(
 
     const req = PRELOAD[key]
 
-    if (!isUndefined(req) && hasKeyButNoData) {
-      use(boundMutate(req))
-    }
+    const mutateReq =
+      !isUndefined(req) && hasKeyButNoData ? boundMutate(req) : resolvedUndef
+    use(mutateReq)
 
     if (!isUndefined(error) && hasKeyButNoData) {
       throw error
     }
-
-    if (hasKeyButNoData) {
-      const revalidation = revalidate(WITH_DEDUPE)
-      if (!isUndefined(returnedData)) {
-        // @ts-ignore modify react promise status
-        revalidation.status = 'fulfilled'
-        // @ts-ignore modify react promise value
-        revalidation.value = true
-      }
-      use(revalidation)
+    const revalidation = hasKeyButNoData
+      ? revalidate(WITH_DEDUPE)
+      : resolvedUndef
+    if (!isUndefined(returnedData) && hasKeyButNoData) {
+      // @ts-ignore modify react promise status
+      revalidation.status = 'fulfilled'
+      // @ts-ignore modify react promise value
+      revalidation.value = true
     }
+    use(revalidation)
   }
 
   const swrResponse: SWRResponse<Data, Error> = {

--- a/test/use-swr-server.test.tsx
+++ b/test/use-swr-server.test.tsx
@@ -4,10 +4,13 @@ import { screen, render } from '@testing-library/react'
 import { Suspense } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 
+// Keep React as the shared singleton while isolated module registries import SWR.
 // https://github.com/jestjs/jest/issues/11471
 jest.mock('react', () => jest.requireActual('react'))
 
 async function withServer(runner: () => Promise<void>) {
+  // Import SWR in a fresh module registry so server globals are observed at
+  // import time and module-level promises are not tagged by earlier tests.
   await jest.isolateModulesAsync(async () => {
     await runner()
   })
@@ -86,6 +89,42 @@ describe('useSWR - SSR', () => {
         await screen.findByText(
           'Fallback data is required when using Suspense in SSR.'
         )
+      })
+    })
+
+    it('should not suspend when fallbackData is a fulfilled promise', async () => {
+      await withServer(async () => {
+        // Import SWR inside the isolated module registry so earlier tests cannot
+        // hide this regression by letting React tag module-level thenables first.
+        const useSWR = (await import('swr')).default
+        const fallbackData = Promise.resolve('fallback data')
+        // React can pass already-fulfilled server promises as tagged thenables.
+        // This simulates that shape so the test isolates SWR's Suspense path.
+        // @ts-expect-error modify react promise status
+        fallbackData.status = 'fulfilled'
+        // @ts-expect-error modify react promise value
+        fallbackData.value = 'fallback data'
+
+        const Page = () => {
+          const { data } = useSWR('suspense-fulfilled-fallback', () => 'SWR', {
+            fallbackData,
+            // Avoid stale revalidation so the only suspend candidate is SWR's no-op promise.
+            revalidateIfStale: false,
+            suspense: true
+          })
+          return <div>{data}</div>
+        }
+
+        render(
+          <Suspense fallback={<div>loading</div>}>
+            <Page />
+          </Suspense>
+        )
+
+        // Any fallback render means SWR suspended despite fulfilled fallback data.
+        const loadingFallback = screen.queryByText('loading')
+        expect(loadingFallback === null).toBe(true)
+        screen.getByText('fallback data')
       })
     })
   })

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { Profiler, act } from 'react'
 import { Suspense, useReducer, useState } from 'react'
 import useSWR, { mutate } from 'swr'
@@ -11,6 +11,10 @@ import {
   sleep
 } from './utils'
 import { ErrorBoundary } from 'react-error-boundary'
+
+// Keep React as the shared singleton while isolated module registries import SWR.
+// https://github.com/jestjs/jest/issues/11471
+jest.mock('react', () => jest.requireActual('react'))
 
 describe('useSWR - suspense', () => {
   afterEach(() => {
@@ -365,6 +369,33 @@ describe('useSWR - suspense', () => {
       expect(renderCount).toBe(1) // data
     }
   )
+
+  itShouldSkipForReactCanary('should not suspend for null key', async () => {
+    // Import SWR inside the isolated module registry so earlier tests cannot
+    // hide this regression by letting React tag module-level thenables first.
+    await jest.isolateModulesAsync(async () => {
+      const isolatedUseSWR = (await import('swr')).default
+      const fetcher = jest.fn(() => createResponse('SWR'))
+
+      function Page() {
+        // A null key disables fetching, but the hook still runs in Suspense mode.
+        const { data } = isolatedUseSWR(null, fetcher, { suspense: true })
+        return <div>{data || 'empty'}</div>
+      }
+
+      render(
+        <Suspense fallback={<div>fallback</div>}>
+          <Page />
+        </Suspense>
+      )
+
+      // With no request for a null key, there is nothing for Suspense to show.
+      const fallback = screen.queryByText('fallback')
+      expect(fallback === null).toBe(true)
+      screen.getByText('empty')
+      expect(fetcher).toHaveBeenCalledTimes(0)
+    })
+  })
 
   itShouldSkipForReactCanary(
     'should return `undefined` data for falsy key',


### PR DESCRIPTION
### Why?

Current behavior: https://github.com/vercel/swr/actions/runs/27748306911/job/82092031539?pr=4271#step:4:714

In SWR Suspense mode, when the promise is already fulfilled, React does not have to suspend. However, there are paths where SWR consumes an internal promise that resolves to `undefined` instead, and because that promise did not have `status` attached, React could not know it's status on the initial consume, so it suspended.

This caused the hook to unnecessarily suspend in conditions where it did not really have to on the client, such as during a sync update or hydration, which could show a Suspense fallback even after the SSR'd content has been rendered.

By marking the internal `undefined` promise as fulfilled, SWR ensures consuming that does not suspend and only suspends when the actual data promise is not fulfilled.

React thenable x-ref: https://github.com/react/react/blob/560db51408f4c186016ccdd8062af75a77c22104/packages/react-reconciler/src/ReactFiberThenable.js#L187-L302

### How?

- Mark SWR's internal `resolvedUndef` promise as fulfilled with an `undefined` value so `use(resolvedUndef)` returns synchronously.
- Add regression coverage for fulfilled promise `fallbackData` and null-key Suspense paths; these tests fail before the fix and pass after it.