### PR TITLE
fix: point _internal react-server export at existing file

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       }
     },
     "./_internal": {
-      "react-server": "./dist/_internal/react-server.mjs",
+      "react-server": "./dist/_internal/index.react-server.mjs",
       "import": {
         "types": "./dist/_internal/index.d.mts",
         "default": "./dist/_internal/index.mjs"
@@ -178,3 +178,4 @@
     "use-sync-external-store": "^1.6.0"
   }
 }
+


### PR DESCRIPTION
## Summary

`exports["./_internal"].react-server` currently points at `./dist/_internal/react-server.mjs`, but the published package contains `./dist/_internal/index.react-server.mjs` instead.

This updates the export target to match the emitted file name used in the package tarball.

## Reproduction

```sh
npm init -y
npm install swr@2.4.1 --ignore-scripts --no-audit --no-fund
node --conditions react-server -e "console.log(import.meta.resolve('swr/_internal'))"
```

Before this change, the react-server condition resolves to the missing file:

```text
node_modules/swr/dist/_internal/react-server.mjs
```

The tarball contains:

```text
node_modules/swr/dist/_internal/index.react-server.mjs
```

## Validation

Locally patched `node_modules/swr/package.json` and verified the same resolution now points at the existing file:

```text
node_modules/swr/dist/_internal/index.react-server.mjs
```

No package scripts were run for this check.
