### PR TITLE
Fix _internal react-server export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
       }
     },
     "./_internal": {
-      "react-server": "./dist/_internal/react-server.mjs",
+      "react-server": "./dist/_internal/index.react-server.mjs",
       "import": {
         "types": "./dist/_internal/index.d.mts",
         "default": "./dist/_internal/index.mjs"


### PR DESCRIPTION
## Summary

- point the `swr/_internal` `react-server` export at the published `index.react-server.mjs` bundle
- keep the existing import/require/type export targets unchanged

## Problem

The published `swr@2.4.1` package declares:

```json
"./_internal": {
  "react-server": "./dist/_internal/react-server.mjs"
}
```

but the tarball does not contain `dist/_internal/react-server.mjs`. It does contain `dist/_internal/index.react-server.mjs`, so resolving `swr/_internal` with the `react-server` condition fails before consumers can load the package.

## Scope

This PR only changes the `_internal` package export path in `package.json`. It does not change runtime code, build scripts, generated artifacts, dependencies, public import/require targets, or type declarations.

## Validation

```text
npm install swr@2.4.1 --ignore-scripts --no-audit --no-fund --prefix F:\消耗token\swr-repro
node -e "import('swr/_internal').then(()=>console.log('default import ok'))"
# default import ok

node --conditions react-server -e "import('swr/_internal')"
# before the metadata fix: ERR_MODULE_NOT_FOUND for dist/_internal/react-server.mjs

node --conditions react-server --input-type=module -e "console.log(await import.meta.resolve('swr/_internal'))"
# after applying the same export-path fix locally: .../node_modules/swr/dist/_internal/index.react-server.mjs

node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('package json ok')"
# package json ok

git diff --check
# passed
```

`pnpm exec prettier --check package.json` could not run because dependencies are not installed in this clean checkout. `npm pack --dry-run --ignore-scripts` still invoked the repository `prepare` script under the local npm version and failed because `husky` was not installed, so I did not use it as evidence.

AI assistance disclosure: this PR was prepared with AI assistance and manually checked against the published package metadata and tarball contents.
