### PR TITLE
ci: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -64,9 +64,11 @@ jobs:
       - name: Install
         uses: ./.github/workflows/install
 
-      # OIDC trusted publishing requires npm >= 11.5.1
-      - name: Update npm
-        run: npm install -g npm@latest
+      # OIDC trusted publishing requires npm >= 11.5.1. Corepack is already
+      # enabled by the install action, so use it to pin npm instead of a
+      # global install.
+      - name: Pin npm via corepack
+        run: corepack prepare npm@11.5.1 --activate
 
       - name: Determine tag
         id: determine_tag

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Install
         uses: ./.github/workflows/install
 
+      # OIDC trusted publishing requires npm >= 11.5.1
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Determine tag
         id: determine_tag
         run: |
@@ -73,14 +77,10 @@ jobs:
         if: steps.determine_tag.outputs.tag != ''
         run: |
           echo "Publishing to ${{ steps.determine_tag.outputs.tag }} tag"
-          npm publish --access public --no-git-checks --provenance --tag ${{ steps.determine_tag.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          npm publish --access public --no-git-checks --tag ${{ steps.determine_tag.outputs.tag }}
 
       - name: Publish to latest
         if: steps.determine_tag.outputs.tag == ''
         run: |
           echo "Publishing to latest"
-          npm publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}
+          npm publish --access public --no-git-checks

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -64,11 +64,9 @@ jobs:
       - name: Install
         uses: ./.github/workflows/install
 
-      # OIDC trusted publishing requires npm >= 11.5.1. Corepack is already
-      # enabled by the install action, so use it to pin npm instead of a
-      # global install.
-      - name: Pin npm via corepack
-        run: corepack prepare npm@11.5.1 --activate
+      # OIDC trusted publishing requires npm >= 11.5.1
+      - name: Install npm 11
+        run: npm install -g npm@11
 
       - name: Determine tag
         id: determine_tag


### PR DESCRIPTION
The release pipeline currently authenticates `npm publish` with a long-lived `NPM_TOKEN_ELEVATED` secret. This moves it to npm's OIDC [trusted publishing](https://docs.npmjs.com/trusted-publishers), which removes the need to store and rotate a publish token.

### What changed
- Removed the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_ELEVATED }}` env from both publish steps in the `release` job — auth now flows through the existing `id-token: write` permission via OIDC.
- Dropped the explicit `--provenance` flag, since provenance is generated automatically under trusted publishing.
- Pinned npm to `latest` in the release job, as trusted publishing requires npm >= 11.5.1 (Node 24's bundled npm may be older).

### Before merging
`swr` must be configured as a trusted publisher for this repo/workflow on npmjs.com (Package settings → Trusted Publisher), pointing at `.github/workflows/test-release.yml`. Once that's set, the `NPM_TOKEN_ELEVATED` secret can be deleted.