### PR TITLE
feat: rsc fetches and prefill swr cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage
 .rollup.cache
 playwright-report
 test-results
+e2e/site/next-env.d.ts

--- a/e2e/site/app/rsc-unstable-preload-conditional/client.tsx
+++ b/e2e/site/app/rsc-unstable-preload-conditional/client.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { Suspense, useCallback, useState } from 'react'
+import useSWR, { SWRConfig, useSWRConfig } from 'swr'
+import type { CacheData } from 'swr'
+import { key } from './key'
+
+function ClientData({
+  fetcher,
+  clientFetches
+}: {
+  fetcher: () => Promise<string>
+  clientFetches: number
+}) {
+  const { cache } = useSWRConfig()
+  const { data, mutate } = useSWR(key, fetcher, { suspense: true })
+  const cachedData = cache.get(key)?.data
+
+  return (
+    <>
+      <div data-testid="data">data:{data}</div>
+      <div data-testid="cache">cache:{cachedData}</div>
+      <div data-testid="client-fetches">client fetches:{clientFetches}</div>
+      <button data-testid="revalidate" onClick={() => void mutate()}>
+        revalidate
+      </button>
+    </>
+  )
+}
+
+export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
+  const [clientFetches, setClientFetches] = useState(0)
+  const fetcher = useCallback(async () => {
+    ;(
+      window as typeof window & {
+        __SWR_RSC_CLIENT_FETCHER_CALLED__?: () => void
+      }
+    ).__SWR_RSC_CLIENT_FETCHER_CALLED__?.()
+    queueMicrotask(() => setClientFetches(count => count + 1))
+    return 'CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
+  }, [])
+
+  return (
+    <SWRConfig value={{ cacheData }}>
+      <Suspense fallback={<div data-testid="fallback">loading</div>}>
+        <ClientData fetcher={fetcher} clientFetches={clientFetches} />
+      </Suspense>
+    </SWRConfig>
+  )
+}

--- a/e2e/site/app/rsc-unstable-preload-conditional/key.ts
+++ b/e2e/site/app/rsc-unstable-preload-conditional/key.ts
@@ -1,0 +1,1 @@
+export const key = 'rsc-unstable-preload-conditional'

--- a/e2e/site/app/rsc-unstable-preload-conditional/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload-conditional/page.tsx
@@ -1,10 +1,9 @@
+import { connection } from 'next/server'
 import { preload } from 'swr'
 import type { CacheData } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
-
-export const dynamic = 'force-dynamic'
 
 async function getServerData() {
   await sleep(150)
@@ -16,6 +15,9 @@ export default async function Page({
 }: {
   searchParams: Promise<{ preload?: string }>
 }) {
+  // Opt into dynamic rendering so each request preloads fresh server data.
+  await connection()
+
   const { preload: shouldPreload } = await searchParams
 
   // Only preload when the search param is present. A request that preloaded

--- a/e2e/site/app/rsc-unstable-preload-conditional/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload-conditional/page.tsx
@@ -1,0 +1,31 @@
+import { preload } from 'swr'
+import type { CacheData } from 'swr'
+import { sleep } from '~/lib/sleep'
+import { ClientRoot } from './client'
+import { key } from './key'
+
+export const dynamic = 'force-dynamic'
+
+async function getServerData() {
+  await sleep(150)
+  return 'SWR_RSC_PRELOAD_CONDITIONAL_MARKER_20260621'
+}
+
+export default async function Page({
+  searchParams
+}: {
+  searchParams: Promise<{ preload?: string }>
+}) {
+  const { preload: shouldPreload } = await searchParams
+
+  // Only preload when the search param is present. A request that preloaded
+  // must not leak its server-loaded data into a later request that didn't,
+  // since the SWR global state is shared across requests on the server.
+  // Runtime resolves the react-server export; this app's type checker still
+  // reads the default client preload signature.
+  const cacheData = (shouldPreload
+    ? preload(key, getServerData)
+    : {}) as unknown as CacheData<string>
+
+  return <ClientRoot cacheData={cacheData} />
+}

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/client.tsx
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/client.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useState } from 'react'
 import useSWR, { SWRConfig, useSWRConfig } from 'swr'
-import type { UnstablePreloadEntry } from 'swr'
+import type { CacheData } from 'swr'
 import { key } from './key'
 
 function ClientData({
@@ -30,11 +30,7 @@ function ClientData({
   )
 }
 
-export function ClientRoot({
-  preload
-}: {
-  preload: UnstablePreloadEntry<string>
-}) {
+export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
   const [clientFetches, setClientFetches] = useState(0)
   const fetcher = useCallback(async () => {
     ;(
@@ -47,7 +43,7 @@ export function ClientRoot({
   }, [])
 
   return (
-    <SWRConfig value={{ unstable_preload: [preload] }}>
+    <SWRConfig value={{ cacheData }}>
       <ClientData fetcher={fetcher} clientFetches={clientFetches} />
     </SWRConfig>
   )

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/client.tsx
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useCallback, useState } from 'react'
+import { useCallback, useState } from 'react'
 import useSWR, { SWRConfig, useSWRConfig } from 'swr'
 import type { UnstablePreloadEntry } from 'swr'
 import { key } from './key'
@@ -13,12 +13,14 @@ function ClientData({
   clientFetches: number
 }) {
   const { cache } = useSWRConfig()
-  const { data, mutate } = useSWR(key, fetcher, { suspense: true })
+  const { data, isLoading, isValidating, mutate } = useSWR(key, fetcher)
   const cachedData = cache.get(key)?.data
 
   return (
     <>
       <div data-testid="data">data:{data}</div>
+      <div data-testid="loading">loading:{`${isLoading}`}</div>
+      <div data-testid="validating">validating:{`${isValidating}`}</div>
       <div data-testid="cache">cache:{cachedData}</div>
       <div data-testid="client-fetches">client fetches:{clientFetches}</div>
       <button data-testid="revalidate" onClick={() => void mutate()}>
@@ -46,9 +48,7 @@ export function ClientRoot({
 
   return (
     <SWRConfig value={{ unstable_preload: [preload] }}>
-      <Suspense fallback={<div data-testid="fallback">loading</div>}>
-        <ClientData fetcher={fetcher} clientFetches={clientFetches} />
-      </Suspense>
+      <ClientData fetcher={fetcher} clientFetches={clientFetches} />
     </SWRConfig>
   )
 }

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/key.ts
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/key.ts
@@ -1,0 +1,1 @@
+export const key = 'rsc-unstable-preload-no-suspense'

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic'
 
 async function getServerData() {
   await sleep(150)
-  return 'SWR_RSC_PRELOAD_FLIGHT_MARKER_20260621'
+  return 'SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
 }
 
 export default function Page() {

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
@@ -1,17 +1,19 @@
+import { connection } from 'next/server'
 import { preload } from 'swr'
 import type { CacheData } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
 
-export const dynamic = 'force-dynamic'
-
 async function getServerData() {
   await sleep(150)
   return 'SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
 }
 
-export default function Page() {
+export default async function Page() {
+  // Opt into dynamic rendering so each request preloads fresh server data.
+  await connection()
+
   // Runtime resolves the react-server export; this app's type checker still
   // reads the default client preload signature.
   const cacheData = preload(key, getServerData) as unknown as CacheData<string>

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
@@ -1,4 +1,5 @@
 import { preload } from 'swr'
+import type { CacheData } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
@@ -11,7 +12,9 @@ async function getServerData() {
 }
 
 export default function Page() {
-  const cacheData = preload(key, getServerData)
+  // Runtime resolves the react-server export; this app's type checker still
+  // reads the default client preload signature.
+  const cacheData = preload(key, getServerData) as unknown as CacheData<string>
 
   return <ClientRoot cacheData={cacheData} />
 }

--- a/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_preload } from 'swr'
+import { preload } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
@@ -11,7 +11,7 @@ async function getServerData() {
 }
 
 export default function Page() {
-  const serverData = unstable_preload(key, getServerData)
+  const cacheData = preload(key, getServerData)
 
-  return <ClientRoot preload={serverData} />
+  return <ClientRoot cacheData={cacheData} />
 }

--- a/e2e/site/app/rsc-unstable-preload/client.tsx
+++ b/e2e/site/app/rsc-unstable-preload/client.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { Suspense } from 'react'
+import useSWR, { SWRConfig, useSWRConfig } from 'swr'
+import type { UnstablePreloadEntry } from 'swr'
+import { key } from './key'
+
+let clientFetches = 0
+
+async function fetcher() {
+  clientFetches += 1
+  return 'client data'
+}
+
+function ClientData() {
+  const { cache } = useSWRConfig()
+  const { data } = useSWR(key, fetcher, {
+    suspense: true,
+    revalidateIfStale: false
+  })
+  const cachedData = cache.get(key)?.data
+
+  return (
+    <>
+      <div data-testid="data">data:{data}</div>
+      <div data-testid="cache">cache:{cachedData}</div>
+      <div data-testid="client-fetches">client fetches:{clientFetches}</div>
+    </>
+  )
+}
+
+export function ClientRoot({
+  preload
+}: {
+  preload: UnstablePreloadEntry<string>
+}) {
+  return (
+    <SWRConfig value={{ unstable_preload: [preload] }}>
+      <Suspense fallback={<div data-testid="fallback">loading</div>}>
+        <ClientData />
+      </Suspense>
+    </SWRConfig>
+  )
+}

--- a/e2e/site/app/rsc-unstable-preload/client.tsx
+++ b/e2e/site/app/rsc-unstable-preload/client.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useCallback, useState } from 'react'
 import useSWR, { SWRConfig, useSWRConfig } from 'swr'
-import type { UnstablePreloadEntry } from 'swr'
+import type { CacheData } from 'swr'
 import { key } from './key'
 
 function ClientData({
@@ -28,11 +28,7 @@ function ClientData({
   )
 }
 
-export function ClientRoot({
-  preload
-}: {
-  preload: UnstablePreloadEntry<string>
-}) {
+export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
   const [clientFetches, setClientFetches] = useState(0)
   const fetcher = useCallback(async () => {
     ;(
@@ -45,7 +41,7 @@ export function ClientRoot({
   }, [])
 
   return (
-    <SWRConfig value={{ unstable_preload: [preload] }}>
+    <SWRConfig value={{ cacheData }}>
       <Suspense fallback={<div data-testid="fallback">loading</div>}>
         <ClientData fetcher={fetcher} clientFetches={clientFetches} />
       </Suspense>

--- a/e2e/site/app/rsc-unstable-preload/key.ts
+++ b/e2e/site/app/rsc-unstable-preload/key.ts
@@ -1,0 +1,1 @@
+export const key = 'rsc-unstable-preload'

--- a/e2e/site/app/rsc-unstable-preload/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload/page.tsx
@@ -1,0 +1,17 @@
+import { unstable_preload } from 'swr'
+import { sleep } from '~/lib/sleep'
+import { ClientRoot } from './client'
+import { key } from './key'
+
+export const dynamic = 'force-dynamic'
+
+async function getServerData() {
+  await sleep(150)
+  return 'server data'
+}
+
+export default function Page() {
+  const serverData = unstable_preload(key, getServerData)
+
+  return <ClientRoot preload={serverData} />
+}

--- a/e2e/site/app/rsc-unstable-preload/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload/page.tsx
@@ -1,4 +1,5 @@
 import { preload } from 'swr'
+import type { CacheData } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
@@ -11,7 +12,9 @@ async function getServerData() {
 }
 
 export default function Page() {
-  const cacheData = preload(key, getServerData)
+  // Runtime resolves the react-server export; this app's type checker still
+  // reads the default client preload signature.
+  const cacheData = preload(key, getServerData) as unknown as CacheData<string>
 
   return <ClientRoot cacheData={cacheData} />
 }

--- a/e2e/site/app/rsc-unstable-preload/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload/page.tsx
@@ -1,17 +1,19 @@
+import { connection } from 'next/server'
 import { preload } from 'swr'
 import type { CacheData } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
 
-export const dynamic = 'force-dynamic'
-
 async function getServerData() {
   await sleep(150)
   return 'SWR_RSC_PRELOAD_FLIGHT_MARKER_20260621'
 }
 
-export default function Page() {
+export default async function Page() {
+  // Opt into dynamic rendering so each request preloads fresh server data.
+  await connection()
+
   // Runtime resolves the react-server export; this app's type checker still
   // reads the default client preload signature.
   const cacheData = preload(key, getServerData) as unknown as CacheData<string>

--- a/e2e/site/app/rsc-unstable-preload/page.tsx
+++ b/e2e/site/app/rsc-unstable-preload/page.tsx
@@ -1,4 +1,4 @@
-import { unstable_preload } from 'swr'
+import { preload } from 'swr'
 import { sleep } from '~/lib/sleep'
 import { ClientRoot } from './client'
 import { key } from './key'
@@ -11,7 +11,7 @@ async function getServerData() {
 }
 
 export default function Page() {
-  const serverData = unstable_preload(key, getServerData)
+  const cacheData = preload(key, getServerData)
 
-  return <ClientRoot preload={serverData} />
+  return <ClientRoot cacheData={cacheData} />
 }

--- a/e2e/site/next-env.d.ts
+++ b/e2e/site/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
-import './.next/types/routes.d.ts'
+import './.next/dev/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/e2e/site/next-env.d.ts
+++ b/e2e/site/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
-import './.next/dev/types/routes.d.ts'
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/e2e/test/promise-scenarios.test.ts
+++ b/e2e/test/promise-scenarios.test.ts
@@ -46,9 +46,7 @@ test.describe('promise scenarios', () => {
     await expect(page.getByTestId('fallback')).toHaveCount(0)
   })
 
-  test('hydrates unstable_preload server data into the client cache', async ({
-    page
-  }) => {
+  test('hydrates preload cacheData into the client cache', async ({ page }) => {
     let clientFetcherCalls = 0
     await page.exposeFunction('__SWR_RSC_CLIENT_FETCHER_CALLED__', () => {
       clientFetcherCalls += 1
@@ -87,7 +85,7 @@ test.describe('promise scenarios', () => {
     )
   })
 
-  test('uses unstable_preload without suspense and skips the client fetcher', async ({
+  test('uses preload cacheData without suspense and skips the client fetcher', async ({
     page
   }) => {
     let clientFetcherCalls = 0

--- a/e2e/test/promise-scenarios.test.ts
+++ b/e2e/test/promise-scenarios.test.ts
@@ -45,4 +45,19 @@ test.describe('promise scenarios', () => {
     await expect(page.getByTestId('data-second')).toHaveText('data:value')
     await expect(page.getByTestId('fallback')).toHaveCount(0)
   })
+
+  test('hydrates unstable_preload server data into the client cache', async ({
+    page
+  }) => {
+    await page.goto('./rsc-unstable-preload', {
+      waitUntil: 'commit'
+    })
+
+    await expect(page.getByTestId('data')).toHaveText('data:server data')
+    await expect(page.getByTestId('cache')).toHaveText('cache:server data')
+    await expect(page.getByTestId('client-fetches')).toHaveText(
+      'client fetches:0'
+    )
+    await expect(page.getByTestId('fallback')).toHaveCount(0)
+  })
 })

--- a/e2e/test/promise-scenarios.test.ts
+++ b/e2e/test/promise-scenarios.test.ts
@@ -49,15 +49,83 @@ test.describe('promise scenarios', () => {
   test('hydrates unstable_preload server data into the client cache', async ({
     page
   }) => {
+    let clientFetcherCalls = 0
+    await page.exposeFunction('__SWR_RSC_CLIENT_FETCHER_CALLED__', () => {
+      clientFetcherCalls += 1
+    })
+
     await page.goto('./rsc-unstable-preload', {
       waitUntil: 'commit'
     })
 
-    await expect(page.getByTestId('data')).toHaveText('data:server data')
-    await expect(page.getByTestId('cache')).toHaveText('cache:server data')
+    await expect(page.getByTestId('data')).toHaveText(
+      'data:SWR_RSC_PRELOAD_FLIGHT_MARKER_20260621'
+    )
+    await expect(page.getByTestId('cache')).toHaveText(
+      'cache:SWR_RSC_PRELOAD_FLIGHT_MARKER_20260621'
+    )
     await expect(page.getByTestId('client-fetches')).toHaveText(
       'client fetches:0'
     )
     await expect(page.getByTestId('fallback')).toHaveCount(0)
+    await expect(
+      page.getByText('CLIENT_FETCHER_RESULT_AFTER_TRIGGER')
+    ).toHaveCount(0)
+    expect(clientFetcherCalls).toBe(0)
+
+    await page.getByTestId('revalidate').click()
+
+    await expect.poll(() => clientFetcherCalls).toBe(1)
+    await expect(page.getByTestId('data')).toHaveText(
+      'data:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
+    )
+    await expect(page.getByTestId('cache')).toHaveText(
+      'cache:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
+    )
+    await expect(page.getByTestId('client-fetches')).toHaveText(
+      'client fetches:1'
+    )
+  })
+
+  test('uses unstable_preload without suspense and skips the client fetcher', async ({
+    page
+  }) => {
+    let clientFetcherCalls = 0
+    await page.exposeFunction('__SWR_RSC_CLIENT_FETCHER_CALLED__', () => {
+      clientFetcherCalls += 1
+    })
+
+    await page.goto('./rsc-unstable-preload-no-suspense', {
+      waitUntil: 'commit'
+    })
+
+    await expect(page.getByTestId('data')).toHaveText(
+      'data:SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
+    )
+    await expect(page.getByTestId('loading')).toHaveText('loading:false')
+    await expect(page.getByTestId('validating')).toHaveText('validating:false')
+    await expect(page.getByTestId('cache')).toHaveText(
+      'cache:SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
+    )
+    await expect(page.getByTestId('client-fetches')).toHaveText(
+      'client fetches:0'
+    )
+    await expect(
+      page.getByText('CLIENT_FETCHER_RESULT_AFTER_TRIGGER')
+    ).toHaveCount(0)
+    expect(clientFetcherCalls).toBe(0)
+
+    await page.getByTestId('revalidate').click()
+
+    await expect.poll(() => clientFetcherCalls).toBe(1)
+    await expect(page.getByTestId('data')).toHaveText(
+      'data:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
+    )
+    await expect(page.getByTestId('cache')).toHaveText(
+      'cache:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
+    )
+    await expect(page.getByTestId('client-fetches')).toHaveText(
+      'client fetches:1'
+    )
   })
 })

--- a/e2e/test/promise-scenarios.test.ts
+++ b/e2e/test/promise-scenarios.test.ts
@@ -126,4 +126,22 @@ test.describe('promise scenarios', () => {
       'client fetches:1'
     )
   })
+
+  test('does not leak preloaded cacheData across requests', async ({
+    request
+  }) => {
+    const marker = 'SWR_RSC_PRELOAD_CONDITIONAL_MARKER_20260621'
+
+    // A request that preloads on the server renders the server-loaded value.
+    const preloaded = await request.get(
+      './rsc-unstable-preload-conditional?preload=1'
+    )
+    expect(await preloaded.text()).toContain(marker)
+
+    // A later request that does not preload must not reuse the previous
+    // request's server-loaded value. SWR's global state is shared across
+    // requests on the server, so the server output must not contain the marker.
+    const notPreloaded = await request.get('./rsc-unstable-preload-conditional')
+    expect(await notPreloaded.text()).not.toContain(marker)
+  })
 })

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "react-server": "./dist/index/react-server.mjs",
+      "react-server": {
+        "types": "./dist/index/react-server.d.mts",
+        "default": "./dist/index/react-server.mjs"
+      },
       "import": {
         "types": "./dist/index/index.d.mts",
         "default": "./dist/index/index.mjs"

--- a/src/_internal/index.react-server.ts
+++ b/src/_internal/index.react-server.ts
@@ -1,4 +1,4 @@
 export { serialize } from './utils/serialize'
 export { SWRConfig } from './index'
 export { INFINITE_PREFIX } from './constants'
-export { unstable_preload } from './utils/unstable-preload'
+export { preload } from './utils/server-preload'

--- a/src/_internal/index.react-server.ts
+++ b/src/_internal/index.react-server.ts
@@ -1,3 +1,4 @@
 export { serialize } from './utils/serialize'
 export { SWRConfig } from './index'
 export { INFINITE_PREFIX } from './constants'
+export { unstable_preload } from './utils/unstable-preload'

--- a/src/_internal/index.ts
+++ b/src/_internal/index.ts
@@ -23,6 +23,7 @@ export { useSWRConfig } from './utils/use-swr-config'
 export { preset, defaultConfigOptions } from './utils/web-preset'
 export { withMiddleware } from './utils/with-middleware'
 export { preload } from './utils/preload'
+export { unstable_preload } from './utils/unstable-preload'
 
 export * from './types'
 

--- a/src/_internal/index.ts
+++ b/src/_internal/index.ts
@@ -23,7 +23,6 @@ export { useSWRConfig } from './utils/use-swr-config'
 export { preset, defaultConfigOptions } from './utils/web-preset'
 export { withMiddleware } from './utils/with-middleware'
 export { preload } from './utils/preload'
-export { unstable_preload } from './utils/unstable-preload'
 
 export * from './types'
 

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -17,7 +17,7 @@ export type GlobalState = [
   /** Fetch cache: Maps cache keys to [data, timestamp] tuples */
   Record<string, [any, number]>,
   /** Preload cache: Maps cache keys to fetcher responses */
-  Record<string, FetcherResponse<any>>,
+  Record<string, PreloadResponse<any>>,
   /** Scoped mutator function for cache updates */
   ScopedMutator,
   /** Cache setter function with prev/current value comparison */
@@ -32,6 +32,13 @@ export type GlobalState = [
  * @public
  */
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
+
+export type PreloadResponse<Data = any> =
+  | FetcherResponse<Data>
+  | {
+      data: FetcherResponse<Data>
+      _unstable_preload: true
+    }
 
 /**
  * Preloaded data entry produced on the server and consumed by SWRConfig on the

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -280,11 +280,6 @@ export interface PublicConfiguration<
    */
   fallback: { [key: string]: any }
   /**
-   * server-loaded data to be consumed by client hooks and written into cache
-   * @experimental
-   */
-  cacheData?: CacheData
-  /**
    * Function to detect whether pause revalidations, will ignore fetched data and errors when it returns true. Returns false by default.
    */
   isPaused: () => boolean
@@ -345,7 +340,14 @@ export type FullConfiguration<
   Data = any,
   Error = any,
   Fn extends Fetcher = BareFetcher
-> = InternalConfiguration & PublicConfiguration<Data, Error, Fn>
+> = InternalConfiguration &
+  PublicConfiguration<Data, Error, Fn> & {
+    /**
+     * server-loaded data to be consumed by client hooks and written into cache
+     * @experimental
+     */
+    cacheData?: CacheData<Data>
+  }
 
 /**
  * Provider configuration for custom focus and reconnect event handling.
@@ -1001,7 +1003,20 @@ export type SWRConfiguration<
 > = Partial<PublicConfiguration<Data, Error, Fn>> &
   Partial<ProviderConfiguration> & {
     provider?: (cache: Readonly<Cache>) => Cache
+    cacheData?: never
   }
+
+export type SWRConfigValue<
+  Data = any,
+  Error = any,
+  Fn extends BareFetcher<any> = BareFetcher<any>
+> = Omit<SWRConfiguration<Data, Error, Fn>, 'cacheData'> & {
+  /**
+   * server-loaded data to be consumed by client hooks and written into cache
+   * @experimental
+   */
+  cacheData?: CacheData<Data>
+}
 
 export type IsLoadingResponse<
   Data = any,

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -17,7 +17,7 @@ export type GlobalState = [
   /** Fetch cache: Maps cache keys to [data, timestamp] tuples */
   Record<string, [any, number]>,
   /** Preload cache: Maps cache keys to fetcher responses */
-  Record<string, PreloadResponse<any>>,
+  Record<string, FetcherResponse<any>>,
   /** Scoped mutator function for cache updates */
   ScopedMutator,
   /** Cache setter function with prev/current value comparison */
@@ -32,13 +32,6 @@ export type GlobalState = [
  * @public
  */
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
-
-export type PreloadResponse<Data = any> =
-  | FetcherResponse<Data>
-  | {
-      data: FetcherResponse<Data>
-      _cacheData: true
-    }
 
 /**
  * Cache data produced on the server and consumed by SWRConfig on the client.

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -34,6 +34,18 @@ export type GlobalState = [
 export type FetcherResponse<Data = unknown> = Data | Promise<Data>
 
 /**
+ * Preloaded data entry produced on the server and consumed by SWRConfig on the
+ * client.
+ *
+ * @experimental
+ * @public
+ */
+export type UnstablePreloadEntry<Data = any> = {
+  key: string
+  data: FetcherResponse<Data>
+}
+
+/**
  * Basic fetcher function that accepts any arguments and returns data or a promise.
  *
  * This is the most permissive fetcher type, allowing any number of arguments
@@ -262,6 +274,11 @@ export interface PublicConfiguration<
    * @see {@link https://swr.vercel.app/docs/with-nextjs#pre-rendering-with-default-data}
    */
   fallback: { [key: string]: any }
+  /**
+   * preloaded server data to be consumed by client hooks
+   * @experimental
+   */
+  unstable_preload?: UnstablePreloadEntry[]
   /**
    * Function to detect whether pause revalidations, will ignore fetched data and errors when it returns true. Returns false by default.
    */

--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -37,19 +37,17 @@ export type PreloadResponse<Data = any> =
   | FetcherResponse<Data>
   | {
       data: FetcherResponse<Data>
-      _unstable_preload: true
+      _cacheData: true
     }
 
 /**
- * Preloaded data entry produced on the server and consumed by SWRConfig on the
- * client.
+ * Cache data produced on the server and consumed by SWRConfig on the client.
  *
  * @experimental
  * @public
  */
-export type UnstablePreloadEntry<Data = any> = {
-  key: string
-  data: FetcherResponse<Data>
+export type CacheData<Data = any> = {
+  [key: string]: FetcherResponse<Data>
 }
 
 /**
@@ -282,10 +280,10 @@ export interface PublicConfiguration<
    */
   fallback: { [key: string]: any }
   /**
-   * preloaded server data to be consumed by client hooks
+   * server-loaded data to be consumed by client hooks and written into cache
    * @experimental
    */
-  unstable_preload?: UnstablePreloadEntry[]
+  cacheData?: CacheData
   /**
    * Function to detect whether pause revalidations, will ignore fetched data and errors when it returns true. Returns false by default.
    */

--- a/src/_internal/utils/config-context.ts
+++ b/src/_internal/utils/config-context.ts
@@ -11,9 +11,10 @@ import {
 import { cache as defaultCache } from './config'
 import { initCache } from './cache'
 import { mergeConfigs } from './merge-config'
-import { UNDEFINED, mergeObjects, isFunction } from './shared'
+import { UNDEFINED, mergeObjects, isFunction, isUndefined } from './shared'
 import { useIsomorphicLayoutEffect } from './env'
-import type { SWRConfiguration, FullConfiguration } from '../types'
+import { SWRGlobalState } from './global-state'
+import type { SWRConfiguration, FullConfiguration, GlobalState } from '../types'
 
 export const SWRConfigContext = createContext<Partial<FullConfiguration>>({})
 
@@ -54,6 +55,21 @@ const SWRConfig: FC<
   if (cacheContext) {
     ;(extendedConfig as any).cache = cacheContext[0]
     ;(extendedConfig as any).mutate = cacheContext[1]
+  }
+
+  const preload = extendedConfig && extendedConfig.unstable_preload
+  if (preload) {
+    const targetCache = (extendedConfig as any).cache || defaultCache
+    const [, , , PRELOAD] = SWRGlobalState.get(targetCache) as GlobalState
+    for (const { key, data } of preload) {
+      if (
+        key &&
+        isUndefined(targetCache.get(key)?.data) &&
+        isUndefined(PRELOAD[key])
+      ) {
+        PRELOAD[key] = data
+      }
+    }
   }
 
   // Unsubscribe events.

--- a/src/_internal/utils/config-context.ts
+++ b/src/_internal/utils/config-context.ts
@@ -14,22 +14,20 @@ import { mergeConfigs } from './merge-config'
 import { UNDEFINED, mergeObjects, isFunction, isUndefined } from './shared'
 import { useIsomorphicLayoutEffect } from './env'
 import { SWRGlobalState } from './global-state'
-import type { SWRConfiguration, FullConfiguration, GlobalState } from '../types'
+import type { SWRConfigValue, FullConfiguration, GlobalState } from '../types'
 
 export const SWRConfigContext = createContext<Partial<FullConfiguration>>({})
 
 const SWRConfig: FC<
   PropsWithChildren<{
-    value?:
-      | SWRConfiguration
-      | ((parentConfig?: SWRConfiguration) => SWRConfiguration)
+    value?: SWRConfigValue | ((parentConfig?: SWRConfigValue) => SWRConfigValue)
   }>
 > = props => {
   const { value } = props
   const parentConfig = useContext(SWRConfigContext)
   const isFunctionalConfig = isFunction(value)
   const config = useMemo(
-    () => (isFunctionalConfig ? value(parentConfig) : value),
+    () => (isFunctionalConfig ? value(parentConfig as SWRConfigValue) : value),
     [isFunctionalConfig, parentConfig, value]
   )
   // Extend parent context values and middleware.

--- a/src/_internal/utils/config-context.ts
+++ b/src/_internal/utils/config-context.ts
@@ -67,7 +67,10 @@ const SWRConfig: FC<
         isUndefined(targetCache.get(key)?.data) &&
         isUndefined(PRELOAD[key])
       ) {
-        PRELOAD[key] = data
+        PRELOAD[key] = {
+          data,
+          _unstable_preload: true
+        }
       }
     }
   }

--- a/src/_internal/utils/config-context.ts
+++ b/src/_internal/utils/config-context.ts
@@ -11,10 +11,9 @@ import {
 import { cache as defaultCache } from './config'
 import { initCache } from './cache'
 import { mergeConfigs } from './merge-config'
-import { UNDEFINED, mergeObjects, isFunction, isUndefined } from './shared'
+import { UNDEFINED, mergeObjects, isFunction } from './shared'
 import { useIsomorphicLayoutEffect } from './env'
-import { SWRGlobalState } from './global-state'
-import type { SWRConfigValue, FullConfiguration, GlobalState } from '../types'
+import type { SWRConfigValue, FullConfiguration } from '../types'
 
 export const SWRConfigContext = createContext<Partial<FullConfiguration>>({})
 
@@ -53,24 +52,6 @@ const SWRConfig: FC<
   if (cacheContext) {
     ;(extendedConfig as any).cache = cacheContext[0]
     ;(extendedConfig as any).mutate = cacheContext[1]
-  }
-
-  const cacheData = extendedConfig && extendedConfig.cacheData
-  if (cacheData) {
-    const targetCache = (extendedConfig as any).cache || defaultCache
-    const [, , , PRELOAD] = SWRGlobalState.get(targetCache) as GlobalState
-    for (const key in cacheData) {
-      if (
-        key &&
-        isUndefined(targetCache.get(key)?.data) &&
-        isUndefined(PRELOAD[key])
-      ) {
-        PRELOAD[key] = {
-          data: cacheData[key],
-          _cacheData: true
-        }
-      }
-    }
   }
 
   // Unsubscribe events.

--- a/src/_internal/utils/config-context.ts
+++ b/src/_internal/utils/config-context.ts
@@ -57,19 +57,19 @@ const SWRConfig: FC<
     ;(extendedConfig as any).mutate = cacheContext[1]
   }
 
-  const preload = extendedConfig && extendedConfig.unstable_preload
-  if (preload) {
+  const cacheData = extendedConfig && extendedConfig.cacheData
+  if (cacheData) {
     const targetCache = (extendedConfig as any).cache || defaultCache
     const [, , , PRELOAD] = SWRGlobalState.get(targetCache) as GlobalState
-    for (const { key, data } of preload) {
+    for (const key in cacheData) {
       if (
         key &&
         isUndefined(targetCache.get(key)?.data) &&
         isUndefined(PRELOAD[key])
       ) {
         PRELOAD[key] = {
-          data,
-          _unstable_preload: true
+          data: cacheData[key],
+          _cacheData: true
         }
       }
     }

--- a/src/_internal/utils/merge-config.ts
+++ b/src/_internal/utils/merge-config.ts
@@ -8,15 +8,19 @@ export const mergeConfigs = (
   // Need to create a new object to avoid mutating the original here.
   const v: Partial<FullConfiguration> = mergeObjects(a, b)
 
-  // If two configs are provided, merge their `use` and `fallback` options.
+  // If two configs are provided, merge their `use`, `fallback`, and
+  // `unstable_preload` options.
   if (b) {
-    const { use: u1, fallback: f1 } = a
-    const { use: u2, fallback: f2 } = b
+    const { use: u1, fallback: f1, unstable_preload: p1 } = a
+    const { use: u2, fallback: f2, unstable_preload: p2 } = b
     if (u1 && u2) {
       v.use = u1.concat(u2)
     }
     if (f1 && f2) {
       v.fallback = mergeObjects(f1, f2)
+    }
+    if (p1 && p2) {
+      v.unstable_preload = p1.concat(p2)
     }
   }
 

--- a/src/_internal/utils/merge-config.ts
+++ b/src/_internal/utils/merge-config.ts
@@ -9,18 +9,18 @@ export const mergeConfigs = (
   const v: Partial<FullConfiguration> = mergeObjects(a, b)
 
   // If two configs are provided, merge their `use`, `fallback`, and
-  // `unstable_preload` options.
+  // `cacheData` options.
   if (b) {
-    const { use: u1, fallback: f1, unstable_preload: p1 } = a
-    const { use: u2, fallback: f2, unstable_preload: p2 } = b
+    const { use: u1, fallback: f1, cacheData: c1 } = a
+    const { use: u2, fallback: f2, cacheData: c2 } = b
     if (u1 && u2) {
       v.use = u1.concat(u2)
     }
     if (f1 && f2) {
       v.fallback = mergeObjects(f1, f2)
     }
-    if (p1 && p2) {
-      v.unstable_preload = p1.concat(p2)
+    if (c1 && c2) {
+      v.cacheData = mergeObjects(c1, c2)
     }
   }
 

--- a/src/_internal/utils/preload.ts
+++ b/src/_internal/utils/preload.ts
@@ -13,11 +13,9 @@ import { INFINITE_PREFIX } from '../constants'
 import { IS_SERVER } from './env'
 
 const resolvePreloadResponse = <Data>(
-  req:
-    | FetcherResponse<Data>
-    | { data: FetcherResponse<Data>; _unstable_preload: true }
+  req: FetcherResponse<Data> | { data: FetcherResponse<Data>; _cacheData: true }
 ): FetcherResponse<Data> =>
-  req && typeof req == 'object' && (req as any)._unstable_preload
+  req && typeof req == 'object' && (req as any)._cacheData
     ? (req as { data: FetcherResponse<Data> }).data
     : (req as FetcherResponse<Data>)
 

--- a/src/_internal/utils/preload.ts
+++ b/src/_internal/utils/preload.ts
@@ -12,13 +12,6 @@ import { isUndefined } from './shared'
 import { INFINITE_PREFIX } from '../constants'
 import { IS_SERVER } from './env'
 
-const resolvePreloadResponse = <Data>(
-  req: FetcherResponse<Data> | { data: FetcherResponse<Data>; _cacheData: true }
-): FetcherResponse<Data> =>
-  req && typeof req == 'object' && (req as any)._cacheData
-    ? (req as { data: FetcherResponse<Data> }).data
-    : (req as FetcherResponse<Data>)
-
 // Basically same as Fetcher but without Conditional Fetching
 type PreloadFetcher<
   Data = unknown,
@@ -47,7 +40,7 @@ export const preload = <
 
   // Prevent preload to be called multiple times before used.
   if (PRELOAD[key]) {
-    return resolvePreloadResponse(PRELOAD[key]) as ReturnType<Fetcher>
+    return PRELOAD[key] as ReturnType<Fetcher>
   }
 
   const req = fetcher(fnArg) as ReturnType<Fetcher>
@@ -73,7 +66,7 @@ export const middleware: Middleware =
         const req = PRELOAD[key]
         if (isUndefined(req)) return fetcher_(...args)
         delete PRELOAD[key]
-        return resolvePreloadResponse(req)
+        return req
       })
     return useSWRNext(key_, fetcher, config)
   }

--- a/src/_internal/utils/preload.ts
+++ b/src/_internal/utils/preload.ts
@@ -52,7 +52,9 @@ export const middleware: Middleware =
       fetcher_ &&
       ((...args: any[]) => {
         const [key] = serialize(key_)
-        const [, , , PRELOAD] = SWRGlobalState.get(cache) as GlobalState
+        const [, , , PRELOAD] = SWRGlobalState.get(
+          (config as any).cache || cache
+        ) as GlobalState
 
         if (key.startsWith(INFINITE_PREFIX)) {
           // we want the infinite fetcher to be called.

--- a/src/_internal/utils/preload.ts
+++ b/src/_internal/utils/preload.ts
@@ -11,6 +11,16 @@ import { SWRGlobalState } from './global-state'
 import { isUndefined } from './shared'
 import { INFINITE_PREFIX } from '../constants'
 import { IS_SERVER } from './env'
+
+const resolvePreloadResponse = <Data>(
+  req:
+    | FetcherResponse<Data>
+    | { data: FetcherResponse<Data>; _unstable_preload: true }
+): FetcherResponse<Data> =>
+  req && typeof req == 'object' && (req as any)._unstable_preload
+    ? (req as { data: FetcherResponse<Data> }).data
+    : (req as FetcherResponse<Data>)
+
 // Basically same as Fetcher but without Conditional Fetching
 type PreloadFetcher<
   Data = unknown,
@@ -38,7 +48,9 @@ export const preload = <
   const [, , , PRELOAD] = SWRGlobalState.get(cache) as GlobalState
 
   // Prevent preload to be called multiple times before used.
-  if (PRELOAD[key]) return PRELOAD[key]
+  if (PRELOAD[key]) {
+    return resolvePreloadResponse(PRELOAD[key]) as ReturnType<Fetcher>
+  }
 
   const req = fetcher(fnArg) as ReturnType<Fetcher>
   PRELOAD[key] = req
@@ -52,9 +64,7 @@ export const middleware: Middleware =
       fetcher_ &&
       ((...args: any[]) => {
         const [key] = serialize(key_)
-        const [, , , PRELOAD] = SWRGlobalState.get(
-          (config as any).cache || cache
-        ) as GlobalState
+        const [, , , PRELOAD] = SWRGlobalState.get(cache) as GlobalState
 
         if (key.startsWith(INFINITE_PREFIX)) {
           // we want the infinite fetcher to be called.
@@ -65,7 +75,7 @@ export const middleware: Middleware =
         const req = PRELOAD[key]
         if (isUndefined(req)) return fetcher_(...args)
         delete PRELOAD[key]
-        return req
+        return resolvePreloadResponse(req)
       })
     return useSWRNext(key_, fetcher, config)
   }

--- a/src/_internal/utils/server-preload.ts
+++ b/src/_internal/utils/server-preload.ts
@@ -1,11 +1,6 @@
 import { serialize } from './serialize'
 
-import type {
-  BareFetcher,
-  FetcherResponse,
-  Key,
-  UnstablePreloadEntry
-} from '../types'
+import type { BareFetcher, CacheData, FetcherResponse, Key } from '../types'
 
 type PreloadFetcher<
   Data = unknown,
@@ -16,18 +11,17 @@ type PreloadFetcher<
   ? (arg: Arg) => FetcherResponse<Data>
   : never
 
-export const unstable_preload = <
+export const preload = <
   Data = any,
   SWRKey extends Key = Key,
   Fetcher extends BareFetcher = PreloadFetcher<Data, SWRKey>
 >(
   key_: SWRKey,
   fetcher: Fetcher
-): UnstablePreloadEntry<Data> => {
+): CacheData<Data> => {
   const [key, fnArg] = serialize(key_)
 
   return {
-    key,
-    data: fetcher(fnArg) as FetcherResponse<Data>
+    [key]: fetcher(fnArg) as FetcherResponse<Data>
   }
 }

--- a/src/_internal/utils/unstable-preload.ts
+++ b/src/_internal/utils/unstable-preload.ts
@@ -1,0 +1,33 @@
+import { serialize } from './serialize'
+
+import type {
+  BareFetcher,
+  FetcherResponse,
+  Key,
+  UnstablePreloadEntry
+} from '../types'
+
+type PreloadFetcher<
+  Data = unknown,
+  SWRKey extends Key = Key
+> = SWRKey extends () => infer Arg
+  ? (arg: Arg) => FetcherResponse<Data>
+  : SWRKey extends infer Arg
+  ? (arg: Arg) => FetcherResponse<Data>
+  : never
+
+export const unstable_preload = <
+  Data = any,
+  SWRKey extends Key = Key,
+  Fetcher extends BareFetcher = PreloadFetcher<Data, SWRKey>
+>(
+  key_: SWRKey,
+  fetcher: Fetcher
+): UnstablePreloadEntry<Data> => {
+  const [key, fnArg] = serialize(key_)
+
+  return {
+    key,
+    data: fetcher(fnArg) as FetcherResponse<Data>
+  }
+}

--- a/src/index/index.react-server.ts
+++ b/src/index/index.react-server.ts
@@ -1,3 +1,3 @@
 export { unstable_serialize } from './serialize'
-export { unstable_preload } from '../_internal/utils/unstable-preload'
+export { preload } from '../_internal/utils/server-preload'
 export { SWRConfig } from './config'

--- a/src/index/index.react-server.ts
+++ b/src/index/index.react-server.ts
@@ -1,2 +1,3 @@
 export { unstable_serialize } from './serialize'
+export { unstable_preload } from '../_internal/utils/unstable-preload'
 export { SWRConfig } from './config'

--- a/src/index/index.ts
+++ b/src/index/index.ts
@@ -7,7 +7,6 @@ export { unstable_serialize } from './serialize'
 export { useSWRConfig } from '../_internal'
 export { mutate } from '../_internal'
 export { preload } from '../_internal'
-export { unstable_preload } from '../_internal'
 
 // Config
 
@@ -35,5 +34,5 @@ export type {
   Arguments,
   State,
   ScopedMutator,
-  UnstablePreloadEntry
+  CacheData
 } from '../_internal'

--- a/src/index/index.ts
+++ b/src/index/index.ts
@@ -7,6 +7,7 @@ export { unstable_serialize } from './serialize'
 export { useSWRConfig } from '../_internal'
 export { mutate } from '../_internal'
 export { preload } from '../_internal'
+export { unstable_preload } from '../_internal'
 
 // Config
 
@@ -33,5 +34,6 @@ export type {
   Middleware,
   Arguments,
   State,
-  ScopedMutator
+  ScopedMutator,
+  UnstablePreloadEntry
 } from '../_internal'

--- a/src/index/index.ts
+++ b/src/index/index.ts
@@ -18,6 +18,7 @@ export interface SWRGlobalConfig {
 // Types
 export type {
   SWRConfiguration,
+  SWRConfigValue,
   Revalidator,
   RevalidatorOptions,
   Key,

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -187,19 +187,11 @@ export const useSWRHandler = <Data = any, Error = any>(
     : fallbackData
   const configCacheData = !key ? UNDEFINED : config.cacheData?.[key]
   const req = key ? PRELOAD[key] : UNDEFINED
-  const cacheDataRecord =
-    req && typeof req == 'object' && (req as any)._cacheData
-      ? (req as {
-          data: Data | Promise<Data>
-        })
-      : UNDEFINED
-  const isConfigCacheData = isUndefined(req) && !isUndefined(configCacheData)
-  const hasCacheData = !!cacheDataRecord || isConfigCacheData
-  const preloadedData = cacheDataRecord
-    ? cacheDataRecord.data
-    : isConfigCacheData
-    ? configCacheData
-    : req
+  // `cacheData` is request-scoped data provided by a Server Component through
+  // `SWRConfig`'s context. It's only used when there's no in-flight client
+  // `preload()` response (`req`) for the same key.
+  const hasCacheData = isUndefined(req) && !isUndefined(configCacheData)
+  const preloadedData = hasCacheData ? configCacheData : req
 
   const isEqual = (prev: State<Data, any>, current: State<Data, any>) => {
     for (const _ in stateDependencies) {
@@ -850,7 +842,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     const shouldConsumePreload = !isUndefined(preloadedData) && hasKeyButNoData
     let preloadData = UNDEFINED as Data | undefined
 
-    if (shouldConsumePreload && (cacheDataRecord || isConfigCacheData)) {
+    if (shouldConsumePreload && hasCacheData) {
       preloadData =
         preloadedData && isPromiseLike(preloadedData)
           ? use(preloadedData)

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -32,7 +32,6 @@ import type {
   SWRResponse,
   RevalidatorOptions,
   FullConfiguration,
-  SWRConfiguration,
   SWRHook,
   RevalidateEvent,
   StateDependencies,
@@ -128,7 +127,7 @@ const sub = () => noop
 export const useSWRHandler = <Data = any, Error = any>(
   _key: Key,
   fetcher: Fetcher<Data> | null,
-  config: FullConfiguration & SWRConfiguration<Data, Error>
+  config: FullConfiguration
 ) => {
   const {
     cache,

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -186,6 +186,9 @@ export const useSWRHandler = <Data = any, Error = any>(
       ? UNDEFINED
       : config.fallback[key]
     : fallbackData
+  const configPreload = !key
+    ? UNDEFINED
+    : config.unstable_preload?.find(preload => preload.key === key)?.data
 
   const isEqual = (prev: State<Data, any>, current: State<Data, any>) => {
     for (const _ in stateDependencies) {
@@ -780,10 +783,18 @@ export const useSWRHandler = <Data = any, Error = any>(
   // If there is no `error`, the `revalidation` promise needs to be thrown to
   // the suspense boundary.
   if (suspense) {
+    const req = PRELOAD[key]
+    const preloadedData = isUndefined(req) ? configPreload : req
+
     // SWR should throw when trying to use Suspense on the server with React 18,
     // without providing any fallback data. This causes hydration errors. See:
     // https://github.com/vercel/swr/issues/1832
-    if (!IS_REACT_LEGACY && IS_SERVER && hasKeyButNoData) {
+    if (
+      !IS_REACT_LEGACY &&
+      IS_SERVER &&
+      hasKeyButNoData &&
+      isUndefined(preloadedData)
+    ) {
       throw new Error('Fallback data is required when using Suspense in SSR.')
     }
 
@@ -794,18 +805,24 @@ export const useSWRHandler = <Data = any, Error = any>(
       unmountedRef.current = false
     }
 
-    const req = PRELOAD[key]
-
-    const mutateReq =
-      !isUndefined(req) && hasKeyButNoData ? boundMutate(req) : resolvedUndef
+    const preloadData =
+      !isUndefined(preloadedData) && hasKeyButNoData
+        ? preloadedData && isPromiseLike(preloadedData)
+          ? use(preloadedData)
+          : preloadedData
+        : UNDEFINED
+    const mutateReq = !isUndefined(preloadData)
+      ? boundMutate(preloadData)
+      : resolvedUndef
     use(mutateReq)
 
     if (!isUndefined(error) && hasKeyButNoData) {
       throw error
     }
-    const revalidation = hasKeyButNoData
-      ? revalidate(WITH_DEDUPE)
-      : resolvedUndef
+    const revalidation =
+      hasKeyButNoData && isUndefined(preloadData)
+        ? revalidate(WITH_DEDUPE)
+        : resolvedUndef
     if (!isUndefined(returnedData) && hasKeyButNoData) {
       // @ts-ignore modify react promise status
       revalidation.status = 'fulfilled'

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -186,22 +186,20 @@ export const useSWRHandler = <Data = any, Error = any>(
       ? UNDEFINED
       : config.fallback[key]
     : fallbackData
-  const configPreload = !key
-    ? UNDEFINED
-    : config.unstable_preload?.find(preload => preload.key === key)?.data
+  const configCacheData = !key ? UNDEFINED : config.cacheData?.[key]
   const req = key ? PRELOAD[key] : UNDEFINED
-  const preloadRecord =
-    req && typeof req == 'object' && (req as any)._unstable_preload
+  const cacheDataRecord =
+    req && typeof req == 'object' && (req as any)._cacheData
       ? (req as {
           data: Data | Promise<Data>
         })
       : UNDEFINED
-  const isConfigPreload = isUndefined(req) && !isUndefined(configPreload)
-  const hasRSCPreload = !!preloadRecord || isConfigPreload
-  const preloadedData = preloadRecord
-    ? preloadRecord.data
-    : isConfigPreload
-    ? configPreload
+  const isConfigCacheData = isUndefined(req) && !isUndefined(configCacheData)
+  const hasCacheData = !!cacheDataRecord || isConfigCacheData
+  const preloadedData = cacheDataRecord
+    ? cacheDataRecord.data
+    : isConfigCacheData
+    ? configCacheData
     : req
 
   const isEqual = (prev: State<Data, any>, current: State<Data, any>) => {
@@ -241,7 +239,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         // If `revalidateOnMount` is set, we take the value directly.
         if (isInitialMount && !isUndefined(revalidateOnMount))
           return revalidateOnMount
-        if (suspense && hasRSCPreload) return false
+        if (suspense && hasCacheData) return false
         const data = !isUndefined(fallback) ? fallback : snapshot.data
         if (suspense) return isUndefined(data) || revalidateIfStale
         return isUndefined(data) || revalidateIfStale
@@ -397,7 +395,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // If `revalidateOnMount` is set, we take the value directly.
     if (isInitialMount && !isUndefined(revalidateOnMount))
       return revalidateOnMount
-    if (suspense && hasRSCPreload) return false
+    if (suspense && hasCacheData) return false
     // Under suspense mode, it will always fetch on render if there is no
     // stale data so no need to revalidate immediately mount it again.
     // If data exists, only revalidate if `revalidateIfStale` is true.
@@ -440,7 +438,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       // new request should be initiated.
       const shouldStartNewRequest = !FETCH[key] || !opts.dedupe
       const shouldUseRSCPreload =
-        hasRSCPreload &&
+        hasCacheData &&
         !rscPreloadConsumedRef.current &&
         !isUndefined(preloadedData) &&
         isUndefined(getCache().data)
@@ -853,7 +851,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     const shouldConsumePreload = !isUndefined(preloadedData) && hasKeyButNoData
     let preloadData = UNDEFINED as Data | undefined
 
-    if (shouldConsumePreload && (preloadRecord || isConfigPreload)) {
+    if (shouldConsumePreload && (cacheDataRecord || isConfigCacheData)) {
       preloadData =
         preloadedData && isPromiseLike(preloadedData)
           ? use(preloadedData)

--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -189,6 +189,20 @@ export const useSWRHandler = <Data = any, Error = any>(
   const configPreload = !key
     ? UNDEFINED
     : config.unstable_preload?.find(preload => preload.key === key)?.data
+  const req = key ? PRELOAD[key] : UNDEFINED
+  const preloadRecord =
+    req && typeof req == 'object' && (req as any)._unstable_preload
+      ? (req as {
+          data: Data | Promise<Data>
+        })
+      : UNDEFINED
+  const isConfigPreload = isUndefined(req) && !isUndefined(configPreload)
+  const hasRSCPreload = !!preloadRecord || isConfigPreload
+  const preloadedData = preloadRecord
+    ? preloadRecord.data
+    : isConfigPreload
+    ? configPreload
+    : req
 
   const isEqual = (prev: State<Data, any>, current: State<Data, any>) => {
     for (const _ in stateDependencies) {
@@ -227,6 +241,7 @@ export const useSWRHandler = <Data = any, Error = any>(
         // If `revalidateOnMount` is set, we take the value directly.
         if (isInitialMount && !isUndefined(revalidateOnMount))
           return revalidateOnMount
+        if (suspense && hasRSCPreload) return false
         const data = !isUndefined(fallback) ? fallback : snapshot.data
         if (suspense) return isUndefined(data) || revalidateIfStale
         return isUndefined(data) || revalidateIfStale
@@ -306,7 +321,7 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   const cachedData = cached.data
 
-  const data = isUndefined(cachedData)
+  let data = isUndefined(cachedData)
     ? fallback && isPromiseLike(fallback)
       ? use(fallback)
       : fallback
@@ -315,8 +330,14 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   // Use a ref to store previously returned data. Use the initial data as its initial value.
   const laggyDataRef = useRef(data)
+  const rscPreloadConsumedRef = useRef(false)
+  const preloadCacheRef = useRef<{
+    data: Data | undefined
+    _k: Key
+    key: string
+  } | null>(null)
 
-  const returnedData = keepPreviousData
+  let returnedData = keepPreviousData
     ? isUndefined(cachedData)
       ? // checking undefined to avoid null being fallback as well
         isUndefined(laggyDataRef.current)
@@ -376,6 +397,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     // If `revalidateOnMount` is set, we take the value directly.
     if (isInitialMount && !isUndefined(revalidateOnMount))
       return revalidateOnMount
+    if (suspense && hasRSCPreload) return false
     // Under suspense mode, it will always fetch on render if there is no
     // stale data so no need to revalidate immediately mount it again.
     // If data exists, only revalidate if `revalidateIfStale` is true.
@@ -417,6 +439,11 @@ export const useSWRHandler = <Data = any, Error = any>(
       // If there is no ongoing concurrent request, or `dedupe` is not set, a
       // new request should be initiated.
       const shouldStartNewRequest = !FETCH[key] || !opts.dedupe
+      const shouldUseRSCPreload =
+        hasRSCPreload &&
+        !rscPreloadConsumedRef.current &&
+        !isUndefined(preloadedData) &&
+        isUndefined(getCache().data)
 
       /*
          For React 17
@@ -478,10 +505,18 @@ export const useSWRHandler = <Data = any, Error = any>(
 
           // Start the request and save the timestamp.
           // Key must be truthy if entering here.
+          if (shouldUseRSCPreload) {
+            rscPreloadConsumedRef.current = true
+          }
           FETCH[key] = [
-            currentFetcher(fnArg as DefinitelyTruthy<Key>),
+            shouldUseRSCPreload
+              ? preloadedData
+              : currentFetcher(fnArg as DefinitelyTruthy<Key>),
             getTimestamp()
           ]
+          if (shouldUseRSCPreload && PRELOAD[key]) {
+            delete PRELOAD[key]
+          }
         }
 
         // Wait until the ongoing request is done. Deduplication is also
@@ -642,6 +677,19 @@ export const useSWRHandler = <Data = any, Error = any>(
     []
   )
 
+  useIsomorphicLayoutEffect(() => {
+    const preloaded = preloadCacheRef.current
+    if (!preloaded) return
+
+    preloadCacheRef.current = null
+    if (isUndefined(getCache().data)) {
+      setCache({ data: preloaded.data, error: UNDEFINED, _k: preloaded._k })
+    }
+    if (PRELOAD[preloaded.key]) {
+      delete PRELOAD[preloaded.key]
+    }
+  })
+
   // The logic for updating refs.
   useIsomorphicLayoutEffect(() => {
     fetcherRef.current = fetcher
@@ -783,9 +831,6 @@ export const useSWRHandler = <Data = any, Error = any>(
   // If there is no `error`, the `revalidation` promise needs to be thrown to
   // the suspense boundary.
   if (suspense) {
-    const req = PRELOAD[key]
-    const preloadedData = isUndefined(req) ? configPreload : req
-
     // SWR should throw when trying to use Suspense on the server with React 18,
     // without providing any fallback data. This causes hydration errors. See:
     // https://github.com/vercel/swr/issues/1832
@@ -805,16 +850,27 @@ export const useSWRHandler = <Data = any, Error = any>(
       unmountedRef.current = false
     }
 
-    const preloadData =
-      !isUndefined(preloadedData) && hasKeyButNoData
-        ? preloadedData && isPromiseLike(preloadedData)
+    const shouldConsumePreload = !isUndefined(preloadedData) && hasKeyButNoData
+    let preloadData = UNDEFINED as Data | undefined
+
+    if (shouldConsumePreload && (preloadRecord || isConfigPreload)) {
+      preloadData =
+        preloadedData && isPromiseLike(preloadedData)
           ? use(preloadedData)
           : preloadedData
-        : UNDEFINED
-    const mutateReq = !isUndefined(preloadData)
-      ? boundMutate(preloadData)
-      : resolvedUndef
-    use(mutateReq)
+      data = preloadData
+      returnedData = preloadData
+
+      if (!IS_SERVER) {
+        rscPreloadConsumedRef.current = true
+        preloadCacheRef.current = { data: preloadData, _k: fnArg, key }
+      }
+    } else {
+      const mutateReq = shouldConsumePreload
+        ? boundMutate(preloadedData)
+        : resolvedUndef
+      use(mutateReq)
+    }
 
     if (!isUndefined(error) && hasKeyButNoData) {
       throw error

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -1,4 +1,4 @@
-import type { Cache, SWRResponse } from 'swr'
+import type { Cache, SWRConfigValue, SWRResponse } from 'swr'
 import useSWR, { useSWRConfig, SWRConfig } from 'swr'
 import { expectType } from './utils'
 import type { FullConfiguration, SWRConfiguration } from 'swr/_internal'
@@ -29,6 +29,7 @@ export function useTestCustomSWRConfig() {
           }
         }}
       />
+      <SWRConfig value={{ cacheData: { '/api': 'cache data' } }} />
 
       <SWRConfig
         // @ts-expect-error
@@ -162,6 +163,32 @@ export function useTestConfigAsSWRConfiguration() {
   const fetcher = (k: string) => Promise.resolve({ value: k })
   const { data } = useSWR('/api', fetcher, {} as SWRConfiguration)
   expectType<Equal<typeof data, { value: string } | undefined>>(true)
+}
+
+export function useTestCacheDataConfig() {
+  const configValue: SWRConfigValue = {
+    cacheData: {
+      '/api': 'cache data'
+    }
+  }
+  expectType<SWRConfigValue>(configValue)
+
+  const fetcher = (k: string) => Promise.resolve({ value: k })
+
+  useSWR('/api', fetcher, {
+    // @ts-expect-error cacheData is only supported in SWRConfig.
+    cacheData: {
+      '/api': 'cache data'
+    }
+  })
+
+  const config: SWRConfiguration = {
+    // @ts-expect-error cacheData is only supported in SWRConfig.
+    cacheData: {
+      '/api': 'cache data'
+    }
+  }
+  expectType<SWRConfiguration>(config)
 }
 
 export function useTestEmptyConfig() {

--- a/test/unit/utils.test.tsx
+++ b/test/unit/utils.test.tsx
@@ -141,5 +141,12 @@ describe('Utils', () => {
     expect(mergeConfigs({ fallback: a }, { fallback: b })).toEqual({
       fallback: { a: 1, b: 1 }
     })
+
+    // Should merge cache data and let the second config replace duplicate keys.
+    expect(
+      mergeConfigs({ cacheData: { a: 1, b: 1 } }, { cacheData: { a: 2, c: 2 } })
+    ).toEqual({
+      cacheData: { a: 2, b: 1, c: 2 }
+    })
   })
 })

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -1,10 +1,12 @@
 import { screen, fireEvent } from '@testing-library/react'
-import { useEffect, useState, act } from 'react'
+import { Suspense, useEffect, useState, act } from 'react'
 import type { Middleware } from 'swr'
-import useSWR, { SWRConfig, useSWRConfig } from 'swr'
+import useSWR, { SWRConfig, unstable_preload, useSWRConfig } from 'swr'
 import {
   renderWithConfig,
   createKey,
+  createResponse,
+  itShouldSkipForReactCanary,
   renderWithGlobalCache,
   sleep
 } from './utils'
@@ -125,6 +127,86 @@ describe('useSWR - configs', () => {
 
   it('should expose default config as static property on SWRConfig', () => {
     expect(SWRConfig.defaultValue).toBeDefined()
+  })
+
+  itShouldSkipForReactCanary(
+    'should not revalidate on mount when suspense consumes unstable_preload',
+    async () => {
+      const key = createKey()
+      const preloaded = unstable_preload(key, () => 'server data')
+      const clientFetcher = jest.fn(() => createResponse('client data'))
+
+      function Page() {
+        const { data } = useSWR(key, clientFetcher, { suspense: true })
+        return <div>data:{data}</div>
+      }
+
+      renderWithGlobalCache(
+        <SWRConfig value={{ unstable_preload: [preloaded] }}>
+          <Suspense fallback={<div>loading</div>}>
+            <Page />
+          </Suspense>
+        </SWRConfig>
+      )
+
+      screen.getByText('data:server data')
+      await act(() => sleep(50))
+      expect(clientFetcher).toHaveBeenCalledTimes(0)
+    }
+  )
+
+  itShouldSkipForReactCanary(
+    'should not expose the unstable_preload record on later revalidation',
+    async () => {
+      const key = createKey()
+      const preloaded = unstable_preload(key, () => 'server data')
+      const clientFetcher = jest.fn(() => createResponse('client data'))
+      let revalidate = () => Promise.resolve<string | undefined>(undefined)
+
+      function Page() {
+        const { data, mutate } = useSWR(key, clientFetcher, {
+          suspense: true
+        })
+        revalidate = mutate
+        return <div>data:{data}</div>
+      }
+
+      renderWithGlobalCache(
+        <SWRConfig value={{ unstable_preload: [preloaded] }}>
+          <Suspense fallback={<div>loading</div>}>
+            <Page />
+          </Suspense>
+        </SWRConfig>
+      )
+
+      screen.getByText('data:server data')
+      await act(() => sleep(10))
+      await act(() => revalidate())
+
+      await screen.findByText('data:client data')
+      expect(clientFetcher).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('should use unstable_preload in default mode without calling the client fetcher', async () => {
+    const key = createKey()
+    const preloaded = unstable_preload(key, () => createResponse('server data'))
+    const clientFetcher = jest.fn(() => createResponse('client data'))
+
+    function Page() {
+      const { data, isLoading } = useSWR(key, clientFetcher)
+      return <div>data:{`${data}:${isLoading}`}</div>
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ unstable_preload: [preloaded] }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    screen.getByText('data:undefined:true')
+    await screen.findByText('data:server data:false')
+    expect(clientFetcher).toHaveBeenCalledTimes(0)
   })
 
   it('should expose the default config from useSWRConfig', () => {

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -1,7 +1,7 @@
 import { screen, fireEvent } from '@testing-library/react'
 import { Suspense, useEffect, useState, act } from 'react'
 import type { Middleware } from 'swr'
-import useSWR, { SWRConfig, unstable_preload, useSWRConfig } from 'swr'
+import useSWR, { SWRConfig, useSWRConfig } from 'swr'
 import {
   renderWithConfig,
   createKey,
@@ -130,10 +130,10 @@ describe('useSWR - configs', () => {
   })
 
   itShouldSkipForReactCanary(
-    'should not revalidate on mount when suspense consumes unstable_preload',
+    'should not revalidate on mount when suspense consumes cacheData',
     async () => {
       const key = createKey()
-      const preloaded = unstable_preload(key, () => 'server data')
+      const cacheData = { [key]: 'server data' }
       const clientFetcher = jest.fn(() => createResponse('client data'))
 
       function Page() {
@@ -142,7 +142,7 @@ describe('useSWR - configs', () => {
       }
 
       renderWithGlobalCache(
-        <SWRConfig value={{ unstable_preload: [preloaded] }}>
+        <SWRConfig value={{ cacheData }}>
           <Suspense fallback={<div>loading</div>}>
             <Page />
           </Suspense>
@@ -156,10 +156,10 @@ describe('useSWR - configs', () => {
   )
 
   itShouldSkipForReactCanary(
-    'should not expose the unstable_preload record on later revalidation',
+    'should not expose the cacheData record on later revalidation',
     async () => {
       const key = createKey()
-      const preloaded = unstable_preload(key, () => 'server data')
+      const cacheData = { [key]: 'server data' }
       const clientFetcher = jest.fn(() => createResponse('client data'))
       let revalidate = () => Promise.resolve<string | undefined>(undefined)
 
@@ -172,7 +172,7 @@ describe('useSWR - configs', () => {
       }
 
       renderWithGlobalCache(
-        <SWRConfig value={{ unstable_preload: [preloaded] }}>
+        <SWRConfig value={{ cacheData }}>
           <Suspense fallback={<div>loading</div>}>
             <Page />
           </Suspense>
@@ -188,9 +188,9 @@ describe('useSWR - configs', () => {
     }
   )
 
-  it('should use unstable_preload in default mode without calling the client fetcher', async () => {
+  it('should use cacheData in default mode without calling the client fetcher', async () => {
     const key = createKey()
-    const preloaded = unstable_preload(key, () => createResponse('server data'))
+    const cacheData = { [key]: createResponse('server data') }
     const clientFetcher = jest.fn(() => createResponse('client data'))
 
     function Page() {
@@ -199,7 +199,7 @@ describe('useSWR - configs', () => {
     }
 
     renderWithGlobalCache(
-      <SWRConfig value={{ unstable_preload: [preloaded] }}>
+      <SWRConfig value={{ cacheData }}>
         <Page />
       </SWRConfig>
     )


### PR DESCRIPTION
Add RSC cache preloading for SWR.

This lets a Server Component call `preload(key, fetcher)` and pass the returned `cacheData` object through the server/client boundary into `SWRConfig`. On the client, `useSWR` consumes that cache data before calling the browser fetcher, returns the server-loaded value, and writes it into the SWR cache after hydration.

Flow:

```txt
Server Component
  preload(key, fetcher)
        | returns { [serializedKey]: dataOrPromise }
        v
Client Boundary
  <SWRConfig value={{ cacheData }}>
        |
        v
useSWR(key, clientFetcher)
  - uses server-loaded cache data for initial data
  - hydrates the SWR cache after hydration
  - skips duplicate initial browser fetch/revalidation
  - later mutate/focus/reconnect revalidation still uses clientFetcher
```

Example:

```tsx
// Server Component
import { preload } from 'swr'
import { ClientRoot } from './client'

const key = '/api/user'

async function getUser() {
  return { name: 'Ada' }
}

export default function Page() {
  const cacheData = preload(key, getUser)
  return <ClientRoot cacheData={cacheData} />
}
```

```tsx
// Client Component
'use client'

import useSWR, { SWRConfig } from 'swr'
import type { CacheData } from 'swr'

const key = '/api/user'

async function fetchUser() {
  const res = await fetch(key)
  return res.json()
}

function User() {
  const { data } = useSWR(key, fetchUser)
  return <div>{data.name}</div>
}

export function ClientRoot({ cacheData }: { cacheData: CacheData }) {
  return (
    <SWRConfig value={{ cacheData }}>
      <User />
    </SWRConfig>
  )
}
```

`cacheData` is object-shaped, so nested configs merge like `fallback` and duplicate keys are replaced by the later config. The tests cover Suspense and default modes, prevent leaking the internal cache-data record into user data, and verify that explicit later revalidation still calls the client fetcher.

Resolves #4065 