### PR TITLE
fix(hash): coerce an invalid Date to a stable string key

### DIFF
--- a/src/_internal/utils/hash.ts
+++ b/src/_internal/utils/hash.ts
@@ -64,7 +64,7 @@ export const stableHash = (arg: any): string => {
     }
   } else {
     result = isDate
-      ? arg.toJSON()
+      ? arg.toJSON() || arg.toString()
       : type == 'symbol'
       ? arg.toString()
       : type == 'string'

--- a/test/unit/serialize.test.ts
+++ b/test/unit/serialize.test.ts
@@ -14,3 +14,15 @@ describe('SWR - unstable_serialize', () => {
     )
   })
 })
+
+describe('SWR - stableHash', () => {
+  it('should hash an invalid date to a string', async () => {
+    expect(typeof stableHash(new Date('invalid'))).toBe('string')
+  })
+
+  it('should not collide an invalid date with null', async () => {
+    expect(stableHash(['/api', new Date('invalid')])).not.toBe(
+      stableHash(['/api', null])
+    )
+  })
+})


### PR DESCRIPTION
## Description

An invalid `Date` in an SWR key hashes to the value `null` instead of a string, so it collides with a literal `null` key and lets two different requests share one cache entry.

`stableHash` hashes a `Date` via `arg.toJSON()`. Per spec, `Date.prototype.toJSON()` returns `null` for an invalid date, whereas every other leaf branch of the hash returns a string. So:

```js
useSWR(['/api/events', filterDate]) // filterDate came from user/URL input and failed to parse
```

hashes to the same key as `['/api/events', null]`. Two distinct requests map to one cache slot and serve each other's data. It also breaks the `stableHash: (arg) => string` return-type contract, since `serialize` then returns a non-string key.

## Fix

```diff
-      ? arg.toJSON()
+      ? arg.toJSON() || arg.toString()
```

Valid dates keep their ISO string (`toJSON()` is truthy); an invalid date falls back to `"Invalid Date"`, a stable string distinct from `null`.

## Test

Added two cases to `test/unit/serialize.test.ts`: an invalid `Date` hashes to a string, and an invalid `Date` in an array key does not collide with `null`. Both fail before the change and pass after.
