### PR TITLE
fix(types): allow null as fetcher in PublicConfiguration

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -259,9 +259,9 @@ export interface PublicConfiguration<
    */
   strictServerPrefetchWarning?: boolean
   /**
-   * the fetcher function
+   * the fetcher function, or null to disable fetching
    */
-  fetcher?: Fn
+  fetcher?: Fn | null
   /**
    * array of middleware functions
    * @see {@link https://swr.vercel.app/docs/middleware}

--- a/test/type/fetcher.ts
+++ b/test/type/fetcher.ts
@@ -3,6 +3,13 @@ import useSWRInfinite from 'swr/infinite'
 import { expectType, truthy } from './utils'
 import type { Equal } from '@type-challenges/utils'
 
+export function useNullFetcher() {
+  // null as 2nd positional arg disables fetching (#2888)
+  useSWR('key', null)
+  // null in config.fetcher also disables fetching (#2888)
+  useSWR('key', { fetcher: null })
+}
+
 export function useDataErrorGeneric() {
   useSWR<{ id: number }>('/api/', () => ({ id: 123 }))
   useSWR<string, any>('/api/', (key: string) => key)


### PR DESCRIPTION
## What

Adds `| null` to `PublicConfiguration.fetcher` so passing `null` as a fetcher via the config object is accepted by TypeScript.

## Why

Passing `null` as fetcher is a valid runtime pattern to disable fetching for a key. The positional overloads on `SWRHook` already typed fetcher as `Fetcher | null`, so `useSWR("key", null)` worked fine. But `PublicConfiguration.fetcher` was typed as just `Fn`, causing type errors for the config-object pattern:

```ts
useSWR("key", { fetcher: null })          // ❌ TS error before fix
const cfg: SWRConfiguration = { fetcher: null }  // ❌ TS error before fix
useSWR("key", null)                        // ✅ already worked
```

## Fix

```diff
- fetcher?: Fn
+ fetcher?: Fn | null
```

Also adds a type test covering both patterns to prevent regression.

All 365 unit tests pass. Full `tsc --noEmit` passes.

Fixes #2888