### PR TITLE
fix(subscription): delete stale Map entries on last-subscriber teardown

### DIFF
--- a/src/subscription/index.ts
+++ b/src/subscription/index.ts
@@ -90,6 +90,8 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
         if (!count) {
           const dispose = disposers.get(subscriptionKey)
           dispose?.()
+          disposers.delete(subscriptionKey)
+          subscriptions.delete(subscriptionKey)
         }
       }
     }, [subscriptionKey])


### PR DESCRIPTION
Fixes #4261.

When the last subscriber unmounts, the cleanup callback calls dispose() but never removes the entries from the subscriptions (ref-count Map) and disposers (cleanup function Map). Both entries remain indefinitely: subscriptions keeps the key mapped to 0, and disposers keeps the key mapped to the already-called dispose function, preventing it from being garbage-collected.

In apps that cycle through many distinct subscription keys, such as paginated feeds, rotating live-data channels, or market tickers, both Maps accumulate one dead entry per unique key and grow without bound.

The fix adds two deletes immediately after dispose():

disposers.delete(subscriptionKey) removes the stale function reference.
subscriptions.delete(subscriptionKey) removes the zero-count entry.

Both Maps then stay proportional to the number of currently-active subscription keys rather than all keys ever seen. The functional behavior is unchanged because a future remount of the same key correctly falls through to the subscribe call regardless of whether a zero entry exists.

Yokubjon Nurullaev identified the missing cleanup in the last-subscriber branch and implemented the two delete calls.

IbrokhimN verified that removing the zero entry does not affect remount behavior, since the ref-count lookup falls back to 0 via the || 0 guard on the next mount.