### PR TITLE
fix: hydrate cacheData for hooks without a fetcher

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -35,7 +35,8 @@ import type {
   SWRHook,
   RevalidateEvent,
   StateDependencies,
-  GlobalState
+  GlobalState,
+  CacheData
 } from '../_internal'
 
 const use =
@@ -75,6 +76,60 @@ const use =
   })
 
 const WITH_DEDUPE = { dedupe: true }
+
+type ConsumedCacheData = WeakMap<CacheData, Set<string>>
+
+const isCacheDataConsumed = (
+  consumedCacheData: ConsumedCacheData,
+  cacheData: CacheData | undefined,
+  key: string
+) => (cacheData ? consumedCacheData.get(cacheData)?.has(key) === true : false)
+
+const markCacheDataConsumed = (
+  consumedCacheData: ConsumedCacheData,
+  cacheData: CacheData | undefined,
+  key: string
+) => {
+  if (!cacheData) return
+
+  let consumedKeys = consumedCacheData.get(cacheData)
+  if (!consumedKeys) {
+    consumedKeys = new Set()
+    consumedCacheData.set(cacheData, consumedKeys)
+  }
+  consumedKeys.add(key)
+}
+
+const commitCacheData = <Data>({
+  value,
+  getCacheData,
+  canCommit,
+  setCache
+}: {
+  value: CacheData<Data>[string]
+  getCacheData: () => Data | undefined
+  canCommit: () => boolean
+  setCache: (
+    state: { data: Data; error: undefined } | { error: unknown }
+  ) => void
+}) => {
+  const commit = (
+    state: { data: Data; error: undefined } | { error: unknown }
+  ) => {
+    if (canCommit() && isUndefined(getCacheData())) {
+      setCache(state)
+    }
+  }
+
+  Promise.resolve(value).then(
+    data => {
+      commit({ data, error: UNDEFINED })
+    },
+    error => {
+      commit({ error })
+    }
+  )
+}
 
 type DefinitelyTruthy<T> = false extends T
   ? never
@@ -185,7 +240,8 @@ export const useSWRHandler = <Data = any, Error = any>(
       ? UNDEFINED
       : config.fallback[key]
     : fallbackData
-  const configCacheData = !key ? UNDEFINED : config.cacheData?.[key]
+  const serverCacheData = config.cacheData
+  const configCacheData = !key ? UNDEFINED : serverCacheData?.[key]
   const req = key ? PRELOAD[key] : UNDEFINED
   // `cacheData` is request-scoped data provided by a Server Component through
   // `SWRConfig`'s context. It's only used when there's no in-flight client
@@ -319,11 +375,17 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   // Use a ref to store previously returned data. Use the initial data as its initial value.
   const laggyDataRef = useRef(data)
-  const rscPreloadConsumedRef = useRef(false)
+  const consumedCacheDataRef = useRef<ConsumedCacheData | undefined>(UNDEFINED)
+  let consumedCacheData = consumedCacheDataRef.current
+  if (!consumedCacheData) {
+    consumedCacheData = new WeakMap()
+    consumedCacheDataRef.current = consumedCacheData
+  }
   const preloadCacheRef = useRef<{
     data: Data | undefined
     _k: Key
     key: string
+    cacheData?: CacheData
   } | null>(null)
 
   let returnedData = keepPreviousData
@@ -430,7 +492,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       const shouldStartNewRequest = !FETCH[key] || !opts.dedupe
       const shouldUseRSCPreload =
         hasCacheData &&
-        !rscPreloadConsumedRef.current &&
+        !isCacheDataConsumed(consumedCacheData, serverCacheData, key) &&
         !isUndefined(preloadedData) &&
         isUndefined(getCache().data)
 
@@ -495,7 +557,7 @@ export const useSWRHandler = <Data = any, Error = any>(
           // Start the request and save the timestamp.
           // Key must be truthy if entering here.
           if (shouldUseRSCPreload) {
-            rscPreloadConsumedRef.current = true
+            markCacheDataConsumed(consumedCacheData, serverCacheData, key)
           }
           FETCH[key] = [
             shouldUseRSCPreload
@@ -671,6 +733,7 @@ export const useSWRHandler = <Data = any, Error = any>(
     if (!preloaded) return
 
     preloadCacheRef.current = null
+    markCacheDataConsumed(consumedCacheData, preloaded.cacheData, preloaded.key)
     if (isUndefined(getCache().data)) {
       setCache({ data: preloaded.data, error: UNDEFINED, _k: preloaded._k })
     }
@@ -688,6 +751,30 @@ export const useSWRHandler = <Data = any, Error = any>(
     if (!isUndefined(cachedData)) {
       laggyDataRef.current = cachedData
     }
+  })
+
+  useIsomorphicLayoutEffect(() => {
+    if (
+      fetcher ||
+      !hasCacheData ||
+      isUndefined(preloadedData) ||
+      isCacheDataConsumed(consumedCacheData, serverCacheData, key) ||
+      !isUndefined(getCache().data)
+    ) {
+      return
+    }
+
+    markCacheDataConsumed(consumedCacheData, serverCacheData, key)
+    const mutation = MUTATION[key]
+    commitCacheData({
+      value: preloadedData,
+      getCacheData: () => getCache().data,
+      canCommit: () =>
+        !unmountedRef.current &&
+        key === keyRef.current &&
+        MUTATION[key] === mutation,
+      setCache: state => setCache({ ...state, _k: fnArg })
+    })
   })
 
   // After mounted or key changed.
@@ -859,8 +946,12 @@ export const useSWRHandler = <Data = any, Error = any>(
       returnedData = preloadData
 
       if (!IS_SERVER) {
-        rscPreloadConsumedRef.current = true
-        preloadCacheRef.current = { data: preloadData, _k: fnArg, key }
+        preloadCacheRef.current = {
+          data: preloadData,
+          _k: fnArg,
+          key,
+          cacheData: serverCacheData
+        }
       }
     } else {
       const mutateReq = shouldConsumePreload

--- a/test/e2e/promise-scenarios.test.ts
+++ b/test/e2e/promise-scenarios.test.ts
@@ -127,6 +127,33 @@ test.describe('promise scenarios', () => {
     )
   })
 
+  test('hydrates preload cacheData without revalidating a fetcherless hook', async ({
+    page
+  }) => {
+    let clientFetcherCalls = 0
+    await page.exposeFunction('__SWR_RSC_CLIENT_FETCHER_CALLED__', () => {
+      clientFetcherCalls += 1
+    })
+
+    await page.goto('./rsc-unstable-preload-no-suspense?fetcher=none', {
+      waitUntil: 'commit'
+    })
+
+    await expect(page.getByTestId('data')).toHaveText(
+      'data:SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
+    )
+    await expect(page.getByTestId('cache')).toHaveText(
+      'cache:SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
+    )
+    await expect(page.getByTestId('loading')).toHaveText('loading:false')
+    await expect(page.getByTestId('validating')).toHaveText('validating:false')
+    await expect(page.getByTestId('successes')).toHaveText('successes:0')
+    await expect(page.getByTestId('client-fetches')).toHaveText(
+      'client fetches:0'
+    )
+    expect(clientFetcherCalls).toBe(0)
+  })
+
   test('does not leak preloaded cacheData across requests', async ({
     request
   }) => {

--- a/test/e2e/site/app/rsc-unstable-preload-no-suspense/client.tsx
+++ b/test/e2e/site/app/rsc-unstable-preload-no-suspense/client.tsx
@@ -7,10 +7,12 @@ import { key } from './key'
 
 function ClientData({
   fetcher,
-  clientFetches
+  clientFetches,
+  successes
 }: {
-  fetcher: () => Promise<string>
+  fetcher: (() => Promise<string>) | null
   clientFetches: number
+  successes: number
 }) {
   const { cache } = useSWRConfig()
   const { data, isLoading, isValidating, mutate } = useSWR(key, fetcher)
@@ -23,6 +25,7 @@ function ClientData({
       <div data-testid="validating">validating:{`${isValidating}`}</div>
       <div data-testid="cache">cache:{cachedData}</div>
       <div data-testid="client-fetches">client fetches:{clientFetches}</div>
+      <div data-testid="successes">successes:{successes}</div>
       <button data-testid="revalidate" onClick={() => void mutate()}>
         revalidate
       </button>
@@ -30,8 +33,15 @@ function ClientData({
   )
 }
 
-export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
+export function ClientRoot({
+  cacheData,
+  withFetcher = true
+}: {
+  cacheData: CacheData<string>
+  withFetcher?: boolean
+}) {
   const [clientFetches, setClientFetches] = useState(0)
+  const [successes, setSuccesses] = useState(0)
   const fetcher = useCallback(async () => {
     ;(
       window as typeof window & {
@@ -43,8 +53,17 @@ export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
   }, [])
 
   return (
-    <SWRConfig value={{ cacheData }}>
-      <ClientData fetcher={fetcher} clientFetches={clientFetches} />
+    <SWRConfig
+      value={{
+        cacheData,
+        onSuccess: () => setSuccesses(count => count + 1)
+      }}
+    >
+      <ClientData
+        fetcher={withFetcher ? fetcher : null}
+        clientFetches={clientFetches}
+        successes={successes}
+      />
     </SWRConfig>
   )
 }

--- a/test/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
+++ b/test/e2e/site/app/rsc-unstable-preload-no-suspense/page.tsx
@@ -10,13 +10,18 @@ async function getServerData() {
   return 'SWR_RSC_PRELOAD_NO_SUSPENSE_MARKER_20260621'
 }
 
-export default async function Page() {
+export default async function Page({
+  searchParams
+}: {
+  searchParams: Promise<{ fetcher?: string }>
+}) {
   // Opt into dynamic rendering so each request preloads fresh server data.
   await connection()
 
   // Runtime resolves the react-server export; this app's type checker still
   // reads the default client preload signature.
   const cacheData = preload(key, getServerData) as unknown as CacheData<string>
+  const { fetcher } = await searchParams
 
-  return <ClientRoot cacheData={cacheData} />
+  return <ClientRoot cacheData={cacheData} withFetcher={fetcher !== 'none'} />
 }

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -209,6 +209,275 @@ describe('useSWR - configs', () => {
     expect(clientFetcher).toHaveBeenCalledTimes(0)
   })
 
+  it('should provide cacheData to hooks without a fetcher', async () => {
+    const key = createKey()
+    const cacheData = { [key]: 'server data' }
+    const onSuccess = jest.fn()
+
+    function Page() {
+      const { data, isValidating } = useSWR<string>(key, null)
+      return (
+        <div>
+          data:{data}:{String(isValidating)}
+        </div>
+      )
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData, onSuccess }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data:server data:false')
+    expect(onSuccess).not.toHaveBeenCalled()
+  })
+
+  it('should provide promised cacheData to hooks without a fetcher', async () => {
+    const key = createKey()
+    const cacheData = { [key]: createResponse('server data') }
+
+    function Page() {
+      const { data } = useSWR<string>(key, null)
+      return <div>data:{data}</div>
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data:server data')
+  })
+
+  it('should write rejected cacheData to the error state for hooks without a fetcher', async () => {
+    const key = createKey()
+    const cacheData = { [key]: Promise.reject(new Error('server error')) }
+
+    function Page() {
+      const { error } = useSWR<string>(key, null)
+      return <div>error:{error?.message}</div>
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('error:server error')
+  })
+
+  it('should consume cacheData after switching to a new key for hooks without a fetcher', async () => {
+    const keyA = createKey()
+    const keyB = createKey()
+    const cacheData = { [keyA]: 'a data', [keyB]: 'b data' }
+
+    function Page() {
+      const [useB, setUseB] = useState(false)
+      const { data } = useSWR<string>(useB ? keyB : keyA, null)
+      return <button onClick={() => setUseB(true)}>data:{data}</button>
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data:a data')
+    fireEvent.click(screen.getByRole('button'))
+    await screen.findByText('data:b data')
+  })
+
+  it('should not reseed cacheData after the cache entry is cleared', async () => {
+    const key = createKey()
+    const cacheData = { [key]: 'server data' }
+
+    function Page() {
+      const { data, mutate } = useSWR<string>(key, null)
+      return (
+        <button onClick={() => mutate(undefined, { revalidate: false })}>
+          data:{String(data)}
+        </button>
+      )
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data:server data')
+    fireEvent.click(screen.getByRole('button'))
+    await screen.findByText('data:undefined')
+    await act(() => sleep(50))
+    screen.getByText('data:undefined')
+  })
+
+  it('should not reuse cacheData after adding a fetcher', async () => {
+    const key = createKey()
+    const cacheData = { [key]: 'server data' }
+    const clientFetcher = jest.fn(() => createResponse('client data'))
+
+    function Page() {
+      const [hasFetcher, setHasFetcher] = useState(false)
+      const { data, mutate } = useSWR<string>(
+        key,
+        hasFetcher ? clientFetcher : null
+      )
+      return (
+        <>
+          <div>data:{String(data)}</div>
+          <button onClick={() => mutate(undefined, { revalidate: false })}>
+            clear
+          </button>
+          <button onClick={() => setHasFetcher(true)}>
+            fetcher:{hasFetcher ? 'on' : 'off'}
+          </button>
+          <button onClick={() => mutate()}>revalidate</button>
+        </>
+      )
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data:server data')
+    fireEvent.click(screen.getByText('clear'))
+    await screen.findByText('data:undefined')
+    fireEvent.click(screen.getByText('fetcher:off'))
+    await screen.findByText('fetcher:on')
+    fireEvent.click(screen.getByText('revalidate'))
+
+    await screen.findByText('data:client data')
+    expect(clientFetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not reuse cacheData after removing a fetcher', async () => {
+    const key = createKey()
+    const cacheData = { [key]: createResponse('server data') }
+    const clientFetcher = jest.fn(() => createResponse('client data'))
+
+    function Page() {
+      const [hasFetcher, setHasFetcher] = useState(true)
+      const { data, mutate } = useSWR<string>(
+        key,
+        hasFetcher ? clientFetcher : null
+      )
+      return (
+        <>
+          <div>data:{String(data)}</div>
+          <button onClick={() => mutate(undefined, { revalidate: false })}>
+            clear
+          </button>
+          <button onClick={() => setHasFetcher(false)}>
+            fetcher:{hasFetcher ? 'on' : 'off'}
+          </button>
+        </>
+      )
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data:server data')
+    expect(clientFetcher).toHaveBeenCalledTimes(0)
+    fireEvent.click(screen.getByText('fetcher:on'))
+    await screen.findByText('fetcher:off')
+    fireEvent.click(screen.getByText('clear'))
+
+    await screen.findByText('data:undefined')
+    await act(() => sleep(50))
+    screen.getByText('data:undefined')
+    expect(clientFetcher).toHaveBeenCalledTimes(0)
+  })
+
+  it('should not commit promised cacheData after a newer mutation', async () => {
+    const key = createKey()
+    let resolveCacheData = (_value: string) => {}
+    const cacheDataPromise = new Promise<string>(resolve => {
+      resolveCacheData = resolve
+    })
+    const cacheData = { [key]: cacheDataPromise }
+
+    function Page() {
+      const { data, mutate } = useSWR<string>(key, null)
+      return (
+        <>
+          <div>data:{String(data)}</div>
+          <button onClick={() => mutate(undefined, { revalidate: false })}>
+            clear
+          </button>
+        </>
+      )
+    }
+
+    renderWithGlobalCache(
+      <SWRConfig value={{ cacheData }}>
+        <Page />
+      </SWRConfig>
+    )
+
+    screen.getByText('data:undefined')
+    fireEvent.click(screen.getByText('clear'))
+    await act(async () => {
+      resolveCacheData('server data')
+      await cacheDataPromise
+    })
+
+    screen.getByText('data:undefined')
+  })
+
+  it('should consume fresh cacheData for the same key', async () => {
+    const key = createKey()
+
+    function Root() {
+      const [cacheData, setCacheData] = useState({ [key]: 'first data' })
+      return (
+        <SWRConfig value={{ cacheData }}>
+          <Page setCacheData={setCacheData} />
+        </SWRConfig>
+      )
+    }
+
+    function Page({
+      setCacheData
+    }: {
+      setCacheData: (cacheData: Record<string, string>) => void
+    }) {
+      const { data, mutate } = useSWR<string>(key, null)
+      return (
+        <>
+          <div>data:{String(data)}</div>
+          <button onClick={() => mutate(undefined, { revalidate: false })}>
+            clear
+          </button>
+          <button onClick={() => setCacheData({ [key]: 'second data' })}>
+            refresh
+          </button>
+        </>
+      )
+    }
+
+    renderWithGlobalCache(<Root />)
+
+    await screen.findByText('data:first data')
+    fireEvent.click(screen.getByText('clear'))
+    await screen.findByText('data:undefined')
+    fireEvent.click(screen.getByText('refresh'))
+
+    await screen.findByText('data:second data')
+  })
+
   it('should expose the default config from useSWRConfig', () => {
     let config
 


### PR DESCRIPTION
## Summary

Hydrate request-scoped `cacheData` into SWR's cache for `useSWR(key, null)` without treating hydration as revalidation.

- Support plain, promised, and rejected `cacheData` values.
- Keep each key one-shot per request-scoped `cacheData` object.
- Share consumption state across fetcher, fetcherless, and Suspense paths.
- Avoid client fetching, validation state, retries, and revalidation callbacks during hydration.

## Problem

Default-mode `cacheData` was consumed inside `revalidate`. A hook without a fetcher never enters that path, so `useSWR(key, null)` remained undefined and the server-loaded value was never written into SWR's cache.

Tracking consumption only by serialized key also cannot distinguish a fresh request-scoped `cacheData` object from an already-consumed one. Promised values additionally need protection from key changes and newer local mutations.

## Solution

After React commits, a fetcherless hook resolves its matching `cacheData` value and writes the resulting data or error into the external cache. The commit proceeds only while:

- the hook still owns the same key;
- no newer mutation has started; and
- the cache entry remains empty.

A per-hook `WeakMap<CacheData, Set<string>>` tracks consumption by request object and serialized key. This lets a fresh request provide new data for the same key while old request objects remain eligible for garbage collection.

Hydration does not call `revalidate`, so `isLoading` and `isValidating` remain false, revalidation callbacks do not fire, and no client fetcher runs.

## Validation

- Jest: 34 suites passed; 374 tests passed and 5 skipped.
- Playwright: 7 promise-scenario tests plus dev-server warmup passed.
- `pnpm run-all-checks` passed.
- `pnpm format:check` passed.
- `pnpm build` passed.

The browser regression verifies real RSC hydration with `useSWR(key, null)`: the server value reaches both the hook and SWR cache, loading and validating stay false, success callbacks remain at zero, and no client request occurs.
