### PR TITLE
fix: clear matching preloads on wildcard mutate

### DIFF
--- a/src/_internal/constants.ts
+++ b/src/_internal/constants.ts
@@ -1,1 +1,4 @@
 export const INFINITE_PREFIX = '$inf$'
+
+// Tags a preloaded request with its original key args for wildcard mutate.
+export const PRELOAD_ARG = Symbol()

--- a/src/_internal/utils/mutate.ts
+++ b/src/_internal/utils/mutate.ts
@@ -8,6 +8,7 @@ import {
   isPromiseLike
 } from './shared'
 import { SWRGlobalState } from './global-state'
+import { PRELOAD_ARG } from '../constants'
 import { getTimestamp } from './timestamp'
 import * as revalidateEvents from '../events'
 import type {
@@ -72,14 +73,29 @@ export async function internalMutate<Data>(
   if (isFunction(_key)) {
     const keyFilter = _key
     const matchedKeys: Key[] = []
+    // The special useSWRInfinite and useSWRSubscription keys are always skipped.
+    const isReservedKey = /^\$(inf|sub)\$/
     const it = cache.keys()
     for (const key of it) {
       if (
-        // Skip the special useSWRInfinite and useSWRSubscription keys.
-        !/^\$(inf|sub)\$/.test(key) &&
+        !isReservedKey.test(key) &&
         keyFilter((cache.get(key) as { _k: Arguments })._k)
       ) {
         matchedKeys.push(key)
+      }
+    }
+    // Also clear matching preloads that no useSWR mount ever consumed, so they
+    // don't outlive an invalidation.
+    const [, , , PRELOAD] = SWRGlobalState.get(cache) as GlobalState
+    for (const key in PRELOAD) {
+      // Filter by the tagged original args (PRELOAD is keyed by the serialized
+      // string), falling back to the key when nothing was tagged.
+      const preloadArg = (PRELOAD[key] as any)?.[PRELOAD_ARG]
+      if (
+        !isReservedKey.test(key) &&
+        keyFilter(isUndefined(preloadArg) ? key : preloadArg)
+      ) {
+        delete PRELOAD[key]
       }
     }
     return Promise.all(matchedKeys.map(mutateByKey))

--- a/src/_internal/utils/preload.ts
+++ b/src/_internal/utils/preload.ts
@@ -9,7 +9,7 @@ import { serialize } from './serialize'
 import { cache } from './config'
 import { SWRGlobalState } from './global-state'
 import { isUndefined } from './shared'
-import { INFINITE_PREFIX } from '../constants'
+import { INFINITE_PREFIX, PRELOAD_ARG } from '../constants'
 import { IS_SERVER } from './env'
 
 // Basically same as Fetcher but without Conditional Fetching
@@ -44,6 +44,10 @@ export const preload = <
   }
 
   const req = fetcher(fnArg) as ReturnType<Fetcher>
+  // Tag with the original key args so wildcard mutate can match by them.
+  if (req && typeof req === 'object') {
+    ;(req as any)[PRELOAD_ARG] = fnArg
+  }
   PRELOAD[key] = req
   return req
 }

--- a/test/use-swr-preload.test.tsx
+++ b/test/use-swr-preload.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { Suspense, useEffect, useState, Profiler, act } from 'react'
-import useSWR, { preload, useSWRConfig } from 'swr'
+import useSWR, { preload, mutate as globalMutate, useSWRConfig } from 'swr'
 import {
   createKey,
   createResponse,
@@ -230,5 +230,109 @@ describe('useSWR - preload', () => {
 
     preload(() => key, fetcher)
     expect(calledWith).toBe(key)
+  })
+
+  it('wildcard mutate clears an unconsumed preload entry', async () => {
+    const key = createKey()
+    const preloadFetcher = jest.fn(() => createResponse('preloaded'))
+    const newFetcher = jest.fn(() => createResponse('fresh'))
+
+    function Page() {
+      const { data } = useSWR(key, newFetcher)
+      return <div>data:{data}</div>
+    }
+
+    // Preloaded but never consumed by a useSWR mount, so it lives only in PRELOAD.
+    preload(key, preloadFetcher)
+    expect(preloadFetcher).toHaveBeenCalledTimes(1)
+
+    // Wildcard mutate should clear the unconsumed preload entry.
+    await globalMutate(() => true, undefined, { revalidate: false })
+
+    renderWithGlobalCache(<Page />)
+    // The value must come from newFetcher, not the stale preloaded promise.
+    await screen.findByText('data:fresh')
+    expect(newFetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('wildcard mutate clears only matching preload entries', async () => {
+    const key1 = createKey()
+    const key2 = createKey()
+    const newFetcher1 = jest.fn(() => createResponse('fresh1'))
+    const newFetcher2 = jest.fn(() => createResponse('fresh2'))
+
+    preload(key1, () => createResponse('preloaded1'))
+    preload(key2, () => createResponse('preloaded2'))
+
+    // Only clear key1's preload entry.
+    await globalMutate(k => k === key1, undefined, { revalidate: false })
+
+    function Page1() {
+      const { data } = useSWR(key1, newFetcher1)
+      return <div>one:{data}</div>
+    }
+    function Page2() {
+      const { data } = useSWR(key2, newFetcher2)
+      return <div>two:{data}</div>
+    }
+
+    renderWithGlobalCache(
+      <>
+        <Page1 />
+        <Page2 />
+      </>
+    )
+
+    // key1: preload cleared -> newFetcher1 runs.
+    await screen.findByText('one:fresh1')
+    // key2: preload intact -> its preloaded value is used, newFetcher2 never runs.
+    await screen.findByText('two:preloaded2')
+    expect(newFetcher1).toHaveBeenCalledTimes(1)
+    expect(newFetcher2).not.toHaveBeenCalled()
+  })
+
+  it('wildcard mutate clears an unconsumed preload with an array key', async () => {
+    const key = createKey()
+    const arrayKey = [key, 1]
+    const preloadFetcher = jest.fn(() => createResponse('preloaded'))
+    const newFetcher = jest.fn(() => createResponse('fresh'))
+
+    function Page() {
+      const { data } = useSWR(arrayKey, newFetcher)
+      return <div>data:{data}</div>
+    }
+
+    preload(arrayKey, preloadFetcher)
+    expect(preloadFetcher).toHaveBeenCalledTimes(1)
+
+    // A structural filter must match the array key by its original args, not
+    // the serialized string that PRELOAD is keyed by.
+    await globalMutate(k => Array.isArray(k) && k[0] === key, undefined, {
+      revalidate: false
+    })
+
+    renderWithGlobalCache(<Page />)
+    await screen.findByText('data:fresh')
+    expect(newFetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('wildcard mutate still revalidates a consumed preload as before', async () => {
+    const key = createKey()
+    let count = 0
+    const fetcher = jest.fn(() => createResponse(`v${++count}`))
+
+    function Page() {
+      const { data } = useSWR(key, fetcher, { dedupingInterval: 0 })
+      return <div>data:{data}</div>
+    }
+
+    preload(key, fetcher) // count -> 1
+    renderWithGlobalCache(<Page />) // consumes preload, deletes PRELOAD[key]
+    await screen.findByText('data:v1')
+
+    // Wildcard mutate with revalidation refetches normally.
+    await act(() => globalMutate(() => true))
+    await screen.findByText('data:v2')
+    expect(fetcher).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## What

Wildcard `mutate(keyFilter)` (e.g. `mutate(() => true)`) previously only swept `cache.keys()`. A key that was preloaded via `preload(key, fetcher)` but never mounted lives only in the per-cache `PRELOAD` table, so the wildcard branch never cleared it. This makes the wildcard path clear matching `PRELOAD` entries too, matching what the per-key `mutate(key)` path already does.

## Flow

Happy path (before this change, already correct): 
- `preload(key)` then `useSWR(key)` mounts
- The middleware consumes and deletes `PRELOAD[key]`
- A later `mutate(() => true)` revalidates the cache key normally.

Unhappy path (fixed here): 
- `preload(key)` runs but nothing ever mounts `useSWR(key)`
- The entry sits only in `PRELOAD`
- A `mutate(() => true)` used to skip it, so a later `useSWR(key)` resolved from the stale preloaded promise instead of calling the new fetcher. 
- Now the wildcard branch clears the matching `PRELOAD` entry
- so the next mount fetches fresh.

## Notes

Preloaded requests are tagged with their original key args (`PRELOAD_ARG` symbol) so the filter matches them by the same shape it uses for cache keys (`_k`), not the serialized string. This keeps structural filters (array/object keys) and blanket `() => true` filters both working. `$inf$` / `$sub$` keys stay excluded. Purely additive: no public API or type changes, and non-wildcard mutate is untouched.

Tests cover: unconsumed preload cleared, selective filter clears only matches, array-key structural filter, and consumed-preload revalidation unchanged.