### PR TITLE
Return keyed fallback under keepPreviousData when current key has no cached data

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -180,11 +180,9 @@ export const useSWRHandler = <Data = any, Error = any>(
 
   // Resolve the fallback data from either the inline option, or the global provider.
   // If it's a promise, we simply let React suspend and resolve it for us.
-  const fallback = isUndefined(fallbackData)
-    ? isUndefined(config.fallback)
-      ? UNDEFINED
-      : config.fallback[key]
-    : fallbackData
+  const fallbackFromConfig =
+    isUndefined(fallbackData) && !isUndefined(config.fallback)
+  const fallback = fallbackFromConfig ? config.fallback[key] : fallbackData
   const configCacheData = !key ? UNDEFINED : config.cacheData?.[key]
   const req = key ? PRELOAD[key] : UNDEFINED
   // `cacheData` is request-scoped data provided by a Server Component through
@@ -325,13 +323,16 @@ export const useSWRHandler = <Data = any, Error = any>(
     _k: Key
     key: string
   } | null>(null)
+  const hasFallbackData =
+    fallbackFromConfig && isUndefined(cachedData) && !isUndefined(data)
 
   let returnedData = keepPreviousData
     ? isUndefined(cachedData)
-      ? // checking undefined to avoid null being fallback as well
-        isUndefined(laggyDataRef.current)
+      ? hasFallbackData
         ? data
-        : laggyDataRef.current
+        : isUndefined(laggyDataRef.current)
+          ? data
+          : laggyDataRef.current
       : cachedData
     : data
 
@@ -687,6 +688,8 @@ export const useSWRHandler = <Data = any, Error = any>(
     // it'll be the correct reference.
     if (!isUndefined(cachedData)) {
       laggyDataRef.current = cachedData
+    } else if (keepPreviousData && hasFallbackData) {
+      laggyDataRef.current = data
     }
   })
 

--- a/test/use-swr-laggy.test.tsx
+++ b/test/use-swr-laggy.test.tsx
@@ -96,6 +96,58 @@ describe('useSWR - keep previous data', () => {
     ])
   })
 
+  it('should return fallback data again when switching back to a fallback key', async () => {
+    const key1 = createKey()
+    const key2 = createKey()
+    const fallbackData = 'fallback-data'
+    const fetcher = k => createResponse(`remote:${k}`, { delay: 50 })
+    const swrOptions = { keepPreviousData: true, revalidateIfStale: false }
+    function App() {
+      const [key, setKey] = useState(key1)
+      const { data } = useSWR(key, fetcher, swrOptions)
+      const toggleKey = () => setKey(key === key1 ? key2 : key1)
+      return <button onClick={toggleKey}>data:{data}</button>
+    }
+
+    renderWithConfig(<App />, { fallback: { [key1]: fallbackData } })
+    screen.getByText(`data:${fallbackData}`)
+
+    fireEvent.click(screen.getByText(`data:${fallbackData}`))
+    await act(() => sleep(100))
+    fireEvent.click(screen.getByText(`data:remote:${key2}`))
+    screen.getByText(`data:${fallbackData}`)
+  })
+
+  it('should use keyed fallback as previous data for a later key without fallback', async () => {
+    const key1 = createKey()
+    const key2 = createKey()
+    const key3 = createKey()
+    const fetcher = jest.fn(k => createResponse(`remote:${k}`, { delay: 50 }))
+    const swrOptions = { keepPreviousData: true, revalidateIfStale: false }
+    function App() {
+      const [key, setKey] = useState(key1)
+      const { data } = useSWR(key, fetcher, swrOptions)
+      const advanceKey = () => {
+        setKey(current => (current === key1 ? key2 : key3))
+      }
+      return <button onClick={advanceKey}>data:{data}</button>
+    }
+
+    renderWithConfig(<App />, {
+      fallback: { [key1]: 'fallback-one', [key2]: 'fallback-two' }
+    })
+    screen.getByText('data:fallback-one')
+
+    fireEvent.click(screen.getByText('data:fallback-one'))
+    screen.getByText('data:fallback-two')
+
+    fireEvent.click(screen.getByText('data:fallback-two'))
+    screen.getByText('data:fallback-two')
+    await screen.findByText(`data:remote:${key3}`)
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(fetcher).toHaveBeenCalledWith(key3)
+  })
+
   it('should always return the latest data', async () => {
     const loggedData = []
     const fetcher = k => createResponse(k, { delay: 50 })


### PR DESCRIPTION
Return keyed fallback under keepPreviousData when the current key has no cached data

## Bug

With `keepPreviousData: true`, switching back to a key that has a keyed `SWRConfig` fallback and no cached data returned the previous key's laggy data instead of the current key's fallback value. The keyed fallback for the active key was effectively ignored during the transition.

## Root cause

In `useSWRHandler`, the `keepPreviousData` branch preferred `laggyDataRef.current` (the previous key's data) whenever the current key had no cached data. It never checked whether the current key had its own keyed fallback from `config.fallback[key]`, so the fallback lost to stale previous data.

The fallback resolution also did not track where the fallback came from, so the return path could not tell a keyed `SWRConfig` fallback apart from an inline `fallbackData`.

## Fix

Track fallback provenance with `fallbackFromConfig` (true only when the value comes from the keyed `config.fallback[key]` provider, not inline `fallbackData`). Derive `hasFallbackData = fallbackFromConfig && isUndefined(cachedData) && !isUndefined(data)`, meaning the current key has a real keyed fallback and no cached data.

Two behaviors follow:

1. In the returned data resolution, when `keepPreviousData` is on and there is no cached data, a keyed fallback for the current key now wins over the previous key's `laggyDataRef.current`.
2. In the layout effect, a keyed fallback is propagated into `laggyDataRef.current` so it becomes the previous data for a later key that has no fallback entry. The `!isUndefined(data)` guard prevents overwriting the ref with `undefined`.

Inline `fallbackData` is untouched (`fallbackFromConfig` is false, so `hasFallbackData` is false), preserving the existing "previous data wins over inline fallback" semantics.

## Tests

Added two tests in `test/use-swr-laggy.test.tsx`:

1. Switching back to a key with a keyed `SWRConfig` fallback and no cached data returns that key's fallback, not the previous key's data.
2. A keyed fallback becomes the previous data for a subsequent key that has no fallback entry (multi switch key1 to key2 to key3).

```
yarn jest test/use-swr-laggy.test.tsx --runInBand   # 10 passed (8 original + 2 new)
yarn jest test/use-swr --runInBand                  # 358 passed, 5 skipped, 0 failed
```

Reverting only the `laggyDataRef` propagation branch fails exactly the second new test while the original #3034 test keeps passing, so the two new tests cover distinct code paths. The existing `should keep previous data even if there is fallback data` test still passes, confirming inline `fallbackData` behavior is unchanged.

Fixes #3034
