### PR TITLE
fix: allow null for the fetcher config option

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -259,9 +259,10 @@ export interface PublicConfiguration<
    */
   strictServerPrefetchWarning?: boolean
   /**
-   * the fetcher function
+   * the fetcher function, or `null` to disable fetching (e.g. to override an
+   * inherited fetcher from `SWRConfig`)
    */
-  fetcher?: Fn
+  fetcher?: Fn | null
   /**
    * array of middleware functions
    * @see {@link https://swr.vercel.app/docs/middleware}

--- a/test/type/option-fetcher.ts
+++ b/test/type/option-fetcher.ts
@@ -516,3 +516,11 @@ export function useReturnReadonlyTuple() {
     }
   )
 }
+
+export function useNullFetcherOverride() {
+  // `fetcher: null` disables fetching, overriding an inherited fetcher
+  // from `SWRConfig` (https://github.com/vercel/swr/issues/2888).
+  useSWR('/api/user', null, { fetcher: null })
+  useSWR<{ id: number }>('/api/', { fetcher: null })
+  useSWRInfinite<number[]>(() => '/api/', { fetcher: null })
+}

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -36,6 +36,28 @@ describe('useSWR - configs', () => {
     await screen.findByText('data: 1')
   })
 
+  it('should not fetch when the inherited fetcher is overridden with null', async () => {
+    const globalFetcher = jest.fn(() => 'global')
+    const key = createKey()
+
+    function Page() {
+      const { data, isLoading } = useSWR(key, null, { fetcher: null })
+      return (
+        <div>
+          data: {data === undefined ? 'undefined' : data},{' '}
+          {isLoading ? 'loading' : 'idle'}
+        </div>
+      )
+    }
+    renderWithConfig(<Page />, { fetcher: globalFetcher, dedupingInterval: 0 })
+
+    screen.getByText('data: undefined, idle')
+    await act(() => sleep(50))
+
+    screen.getByText('data: undefined, idle')
+    expect(globalFetcher).not.toHaveBeenCalled()
+  })
+
   it('should stop revalidations when config.isPaused returns true', async () => {
     const key = createKey()
     let value = 0


### PR DESCRIPTION
Fixes #2888

## Problem

Overriding an inherited fetcher (from `SWRConfig`) with `{ fetcher: null }` already works at runtime — `mergeConfigs` spreads the local config over the context config, so the merged `config.fetcher` becomes `null` and `withArgs` resolves `fn || config.fetcher || null` to `null`, disabling fetching. But the `SWRConfiguration` type declares `fetcher?: Fn`, so the only working override doesn't typecheck and needs a `@ts-ignore`:

```tsx
// runtime: no request. types: error.
useSWR('state', null, { fetcher: null })
```

(Note the `null` second argument alone can't do it: `withArgs` intentionally falls back to the context fetcher there, and changing that would be a behavioral break — so the config override is the supported escape hatch, it just wasn't typed.)

## Fix

Type the option as `fetcher?: Fn | null` and document that `null` disables fetching. `withArgs` is already null-safe (single consumer of `config.fetcher`).

## Tests

- Runtime: with a global fetcher in `SWRConfig`, `useSWR(key, null, { fetcher: null })` renders idle, never calls the global fetcher.
- Type tests: `fetcher: null` accepted for `useSWR` (2- and 3-arg forms) and `useSWRInfinite`.
- `tsc --noEmit`, oxlint, and the config test suite pass.