### PR TITLE
fix: release the correct listener set when initCache is re-entered under StrictMode

### DIFF
--- a/src/_internal/utils/cache.ts
+++ b/src/_internal/utils/cache.ts
@@ -191,7 +191,13 @@ export const initCache = <Data = any>(
     // We might want to inject an extra layer on top of `provider` in the future,
     // such as key serialization, auto GC, etc.
     // For now, it's just a `Map` interface without any modifications.
-    return [provider, mutate, initProvider, unmount, unload]
+    // The 4th element defers to a live read of `unmount` instead of freezing
+    // its current value: under StrictMode, the caller's effect can run
+    // cleanup-then-setup again before ever calling this, which re-invokes
+    // `initProvider` and reassigns `unmount` to a new closure over fresh
+    // listeners. A frozen snapshot here would keep pointing at the first,
+    // already-released set, leaking the second set's listeners forever.
+    return [provider, mutate, initProvider, () => unmount(), unload]
   }
 
   const state = SWRGlobalState.get(provider) as GlobalState

--- a/test/use-swr-init-cache.test.tsx
+++ b/test/use-swr-init-cache.test.tsx
@@ -1,0 +1,56 @@
+import { initCache } from 'swr/_internal'
+
+describe('initCache', () => {
+  it('should release the listeners from the latest initProvider() call, not a stale snapshot', () => {
+    // Simulates exactly the sequence SWRConfig's effect produces under
+    // StrictMode: render calls initCache() once; the effect then does
+    // setup -> simulated cleanup -> setup again -> (eventually) real
+    // cleanup, reusing the same returned tuple throughout.
+    const provider = new Map()
+    let initCount = 0
+    const released: number[] = []
+
+    const initFocus = () => {
+      initCount++
+      const myInit = initCount
+      return () => {
+        released.push(myInit)
+      }
+    }
+    const initReconnect = () => () => undefined
+
+    const tuple = initCache(provider, { initFocus, initReconnect })
+    const [, , initProvider, unmount] = tuple as [
+      unknown,
+      unknown,
+      () => void,
+      () => void
+    ]
+
+    expect(initCount).toBe(1)
+
+    // Effect setup #1 (StrictMode's first invoke): initProvider() is a
+    // no-op here, the state from the render-time initCache() call above
+    // is still present.
+    initProvider()
+    expect(initCount).toBe(1)
+
+    // StrictMode's simulated cleanup: releases listener set #1 and tears
+    // down the provider's global state.
+    unmount()
+    expect(released).toEqual([1])
+
+    // StrictMode's re-setup: state is gone, so this genuinely re-runs and
+    // registers a second, independent listener set.
+    initProvider()
+    expect(initCount).toBe(2)
+
+    // The real, final cleanup. The tuple's own `unmount` reference must
+    // resolve to whichever listener set is actually live right now (set
+    // #2), not the already-released set #1 it was holding when the tuple
+    // was first created. A stale reference would call release #1 again
+    // here (released = [1, 1]) and leak set #2's listeners forever.
+    unmount()
+    expect(released).toEqual([1, 2])
+  })
+})


### PR DESCRIPTION
## Summary

`initCache()` returned a frozen snapshot of its `unmount` closure variable in the tuple's 4th element. `SWRConfig`'s effect reuses this same tuple across StrictMode's simulated cleanup-then-resetup:

1. The simulated cleanup correctly releases the first `focus`/`reconnect` listener set and tears down the provider's global state.
2. The resulting re-setup calls `initProvider()` again, which (since the state is now gone) genuinely re-runs and reassigns the internal `unmount` variable to a **new** closure over a second, independent listener set.
3. The tuple's 4th element still points at the **first** closure, so the real, final cleanup releases the (already-released) first set again instead of the second, leaking its listeners for the life of the page.

This is dev-only (StrictMode's double-invoke is stripped from production builds), so there's no production runtime-correctness impact, just a real, deterministic resource-cleanup gap in development.

## Fix

Wrap the tuple's exposed `unmount` in a thunk that defers to a live read of the closure variable, so whichever listener set is actually current gets released, regardless of how many times `initProvider()` re-ran in between:

```diff
- return [provider, mutate, initProvider, unmount, unload]
+ return [provider, mutate, initProvider, () => unmount(), unload]
```

## Testing

Added `test/use-swr-init-cache.test.tsx`, which exercises `initCache()` directly through the exact call sequence `SWRConfig`'s effect produces (setup, simulated cleanup, re-setup, real cleanup), asserting the second listener set is the one that actually gets released. Confirmed it fails against the unfixed code (both cleanups incorrectly release the first set, `released` ends up `[1, 1]` instead of `[1, 2]`) and passes with the fix.

Also verified end-to-end against the actual built `dist/_internal/index.mjs` (not just source + jest), confirming the fix holds through the real build pipeline. Full test suite, `tsc --noEmit`, and `oxlint` all pass.