### PR TITLE
fix: useSWRMutation isMutating never shows true when called inside <form action>

### DIFF
--- a/src/mutation/index.ts
+++ b/src/mutation/index.ts
@@ -71,7 +71,13 @@ const mutation = (<Data, Error>() =>
 
         ditchMutationsUntilRef.current = mutationStartedAt
 
-        setState({ isMutating: true })
+        // Schedule the isMutating update outside any React transition context
+        // (e.g. when trigger is called inside a <form action> handler) so it
+        // renders as an urgent update instead of being deferred.
+        let didErrorSync = false
+        queueMicrotask(() => {
+          if (!didErrorSync) setState({ isMutating: true })
+        })
 
         try {
           const data = await mutate<Data>(
@@ -90,6 +96,8 @@ const mutation = (<Data, Error>() =>
           }
           return data
         } catch (error) {
+          didErrorSync = true
+
           // If it's reset after the mutation, we don't broadcast any state change
           // or throw because it's discarded.
           if (ditchMutationsUntilRef.current <= mutationStartedAt) {

--- a/test/use-swr-remote-mutation.test.tsx
+++ b/test/use-swr-remote-mutation.test.tsx
@@ -225,6 +225,37 @@ describe('useSWR - remote mutation', () => {
     await screen.findByText('state:data')
   })
 
+  it('should return `isMutating` state correctly when triggered inside a React transition', async () => {
+    const key = createKey()
+
+    function Page() {
+      const { data, trigger, isMutating } = useSWRMutation(key, async () => {
+        await sleep(10)
+        return 'data'
+      })
+      return (
+        <button
+          onClick={() => {
+            React.startTransition(() => {
+              trigger()
+            })
+          }}
+        >
+          state:{(isMutating ? 'pending' : data) || ''}
+        </button>
+      )
+    }
+
+    render(<Page />)
+
+    // mount
+    await screen.findByText('state:')
+    fireEvent.click(screen.getByText('state:'))
+
+    await screen.findByText('state:pending')
+    await screen.findByText('state:data')
+  })
+
   it('should send `onError` and `onSuccess` events', async () => {
     const key = createKey()
     const onSuccess = jest.fn()


### PR DESCRIPTION
Closes #4247
## What was the issue
When `useSWRMutation`'s `trigger` is called as a `<form action>` handler
(React 19+), the `isMutating` flag never transitions to `true`. The button
stays stuck showing its default state instead of briefly showing a loading
state during the mutation.
## Where was the issue
`src/mutation/index.ts`, line 74 — the synchronous
`setState(
{
isMutating: true })` call.
React wraps `<form action>` handlers in an async transition (similar to
`startTransition` but spanning the entire async function across `await`
boundaries). The `setState(
{
isMutating: true })` runs inside that
transition scope, so React defers the re-render. The function immediately
`await`s the mutation, and by the time the transition would commit,
`isMutating` is already set back to `false` on lines 92-93.
## How it was fixed
The `isMutating: true` update is now scheduled via `queueMicrotask`
instead of being called synchronously. The microtask fires after the
`<form action>`'s synchronous transition callback returns (escaping its
scope), so React treats the update as urgent and renders it before the
`await mutate(...)` continuation runs.
A `didErrorSync` guard flag prevents the microtask from overwriting
`isMutating` if the fetcher throws synchronously — the catch block sets
`didErrorSync = true` before the microtask fires.
**Files changed:**
- `src/mutation/index.ts` — 1 line removed, 9 lines added
- `test/use-swr-remote-mutation.test.tsx` — 31-line test case added
## Why this approach over others
**`flushSync` (react-dom)** — SWR targets React Native too and has zero
dependency on `react-dom`. Adding it would break that contract.
**`useTransition` hook** — would require restructuring `trigger` to return
its data through the transition, changing the public API and risking
subtle timing regressions.
**`setTimeout(fn, 0)`** — introduces a visible frame delay.
`queueMicrotask` fires before the next paint, so there's no perceptible lag.
**`queueMicrotask`** — minimal, surgical change. The microtask fires
immediately after the synchronous `<form action>` callback returns (and
the transition scope ends), so React processes the update as urgent. No
API changes, no new dependencies, no architectural changes.
## How to test locally
```bash
pnpm jest test/use-swr-remote-mutation.test.tsx --no-coverage
pnpm types:check
pnpm lint