### PR TITLE
fix: track window focus for refreshWhenHidden during OS-level window switches

### DIFF
--- a/src/_internal/utils/web-preset.ts
+++ b/src/_internal/utils/web-preset.ts
@@ -12,6 +12,13 @@ import { isUndefined, noop } from './shared'
 let online = true
 const isOnline = () => online
 
+/**
+ * Track window focus state to handle OS-level window switches (Alt-Tab)
+ * where document.visibilityState may remain 'visible' but the window
+ * has lost focus. This ensures refreshWhenHidden works correctly.
+ */
+let focused = true
+
 // For node and React Native, `add/removeEventListener` doesn't exist on window.
 const [onWindowEvent, offWindowEvent] =
   isWindowDefined && window.addEventListener
@@ -23,7 +30,10 @@ const [onWindowEvent, offWindowEvent] =
 
 const isVisible = () => {
   const visibilityState = isDocumentDefined && document.visibilityState
-  return isUndefined(visibilityState) || visibilityState !== 'hidden'
+  if (!isUndefined(visibilityState) && visibilityState === 'hidden') {
+    return false
+  }
+  return focused
 }
 
 const initFocus = (callback: () => void) => {
@@ -32,11 +42,26 @@ const initFocus = (callback: () => void) => {
     document.addEventListener('visibilitychange', callback)
   }
   onWindowEvent('focus', callback)
+
+  // Track window focus/blur for OS-level window switches (Alt-Tab).
+  // visibilityState may remain 'visible' when alt-tabbing, so we track
+  // window focus state to ensure refreshWhenHidden works correctly.
+  const onFocus = () => {
+    focused = true
+  }
+  const onBlur = () => {
+    focused = false
+  }
+  onWindowEvent('focus', onFocus)
+  onWindowEvent('blur', onBlur)
+
   return () => {
     if (isDocumentDefined) {
       document.removeEventListener('visibilitychange', callback)
     }
     offWindowEvent('focus', callback)
+    offWindowEvent('focus', onFocus)
+    offWindowEvent('blur', onBlur)
   }
 }
 

--- a/test/unit/web-preset.test.ts
+++ b/test/unit/web-preset.test.ts
@@ -92,3 +92,67 @@ function runTests(propertyName) {
 
 runTests('window')
 runTests('document')
+
+describe('Web Preset isVisible', () => {
+  const globalSpy = {
+    window: undefined as any,
+    document: undefined as any
+  }
+
+  beforeEach(() => {
+    globalSpy.window = jest.spyOn(global, 'window', 'get')
+    globalSpy.document = jest.spyOn(global, 'document', 'get')
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    globalSpy.window.mockClear()
+    globalSpy.document.mockClear()
+  })
+
+  it('should return true when visibilityState is visible and window is focused', () => {
+    const target = createEventTarget()
+    ;(target as any).visibilityState = 'visible'
+    globalSpy.window.mockImplementation(() => target)
+    globalSpy.document.mockImplementation(() => target)
+
+    const { preset: p } = require('swr/_internal')
+    expect(p.isVisible()).toBe(true)
+  })
+
+  it('should return false when visibilityState is hidden', () => {
+    const target = createEventTarget()
+    ;(target as any).visibilityState = 'hidden'
+    globalSpy.window.mockImplementation(() => undefined)
+    globalSpy.document.mockImplementation(() => target)
+
+    const { preset: p } = require('swr/_internal')
+    expect(p.isVisible()).toBe(false)
+  })
+
+  it('should return false when window loses focus (Alt-Tab / OS-level window switch)', () => {
+    const target = createEventTarget()
+    ;(target as any).visibilityState = 'visible'
+    globalSpy.window.mockImplementation(() => target)
+    globalSpy.document.mockImplementation(() => target)
+
+    const { preset: p } = require('swr/_internal')
+    expect(p.isVisible()).toBe(true)
+
+    // Simulate Alt-Tab by emitting blur event on window
+    target.emit('blur')
+    expect(p.isVisible()).toBe(false)
+
+    // Simulate returning to the window
+    target.emit('focus')
+    expect(p.isVisible()).toBe(true)
+  })
+
+  it('should return true when document is not defined (server / React Native)', () => {
+    globalSpy.window.mockImplementation(() => undefined)
+    globalSpy.document.mockImplementation(() => undefined)
+
+    const { preset: p } = require('swr/_internal')
+    expect(p.isVisible()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Fixes #3039

### Problem
\efreshWhenHidden: false\ does not prevent revalidation when the user Alt-Tabs to another application, because \document.visibilityState\ remains \'visible'\ during OS-level window switches (it only transitions to \'hidden'\ on intra-browser tab switches).

### Root Cause
\isVisible()\ in \src/_internal/utils/web-preset.ts\ only checks \document.visibilityState\, which doesn't detect OS-level window focus changes.

### Fix
Track window focus state via \lur\/\ocus\ events alongside the existing visibility state check. When the window loses focus (Alt-Tab), \isVisible()\ now returns \alse\, correctly pausing polling when \efreshWhenHidden: false\.

### Changes
- **\src/_internal/utils/web-preset.ts\**: Added \ocused\ state variable tracked by \lur\/\ocus\ event listeners in \initFocus\. Updated \isVisible()\ to return \alse\ when the window is unfocused.
- **\	est/unit/web-preset.test.ts\**: Added unit tests for \isVisible\ covering blur/focus state transitions and server-side rendering.

### Test Results
- All existing tests pass (pre-existing failures in subscription/remote-mutation/error/local-mutation suites are unrelated and also fail on the base branch)
- New tests verify: Alt-Tab detection via blur event, focus restoration via focus event, hidden visibility state, and server-side rendering

### Behavior
| Scenario | Before | After |
|---|---|---|
| Normal use (visible + focused) | ✅ | ✅ |
| Alt-Tab (visible + unfocused) | ❌ Polls anyway | ✅ Polling paused |
| Tab switch (hidden) | ✅ | ✅ |
| Server / React Native | ✅ | ✅ |
