### PR TITLE
fix: skip isLoading when fallback data is available

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -476,7 +476,7 @@ export const useSWRHandler = <Data = any, Error = any>(
       const initialState: State<Data, Error> = { isValidating: true }
       // It is in the `isLoading` state, if and only if there is no cached data.
       // This bypasses fallback data and laggy data.
-      if (isUndefined(getCache().data)) {
+      if (isUndefined(getCache().data) && isUndefined(fallback)) {
         initialState.isLoading = true
       }
       try {


### PR DESCRIPTION
When a component provides `fallbackData` or a `SWRConfig` `fallback` map, the hook resolves a non-undefined `fallback` value at line 183. However the `isLoading` guard at line 479 only checks the internal cache — it misses the resolved fallback entirely.

The comment on the guarded block even says "This bypasses fallback data and laggy data", but the condition didn't actually bypass fallback. Result: `isLoading` fires as `true` on initial render even though the UI is already showing fallback data, causing unnecessary loading skeletons in SSR and App Router setups.

Add `&& isUndefined(fallback)` so `isLoading` is only set when there's genuinely nothing to show — no cached data and no fallback.

Closes #3046