### PR TITLE
chore: remove deprecated eslint config files

### DIFF
--- a/examples/.eslintrc
+++ b/examples/.eslintrc
@@ -1,2 +1,0 @@
-// next is loading eslintrc from the root directory, adding this to avoid eslint rules being overridden
-{}

--- a/test/type/.eslintrc
+++ b/test/type/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": "../../.eslintrc",
-  "rules": {
-    "react-hooks/rules-of-hooks": 0
-  }
-}


### PR DESCRIPTION
The repository has migrated from ESLint to oxlint (see commit c822a5d). These .eslintrc files are no longer needed.

Removed:

examples/.eslintrc (empty placeholder)
test/type/.eslintrc (orphaned, extends non-existent root config)