### PR TITLE
fix: clean up completed subscription state

### DIFF
--- a/src/subscription/index.ts
+++ b/src/subscription/index.ts
@@ -90,6 +90,11 @@ export const subscription = (<Data = any, Error = any>(useSWRNext: SWRHook) =>
         if (!count) {
           const dispose = disposers.get(subscriptionKey)
           dispose?.()
+
+          // Remove both entries, so the internal states only retain the
+          // subscription keys that currently have active subscribers.
+          subscriptions.delete(subscriptionKey)
+          disposers.delete(subscriptionKey)
         }
       }
     }, [subscriptionKey])

--- a/test/use-swr-subscription.test.tsx
+++ b/test/use-swr-subscription.test.tsx
@@ -321,4 +321,52 @@ describe('useSWRSubscription', () => {
       'The `subscribe` function must return a function to unsubscribe.'
     )
   })
+
+  it('should clean up the subscription state after the last subscriber unmounts', async () => {
+    const swrKey = createKey()
+
+    let subscribeCount = 0
+    let disposeCount = 0
+
+    function subscribe(key, { next }) {
+      ++subscribeCount
+      next(undefined, key)
+      return () => {
+        ++disposeCount
+      }
+    }
+
+    function Sub() {
+      useSWRSubscription(swrKey, subscribe)
+      useSWRSubscription(swrKey, subscribe)
+      useSWRSubscription(swrKey, subscribe)
+      return null
+    }
+
+    function Page() {
+      const [mounted, setMounted] = useState(true)
+      return (
+        <>
+          <button onClick={() => setMounted(v => !v)}>toggle</button>
+          {mounted ? <Sub /> : null}
+        </>
+      )
+    }
+
+    renderWithConfig(<Page />)
+    await act(() => sleep(10))
+
+    // Multiple hooks with the same key share a single subscription.
+    expect(subscribeCount).toBe(1)
+    expect(disposeCount).toBe(0)
+
+    // Unmounting the last subscriber disposes the subscription.
+    fireEvent.click(screen.getByText('toggle'))
+    expect(disposeCount).toBe(1)
+
+    // The state is fully cleaned up, so remounting starts fresh.
+    fireEvent.click(screen.getByText('toggle'))
+    expect(subscribeCount).toBe(2)
+    expect(disposeCount).toBe(1)
+  })
 })


### PR DESCRIPTION
Closes #4261

## Summary

- Remove the final subscriber's stale ref-count and disposer entries from the cache-bound Maps.
- Add a regression test covering deduplication, disposal, and a fresh remount.

## Verification

local verification not run; relying on upstream CI

The worktree has no installed `node_modules`, so the repository's Jest command cannot run locally.
