### PR TITLE
fix: allow null fetcher to override global config

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -291,9 +291,10 @@ export interface PublicConfiguration<
    */
   strictServerPrefetchWarning?: boolean
   /**
-   * the fetcher function
+   * the fetcher function, or `null` to disable data fetching (e.g. to
+   * explicitly override an inherited global fetcher)
    */
-  fetcher?: Fn
+  fetcher?: Fn | null
   /**
    * array of middleware functions
    * @see {@link https://swr.vercel.app/docs/middleware}

--- a/src/_internal/utils/normalize-args.ts
+++ b/src/_internal/utils/normalize-args.ts
@@ -9,7 +9,17 @@ export const normalize = <KeyType = Key, Data = any>(
     | [KeyType, SWRConfiguration | undefined]
     | [KeyType, Fetcher<Data> | null, SWRConfiguration | undefined]
 ): [KeyType, Fetcher<Data> | null, Partial<SWRConfiguration<Data>>] => {
+  // An explicit `null` fetcher disables the request and must override an
+  // inherited global fetcher. Since the hook falls back to `config.fetcher`
+  // when the normalized fetcher argument is falsy, we set `fetcher: null` in
+  // the hook-level config so the config merge resolves to `null` instead of
+  // restoring the inherited fetcher. An omitted or `undefined` fetcher still
+  // inherits the global one.
   return isFunction(args[1])
     ? [args[0], args[1], args[2] || {}]
-    : [args[0], null, (args[1] === null ? args[2] : args[1]) || {}]
+    : [
+        args[0],
+        null,
+        (args[1] === null ? { ...args[2], fetcher: null } : args[1]) || {}
+      ]
 }

--- a/test/type/config.tsx
+++ b/test/type/config.tsx
@@ -244,3 +244,19 @@ export function useTestProviderConfig() {
     </GlobalSetting>
   )
 }
+
+export function useTestNullFetcher() {
+  // A `null` fetcher disables the request and overrides an inherited global
+  // fetcher, both as the hook argument and inside the options object.
+  const { data: data1 } = useSWR('/api', null)
+  expectType<any>(data1)
+
+  const { data: data2 } = useSWR('/api', { fetcher: null })
+  expectType<any>(data2)
+
+  const { data: data3 } = useSWR('/api', null, { fetcher: null })
+  expectType<any>(data3)
+
+  const configValue: SWRConfigValue = { fetcher: null }
+  expectType<SWRConfigValue>(configValue)
+}

--- a/test/use-swr-fetcher.test.tsx
+++ b/test/use-swr-fetcher.test.tsx
@@ -3,9 +3,11 @@ import { Suspense, useState, act } from 'react'
 import useSWR from 'swr'
 import {
   createKey,
+  createResponse,
   renderWithConfig,
   nextTick,
-  itShouldSkipForReactCanary
+  itShouldSkipForReactCanary,
+  sleep
 } from './utils'
 
 describe('useSWR - fetcher', () => {
@@ -133,5 +135,52 @@ describe('useSWR - fetcher', () => {
 
     rerender(<Page fetcher={false} />)
     screen.getByText('data:')
+  })
+
+  it('should not fetch with a null fetcher even when a global fetcher is configured', async () => {
+    const key = createKey()
+    const fetcher = jest.fn(() => createResponse('data'))
+
+    function Page() {
+      const { data, isValidating } = useSWR(key, null)
+      return <div>data:{String(data)} validating:{String(isValidating)}</div>
+    }
+
+    renderWithConfig(<Page />, { fetcher })
+
+    screen.getByText('data:undefined validating:false')
+    await act(() => sleep(50))
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('should not fetch with `fetcher: null` in the config even when a global fetcher is configured', async () => {
+    const key = createKey()
+    const fetcher = jest.fn(() => createResponse('data'))
+
+    function Page() {
+      const { data } = useSWR(key, { fetcher: null })
+      return <div>data:{String(data)}</div>
+    }
+
+    renderWithConfig(<Page />, { fetcher })
+
+    screen.getByText('data:undefined')
+    await act(() => sleep(50))
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('should still use the global fetcher when the hook fetcher is not specified', async () => {
+    const key = createKey()
+    const fetcher = jest.fn(() => createResponse('data'))
+
+    function Page() {
+      const { data } = useSWR<string>(key)
+      return <div>data:{String(data)}</div>
+    }
+
+    renderWithConfig(<Page />, { fetcher })
+
+    await screen.findByText('data:data')
+    expect(fetcher).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
Fixes #2888

## Summary
- allow an explicit null fetcher to override an inherited global fetcher
- preserve global fetcher behavior when the hook fetcher is omitted
- add runtime and type coverage for the null and omitted cases

## Validation
- git apply --check --recount: passed
- git diff --check: passed
- local Jest/type checks unavailable because this checkout has no node_modules; CI should run the full workflow.