### PR TITLE
fix: revalidate suspense cacheData on remount

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -286,8 +286,10 @@ export const useSWRHandler = <Data = any, Error = any>(
         // If `revalidateOnMount` is set, we take the value directly.
         if (isInitialMount && !isUndefined(revalidateOnMount))
           return revalidateOnMount
-        if (suspense && hasCacheData) return false
         const data = !isUndefined(fallback) ? fallback : snapshot.data
+        // cacheData is consumed during the initial Suspense render. Once data
+        // is cached, fall through to the normal mount revalidation policy.
+        if (suspense && hasCacheData && isUndefined(data)) return false
         if (suspense) return isUndefined(data) || revalidateIfStale
         return isUndefined(data) || revalidateIfStale
       })()
@@ -448,7 +450,9 @@ export const useSWRHandler = <Data = any, Error = any>(
     // If `revalidateOnMount` is set, we take the value directly.
     if (isInitialMount && !isUndefined(revalidateOnMount))
       return revalidateOnMount
-    if (suspense && hasCacheData) return false
+    // cacheData satisfies the initial Suspense render without a duplicate
+    // request. Cached data on a later mount follows revalidateIfStale.
+    if (suspense && hasCacheData && hasKeyButNoData) return false
     // Under suspense mode, it will always fetch on render if there is no
     // stale data so no need to revalidate immediately mount it again.
     // If data exists, only revalidate if `revalidateIfStale` is true.

--- a/test/e2e/promise-scenarios.test.ts
+++ b/test/e2e/promise-scenarios.test.ts
@@ -71,9 +71,18 @@ test.describe('promise scenarios', () => {
     ).toHaveCount(0)
     expect(clientFetcherCalls).toBe(0)
 
-    await page.getByTestId('revalidate').click()
+    await page.getByTestId('toggle-mounted').click()
+    await expect(page.getByTestId('data')).toHaveCount(0)
+    await page.getByTestId('toggle-mounted').click()
 
     await expect.poll(() => clientFetcherCalls).toBe(1)
+    await expect(page.getByTestId('data')).toHaveText(
+      'data:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
+    )
+
+    await page.getByTestId('revalidate').click()
+
+    await expect.poll(() => clientFetcherCalls).toBe(2)
     await expect(page.getByTestId('data')).toHaveText(
       'data:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
     )
@@ -81,7 +90,7 @@ test.describe('promise scenarios', () => {
       'cache:CLIENT_FETCHER_RESULT_AFTER_TRIGGER'
     )
     await expect(page.getByTestId('client-fetches')).toHaveText(
-      'client fetches:1'
+      'client fetches:2'
     )
   })
 

--- a/test/e2e/site/app/rsc-unstable-preload/client.tsx
+++ b/test/e2e/site/app/rsc-unstable-preload/client.tsx
@@ -30,6 +30,7 @@ function ClientData({
 
 export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
   const [clientFetches, setClientFetches] = useState(0)
+  const [mounted, setMounted] = useState(true)
   const fetcher = useCallback(async () => {
     ;(
       window as typeof window & {
@@ -42,9 +43,17 @@ export function ClientRoot({ cacheData }: { cacheData: CacheData<string> }) {
 
   return (
     <SWRConfig value={{ cacheData }}>
-      <Suspense fallback={<div data-testid="fallback">loading</div>}>
-        <ClientData fetcher={fetcher} clientFetches={clientFetches} />
-      </Suspense>
+      <button
+        data-testid="toggle-mounted"
+        onClick={() => setMounted(current => !current)}
+      >
+        {mounted ? 'unmount' : 'mount'}
+      </button>
+      {mounted && (
+        <Suspense fallback={<div data-testid="fallback">loading</div>}>
+          <ClientData fetcher={fetcher} clientFetches={clientFetches} />
+        </Suspense>
+      )}
     </SWRConfig>
   )
 }

--- a/test/use-swr-config.test.tsx
+++ b/test/use-swr-config.test.tsx
@@ -11,6 +11,35 @@ import {
   sleep
 } from './utils'
 
+function renderSuspenseCacheData({
+  key,
+  fetcher,
+  revalidateIfStale,
+  revalidateOnMount
+}: {
+  key: string
+  fetcher: () => Promise<string>
+  revalidateIfStale?: boolean
+  revalidateOnMount?: boolean
+}) {
+  function Page() {
+    const { data } = useSWR(key, fetcher, {
+      suspense: true,
+      ...(revalidateIfStale === undefined ? {} : { revalidateIfStale }),
+      ...(revalidateOnMount === undefined ? {} : { revalidateOnMount })
+    })
+    return <div>data:{data}</div>
+  }
+
+  return renderWithGlobalCache(
+    <SWRConfig value={{ cacheData: { [key]: 'server data' } }}>
+      <Suspense fallback={<div>loading</div>}>
+        <Page />
+      </Suspense>
+    </SWRConfig>
+  )
+}
+
 describe('useSWR - configs', () => {
   it('should read the config fallback from the context', async () => {
     let value = 0
@@ -152,6 +181,99 @@ describe('useSWR - configs', () => {
       screen.getByText('data:server data')
       await act(() => sleep(50))
       expect(clientFetcher).toHaveBeenCalledTimes(0)
+    }
+  )
+
+  itShouldSkipForReactCanary(
+    'should revalidate on remount after suspense consumes cacheData',
+    async () => {
+      const key = createKey()
+      const clientFetcher = jest.fn(() => createResponse('client data'))
+
+      const firstRender = renderSuspenseCacheData({
+        key,
+        fetcher: clientFetcher
+      })
+
+      screen.getByText('data:server data')
+      await act(() => sleep(50))
+      expect(clientFetcher).not.toHaveBeenCalled()
+
+      firstRender.unmount()
+      renderSuspenseCacheData({ key, fetcher: clientFetcher })
+
+      await screen.findByText('data:client data')
+      expect(clientFetcher).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  itShouldSkipForReactCanary(
+    'should respect revalidateIfStale after suspense consumes cacheData',
+    async () => {
+      const key = createKey()
+      const clientFetcher = jest.fn(() => createResponse('client data'))
+
+      const firstRender = renderSuspenseCacheData({
+        key,
+        fetcher: clientFetcher,
+        revalidateIfStale: false
+      })
+
+      screen.getByText('data:server data')
+      firstRender.unmount()
+      renderSuspenseCacheData({
+        key,
+        fetcher: clientFetcher,
+        revalidateIfStale: false
+      })
+
+      await act(() => sleep(50))
+      screen.getByText('data:server data')
+      expect(clientFetcher).not.toHaveBeenCalled()
+    }
+  )
+
+  itShouldSkipForReactCanary(
+    'should respect revalidateOnMount false after suspense consumes cacheData',
+    async () => {
+      const key = createKey()
+      const clientFetcher = jest.fn(() => createResponse('client data'))
+
+      const firstRender = renderSuspenseCacheData({
+        key,
+        fetcher: clientFetcher,
+        revalidateOnMount: false
+      })
+
+      screen.getByText('data:server data')
+      firstRender.unmount()
+      renderSuspenseCacheData({
+        key,
+        fetcher: clientFetcher,
+        revalidateOnMount: false
+      })
+
+      await act(() => sleep(50))
+      screen.getByText('data:server data')
+      expect(clientFetcher).not.toHaveBeenCalled()
+    }
+  )
+
+  itShouldSkipForReactCanary(
+    'should respect revalidateOnMount true when suspense consumes cacheData',
+    async () => {
+      const key = createKey()
+      const clientFetcher = jest.fn(() => createResponse('client data'))
+
+      renderSuspenseCacheData({
+        key,
+        fetcher: clientFetcher,
+        revalidateOnMount: true
+      })
+
+      screen.getByText('data:server data')
+      await screen.findByText('data:client data')
+      expect(clientFetcher).toHaveBeenCalledTimes(1)
     }
   )
 


### PR DESCRIPTION
## Problem

When `suspense: true` is set and `cacheData` is present for the key, current implementation does not revalidate on unmount/remount even when `revalidateIfStale: true` is set, preventing automatic client-side mount revalidation indefinitely when both options are used.

This PR restores the normal `revalidateOnMount` / `revalidateIfStale` behavior after the server-loaded value has entered the SWR cache.

> Context: In our app, we rely on automatic remount revalidation on SPA navigation to achieve MPA-like refetch behavior so that we only have to cal `mutate()` keys within the same page for UI consistency. We still want to skip initial duplicate fetches but need remount re-validations to achieve this behavior.

## Summary

- Skip `cacheData` revalidation only for the render where no cached data exists
- Extend the RSC preload E2E to cover unmounting and remounting behaviors with suspense: true
## Behavior

| Scenario | Browser fetches |
| --- | ---: |
| Initial Suspense render with an empty SWR cache and `cacheData` | 0 |
| Later remount with cached data and default options | 1 |
| Later remount with `revalidateIfStale: false` | 0 |
| Later remount with `revalidateOnMount: false` | 0 |
| Initial mount with explicit `revalidateOnMount: true` | 1 |

This PR now covers common application behaviors for suspense-enabled SWR hooks
- Allows re-mount revalidations but skips initial duplicate client-side mount revalidation with `revalidateOnMount: undefined`(default) 
- Skip mount revalidation indefinitely with `revalidateIfStale: false`
- Allows initial duplicate client-side revalidation and later remount revalidations with explicit `revalidateOnMount: true` (unchanged)

## Tests
- Added unit tests and e2e tests to cover those scenarios