### PR TITLE
chore: bump version to 2.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swr",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "React Hooks library for remote data fetching",
   "keywords": [
     "swr",


### PR DESCRIPTION
bump to 2.5.1