### PR TITLE
fix: consider document focus for visibility

### DIFF
--- a/src/_internal/utils/web-preset.ts
+++ b/src/_internal/utils/web-preset.ts
@@ -1,6 +1,6 @@
 import type { ProviderConfiguration } from '../types'
 import { isWindowDefined, isDocumentDefined } from './helper'
-import { isUndefined, noop } from './shared'
+import { isFunction, isUndefined, noop } from './shared'
 
 /**
  * Due to the bug https://bugs.chromium.org/p/chromium/issues/detail?id=678075,
@@ -23,7 +23,15 @@ const [onWindowEvent, offWindowEvent] =
 
 const isVisible = () => {
   const visibilityState = isDocumentDefined && document.visibilityState
-  return isUndefined(visibilityState) || visibilityState !== 'hidden'
+  if (!isUndefined(visibilityState) && visibilityState === 'hidden') {
+    return false
+  }
+
+  if (isDocumentDefined && isFunction(document.hasFocus)) {
+    return document.hasFocus()
+  }
+
+  return true
 }
 
 const initFocus = (callback: () => void) => {

--- a/test/unit/web-preset.test.ts
+++ b/test/unit/web-preset.test.ts
@@ -92,3 +92,58 @@ function runTests(propertyName) {
 
 runTests('window')
 runTests('document')
+
+describe('Web Preset visibility', () => {
+  let documentSpy
+
+  beforeEach(() => {
+    documentSpy = jest.spyOn(global, 'document', 'get')
+    jest.resetModules()
+  })
+
+  afterEach(() => {
+    documentSpy.mockRestore()
+  })
+
+  const loadIsVisible = (documentMock: Partial<Document> | undefined) => {
+    documentSpy.mockImplementation(() => documentMock)
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('swr/_internal').preset.isVisible
+  }
+
+  it('should be visible when document visibility is visible and focused', () => {
+    const isVisible = loadIsVisible({
+      visibilityState: 'visible',
+      hasFocus: () => true
+    })
+
+    expect(isVisible()).toBe(true)
+  })
+
+  it('should not be visible when document visibility is hidden', () => {
+    const isVisible = loadIsVisible({
+      visibilityState: 'hidden',
+      hasFocus: () => true
+    })
+
+    expect(isVisible()).toBe(false)
+  })
+
+  it('should not be visible when document visibility is visible but unfocused', () => {
+    const isVisible = loadIsVisible({
+      visibilityState: 'visible',
+      hasFocus: () => false
+    })
+
+    expect(isVisible()).toBe(false)
+  })
+
+  it('should be visible when focus detection is unavailable', () => {
+    const isVisible = loadIsVisible({
+      visibilityState: 'visible'
+    })
+
+    expect(isVisible()).toBe(true)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Fixes #3039.

SWR's default `isVisible()` check only looked at `document.visibilityState`. Some browsers keep `visibilityState === "visible"` when the user switches to another application/window, so interval revalidation can continue even when `refreshWhenHidden` is false.

This change treats a visible-but-unfocused document as inactive when `document.hasFocus()` is available, while preserving the existing fallback behavior for non-browser environments or documents without focus detection.

## Validation

- `pnpm install --frozen-lockfile --store-dir "D:\grand-final prr\.cache\pnpm-store-swr"`
- `pnpm test test/unit/web-preset.test.ts`
- `pnpm exec oxfmt --check src/_internal/utils/web-preset.ts test/unit/web-preset.test.ts`
- `pnpm exec oxlint src/_internal/utils/web-preset.ts test/unit/web-preset.test.ts`
- `pnpm run types:check`
- `git diff --check`

Local note: commands used command-scoped `COREPACK_HOME`, `PNPM_HOME`, `TEMP`, and `TMP` under `D:\grand-final prr\.cache` because this machine's C: drive is full.