### PR TITLE
fix(mutation): type optimisticData with the displayedData parameter

### DIFF
--- a/src/mutation/types.ts
+++ b/src/mutation/types.ts
@@ -29,7 +29,12 @@ export type SWRMutationConfiguration<
   populateCache?:
     | boolean
     | ((result: Data, currentData: SWRData | undefined) => SWRData)
-  optimisticData?: SWRData | ((currentData?: SWRData) => SWRData)
+  // `optimisticData` is forwarded to the core mutate, which invokes it as
+  // `optimisticData(committedData, displayedData)`. Both parameters stay
+  // optional so existing single-parameter callbacks keep type-checking.
+  optimisticData?:
+    | SWRData
+    | ((currentData?: SWRData, displayedData?: SWRData) => SWRData)
   rollbackOnError?: boolean | ((error: unknown) => boolean)
   fetcher?: MutationFetcher<Data, SWRMutationKey, ExtraArg>
   onSuccess?: (

--- a/test/type/mutation.ts
+++ b/test/type/mutation.ts
@@ -5,3 +5,32 @@ export function useConfigMutation() {
   const { trigger } = useSWRMutation('key', k => k)
   expectType<TriggerWithoutArgs<'key', any, string, never>>(trigger)
 }
+
+export function useOptimisticDataMutation() {
+  // `optimisticData` is forwarded to the core mutate, which calls it with both
+  // the committed data and the data currently displayed. Both parameters must
+  // be visible to callers here, and both are typed as the SWR data.
+  useSWRMutation('key', (k: string) => k, {
+    optimisticData: (currentData, displayedData) => {
+      expectType<string | undefined>(currentData)
+      expectType<string | undefined>(displayedData)
+      return 'optimistic'
+    }
+  })
+
+  // Callbacks that ignore the extra parameters must keep type-checking.
+  useSWRMutation('key', (k: string) => k, {
+    optimisticData: currentData => {
+      expectType<string | undefined>(currentData)
+      return 'optimistic'
+    }
+  })
+  useSWRMutation('key', (k: string) => k, {
+    optimisticData: () => 'optimistic'
+  })
+
+  // The non-function form stays supported.
+  useSWRMutation('key', (k: string) => k, {
+    optimisticData: 'optimistic'
+  })
+}


### PR DESCRIPTION
## Summary

`SWRMutationConfiguration.optimisticData` types its callback as `(currentData?: SWRData) => SWRData`, but the option is forwarded to the core `mutate`, which calls it with **two** arguments:

https://github.com/vercel/swr/blob/main/src/_internal/utils/mutate.ts#L144-L146

```ts
optimisticData = isFunction(optimisticData)
  ? optimisticData(committedData, displayedData)
  : optimisticData
```

`useSWRMutation` passes its options straight into that call (`src/mutation/index.ts`, `mergeObjects(options, { throwOnError: true })`), so `displayedData` is genuinely available at runtime but invisible to TypeScript. Callers currently have to cast to reach it, which is what #4161 reports.

`MutatorOptions.optimisticData` in `src/_internal/types.ts` already documents both parameters:

```ts
optimisticData?:
  | Data
  | ((currentData: Data | undefined, displayedData: Data | undefined) => Data)
```

## Change

Align the mutation-side signature with the core one. Both parameters stay optional, so this is backward compatible: callbacks taking one parameter or none still type-check, and the non-function form is unchanged.

## Test

Extends `test/type/mutation.ts` to assert the two-parameter form type-checks with both parameters inferred as `string | undefined`, and that the one-parameter, zero-parameter, and non-function forms still compile. Before the fix that file fails to compile:

```
test/type/mutation.ts(14,21): error TS2769: No overload matches this call.
test/type/mutation.ts(14,22): error TS7006: Parameter 'currentData' implicitly has an 'any' type.
test/type/mutation.ts(14,35): error TS7006: Parameter 'displayedData' implicitly has an 'any' type.
```

## Verification

Ran the same commands as `.github/workflows/test.yml`:

- `pnpm build` — ok
- `pnpm run-all-checks` (`types:check` + `lint` + `test-typing`) — ok
- `pnpm test` — 35 suites, 388 passed, 5 skipped
- `pnpm test:build` — 35 suites, 388 passed, 5 skipped
- `pnpm format:check` — all 194 files correctly formatted

Fixes #4161
