### PR TITLE
fix: cache suspense revalidation promise to avoid uncached promise warning

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -390,6 +390,23 @@ export const useSWRHandler = <Data = any, Error = any>(
     cacheData?: CacheData
   } | null>(null)
 
+  // Cache the pending revalidation promise for Suspense. React's `use()` throws
+    // the thenable back to the nearest boundary; it expects the same object at the
+    // same hook index across concurrent re-renders. Re-calling `revalidate()`
+    // returns a new promise each time, triggering an "uncached promise" warning.
+    // Keyed so a key change in the same hook instance starts a fresh fetch. (#4314)
+    const revalidationPromiseRef = useRef<{
+      key: string
+      promise: ReturnType<typeof revalidate>
+    } | null>(null)
+    const getRevalidationPromise = () => {
+      const cached = revalidationPromiseRef.current
+      if (cached && cached.key === key) return cached.promise
+      const promise = revalidate(WITH_DEDUPE)
+      revalidationPromiseRef.current = { key, promise }
+      return promise
+    }
+
   let returnedData = keepPreviousData
     ? isUndefined(cachedData)
       ? // checking undefined to avoid null being fallback as well
@@ -969,13 +986,16 @@ export const useSWRHandler = <Data = any, Error = any>(
     }
     const revalidation =
       hasKeyButNoData && isUndefined(preloadData)
-        ? revalidate(WITH_DEDUPE)
+        ? getRevalidationPromise()
         : resolvedUndef
     if (!isUndefined(returnedData) && hasKeyButNoData) {
       // @ts-ignore modify react promise status
       revalidation.status = 'fulfilled'
       // @ts-ignore modify react promise value
       revalidation.value = true
+      // The cached promise has been consumed; clear it so a future suspense
+      // re-fetch starts a fresh one. (#4314)
+      revalidationPromiseRef.current = null
     }
     use(revalidation)
   }

--- a/test/use-swr-suspense.test.tsx
+++ b/test/use-swr-suspense.test.tsx
@@ -476,4 +476,48 @@ describe('useSWR - suspense', () => {
       expect(onRender).toHaveBeenCalledTimes(1)
     }
   )
+
+  itShouldSkipForReactCanary(
+    'should not pass an uncached promise to use() with sibling suspense components',
+    async () => {
+      // Regression test for #4314: two sibling useSWR hooks under one Suspense
+      // boundary. The pending revalidation promise passed to use() must be
+      // stable across concurrent re-renders, or React logs an "uncached
+      // promise" warning.
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {})
+      const keyA = createKey()
+      const keyB = createKey()
+
+      function A() {
+        const { data } = useSWR(keyA, () => createResponse('A'), {
+          suspense: true
+        })
+        return <div>{data}</div>
+      }
+      function B() {
+        const { data } = useSWR(keyB, () => createResponse('B'), {
+          suspense: true
+        })
+        return <div>{data}</div>
+      }
+
+      renderWithConfig(
+        <Suspense fallback={<div>fallback</div>}>
+          <A />
+          <B />
+        </Suspense>
+      )
+
+      screen.getByText('fallback')
+      await screen.findByText('A')
+      await screen.findByText('B')
+
+      expect(
+        spy.mock.calls.filter(([message]) =>
+          String(message).includes('uncached promise')
+        )
+      ).toHaveLength(0)
+      spy.mockRestore()
+    }
+  )
 })


### PR DESCRIPTION
## Summary

In Suspense mode, the pending-data branch called `revalidate(WITH_DEDUPE)` on **every render**. `revalidate` is async, so each call returned a brand-new promise — `use()` then received a different thenable at the same hook index during the concurrent-render replay, triggering React's "uncached promise" warning (most visible with sibling Suspense components under one boundary, as reported in #4314).

## Changes

- Added `revalidationPromiseRef` — a keyed cache `{ key, promise }`.
- Added `getRevalidationPromise()` helper that reuses the cached promise when `key` matches, else starts a fresh one.
- Replaced the inline `revalidate(WITH_DEDUPE)` call in the Suspense render site with `getRevalidationPromise()`.
- Reset the ref once data arrives so a future re-fetch starts fresh.

## Test

- Added regression test: two sibling `useSWR(..., { suspense: true })` hooks under one `<Suspense>` — asserts no "uncached promise" console.error.
- `tsc --noEmit` clean; `jest test/use-swr-suspense.test.tsx` → 15 passed (14 + 1 new).

Closes #4314
