### PR TITLE
fix(types): allow null fetcher in SWRConfiguration to override global config

### DIFF
--- a/src/_internal/types.ts
+++ b/src/_internal/types.ts
@@ -293,7 +293,7 @@ export interface PublicConfiguration<
   /**
    * the fetcher function
    */
-  fetcher?: Fn
+  fetcher?: Fn | null
   /**
    * array of middleware functions
    * @see {@link https://swr.vercel.app/docs/middleware}

--- a/src/infinite/types.ts
+++ b/src/infinite/types.ts
@@ -39,7 +39,7 @@ export interface SWRInfiniteConfiguration<
   persistSize?: boolean
   revalidateFirstPage?: boolean
   parallel?: boolean
-  fetcher?: Fn
+  fetcher?: Fn | null
   compare?: SWRInfiniteCompareFn<Data>
 }
 


### PR DESCRIPTION
Fixes #2888

`{ fetcher: null }` correctly disables fetching at runtime (mergeConfigs spreads local config over context, and `withArgs` resolves `fn || config.fetcher || null` to null). Only the `SWRConfiguration` type rejected it, forcing a `@ts-ignore`.

Allow `fetcher?: Fn | null` in `SWRConfiguration` and `SWRInfiniteConfiguration`.