### PR TITLE
Fix: Preserve data reference when structurally identical during mutation

### DIFF
--- a/src/index/use-swr.ts
+++ b/src/index/use-swr.ts
@@ -331,7 +331,9 @@ export const useSWRHandler = <Data = any, Error = any>(
           // with direct mutations to ensure the snapshot is always up-to-date
           // even for the unselected fields, but only trigger re-renders when
           // the selected fields are changed.
-          memorizedSnapshot.data = newSnapshot.data
+          if (!stateDependencies.data) {
+            memorizedSnapshot.data = newSnapshot.data
+          }
           memorizedSnapshot.isLoading = newSnapshot.isLoading
           memorizedSnapshot.isValidating = newSnapshot.isValidating
           memorizedSnapshot.error = newSnapshot.error

--- a/test/test-issue-4180.test.tsx
+++ b/test/test-issue-4180.test.tsx
@@ -1,0 +1,65 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import React, { useEffect, useState } from 'react'
+import useSWRInfinite from '../src/infinite'
+import { sleep } from './utils'
+
+describe('useSWRInfinite mutation bug', () => {
+  it('should not change data reference if structurally identical', async () => {
+    let isUpdated = false
+    const fetcher = async () => {
+      await sleep(10)
+      return isUpdated ? [{ id: 1, updated: true }] : [{ id: 1 }]
+    }
+    const initialData = [[{ id: 1 }]]
+
+    function Page() {
+      const { data, mutate } = useSWRInfinite(
+        index => `key-${index}`,
+        fetcher,
+        { fallbackData: initialData }
+      )
+      const [dataChanges, setDataChanges] = useState(0)
+
+      const prevData = React.useRef(data)
+      if (prevData.current !== data) {
+        prevData.current = data
+      }
+      
+      useEffect(() => {
+        setDataChanges(c => c + 1)
+      }, [data])
+
+      return (
+        <div>
+          <div data-testid="changes">{dataChanges}</div>
+          <button
+            onClick={async () => {
+              isUpdated = true
+              await mutate(
+                async () => {
+                  await sleep(10)
+                  return [[{ id: 1, updated: true }]]
+                },
+                {
+                  optimisticData: [[{ id: 1, updated: true }]],
+                  revalidate: true
+                }
+              )
+            }}
+          >
+            Mutate
+          </button>
+        </div>
+      )
+    }
+
+    render(<Page />)
+    await screen.findByText('1') // initial data
+
+    fireEvent.click(screen.getByText('Mutate'))
+
+    await sleep(200)
+
+    expect(screen.getByTestId('changes').textContent).toBe('2')
+  })
+})


### PR DESCRIPTION
Problem:
When using \mutate\ with both \optimisticData\ and an async data function that return structurally identical data (but different array references), SWR populates the cache with the new reference. Even though \useSWR\ evaluates that the snapshots are deeply equal and initially returns the old \memorizedSnapshot\ object, it updates the snapshot's \data\ field to the new cache reference via \memorizedSnapshot.data = newSnapshot.data\. This breaks referential equality of the returned \data\, causing React child components (like \React.memo\ lists) to unnecessarily re-render the whole array, despite the content remaining exactly the same.

Solution:
In \src/index/use-swr.ts\, when \compareResult\ is evaluated as true (indicating structural equality), we conditionally preserve \memorizedSnapshot.data\ if it wasn't a tracked field that we should ignore. If they are structurally identical, we skip assigning the new data reference to \memorizedSnapshot.data\, thereby preserving referential equality. This ensures that mutations won't inadvertently break object references in the active hook instances.

Changes Made:
- \src/index/use-swr.ts\: Updated the snapshot assignment inside \if (compareResult)\ to only update \memorizedSnapshot.data\ if \stateDependencies.data\ is false.
- \	est/test-issue-4180.test.tsx\: Added a test specifically reproducing the \mutate\ sequence on \useSWRInfinite\ to assert that the \data\ array reference does not change when the asynchronously fetched payload is structurally identical to the optimistic payload.

Testing:
- Checked out the issue #4180 reproduction using \useSWRInfinite\ with an array payload in the new Jest test (\	est-issue-4180.test.tsx\).
- Verified that without the fix, the \data\ reference changed when the mutate promise resolved.
- Verified that with the fix, the \data\ array reference remains stable and the component only re-renders twice instead of three times for identical data.
- Ran all tests with \pnpm test\ to ensure no side effects on existing revalidation or subscription logic.

Fixes #4180