### PR TITLE
fix(immutable): respect a hook-level `refreshInterval`

### DIFF
--- a/src/immutable/index.ts
+++ b/src/immutable/index.ts
@@ -1,16 +1,48 @@
-import type { Middleware } from '../index'
+import type { Key, Fetcher, Middleware, SWRConfiguration } from '../index'
 import useSWR from '../index'
-import { withMiddleware } from '../_internal'
+import { normalize } from '../_internal'
+
+/**
+Marks a `refreshInterval` that was passed directly to the hook, as opposed to
+one inherited from a parent `<SWRConfig>`. The `immutable` middleware runs after
+both sources have been merged into a single config, so the distinction has to be
+recorded before that merge happens.
+*/
+const HOOK_LEVEL_REFRESH_INTERVAL = Symbol.for('swr.immutable.refreshInterval')
 
 export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
   // Always override all revalidate options.
   config.revalidateOnFocus = false
   config.revalidateIfStale = false
   config.revalidateOnReconnect = false
-  config.refreshInterval = 0
+
+  // Only clear a `refreshInterval` inherited from a parent `<SWRConfig>`. One
+  // passed directly to the hook is an explicit opt-in to polling, so it's kept.
+  if (!(HOOK_LEVEL_REFRESH_INTERVAL in config)) {
+    config.refreshInterval = 0
+  }
+
   return useSWRNext(key, fetcher, config)
 }
 
-const useSWRImmutable = withMiddleware(useSWR, immutable)
+const useSWRImmutable = <Data = any, Error = any>(
+  ...args:
+    | [Key]
+    | [Key, Fetcher<Data> | null]
+    | [Key, SWRConfiguration | undefined]
+    | [Key, Fetcher<Data> | null, SWRConfiguration | undefined]
+) => {
+  const [key, fn, config] = normalize<Key, Data>(args)
+  const uses = (config.use || []).concat(immutable)
+
+  // Record whether `refreshInterval` came from the hook itself, before the
+  // context config is merged in and the two become indistinguishable.
+  const nextConfig: Record<string | symbol, unknown> = { ...config, use: uses }
+  if (config.refreshInterval !== undefined) {
+    nextConfig[HOOK_LEVEL_REFRESH_INTERVAL] = true
+  }
+
+  return useSWR<Data, Error>(key, fn, nextConfig as SWRConfiguration)
+}
 
 export default useSWRImmutable

--- a/test/use-swr-immutable.test.tsx
+++ b/test/use-swr-immutable.test.tsx
@@ -329,3 +329,63 @@ describe('issue #4207', () => {
     expect(fetchCount).toBe(1)
   })
 })
+
+describe('issue #4322', () => {
+  it('should respect a hook-level refreshInterval', async () => {
+    let fetchCount = 0
+    const fetcher = () => {
+      fetchCount++
+      return 'data'
+    }
+
+    function Page() {
+      const { data } = useSWRImmutable('key', fetcher, {
+        refreshInterval: 100,
+        dedupingInterval: 0
+      })
+      return <div>{data}</div>
+    }
+
+    renderWithConfig(<Page />, { provider: () => new Map() })
+
+    await screen.findByText('data')
+    expect(fetchCount).toBe(1)
+
+    await new Promise(resolve => setTimeout(resolve, 350))
+    expect(fetchCount).toBeGreaterThan(1)
+  })
+
+  it('should let a hook-level refreshInterval override a global one', async () => {
+    let fetchCount = 0
+    const fetcher = () => {
+      fetchCount++
+      return 'data'
+    }
+
+    function Page() {
+      const { data } = useSWRImmutable('key', fetcher, {
+        refreshInterval: 100,
+        dedupingInterval: 0
+      })
+      return <div>{data}</div>
+    }
+
+    renderWithConfig(
+      <SWRConfig
+        value={{
+          refreshInterval: 5000,
+          dedupingInterval: 0,
+          provider: () => new Map()
+        }}
+      >
+        <Page />
+      </SWRConfig>
+    )
+
+    await screen.findByText('data')
+    expect(fetchCount).toBe(1)
+
+    await new Promise(resolve => setTimeout(resolve, 350))
+    expect(fetchCount).toBeGreaterThan(1)
+  })
+})


### PR DESCRIPTION
Fixes #4322

## Problem

#4208 added `config.refreshInterval = 0` to the `immutable` middleware so `useSWRImmutable` would ignore a `refreshInterval` inherited from a parent `<SWRConfig>`.

Middleware runs *after* hook options and the context config have been merged into a single object, so at that point the two sources are indistinguishable — the line disables both. A `refreshInterval` passed directly to the hook has silently stopped working since 2.4.0:

```tsx
// 2.3.x: polls every second. >= 2.4.0: fetches once, interval discarded.
useSWRImmutable('/api/status', fetcher, { refreshInterval: 1000 })
```

## Fix

Record whether `refreshInterval` came from the hook itself *before* the merge happens, using a symbol on the config object, and only clear the value in the middleware when that marker is absent.

`useSWRImmutable` previously used the generic `withMiddleware` helper; it now inlines the same normalize-and-append-middleware logic so it can set the marker. `withMiddleware` itself is untouched, so other middleware users are unaffected. The symbol survives SWR's config merging (`mergeObjects` is object spread, which copies symbol keys).

Behavior after this change:
- `refreshInterval` from a parent `<SWRConfig>` → still ignored (#4208's case, its test still passes).
- `refreshInterval` passed to the hook → honored, and it overrides a global one.

## Tests

Added two regression tests under `describe('issue #4322')`: a hook-level `refreshInterval` polls, and a hook-level value overrides a global one. Both fail on the current code (`git stash` on the source file → exactly these 2 fail) and pass with the fix.

## Verification

- `pnpm jest test/use-swr-immutable.test.tsx` — 9/9 pass (7 existing + 2 new).
- `pnpm types:check` and `pnpm test-typing` pass.
- `pnpm oxlint` and `pnpm oxfmt --check` clean on the changed files.
- Full `pnpm jest`: 389 pass, 1 failure in `test/use-swr-remote-mutation.test.tsx` ("should prevent race condition if triggered multiple times"). That failure reproduces identically on unmodified `main` in this environment (verified via `git stash`) — a pre-existing timing flake, unrelated to this change.