### PR TITLE
fix: respect hook-level refreshInterval in useSWRImmutable

### DIFF
--- a/src/_internal/utils/with-middleware.ts
+++ b/src/_internal/utils/with-middleware.ts
@@ -11,7 +11,8 @@ import type {
 // Create a custom hook with a middleware
 export const withMiddleware = (
   useSWR: SWRHook,
-  middleware: Middleware
+  middleware: Middleware,
+  defaultConfig?: SWRConfiguration
 ): SWRHook => {
   return <Data = any, Error = any>(
     ...args:
@@ -22,6 +23,10 @@ export const withMiddleware = (
   ) => {
     const [key, fn, config] = normalize(args)
     const uses = (config.use || []).concat(middleware)
-    return useSWR<Data, Error>(key, fn, { ...config, use: uses })
+    return useSWR<Data, Error>(key, fn, {
+      ...defaultConfig,
+      ...config,
+      use: uses
+    })
   }
 }

--- a/src/immutable/index.ts
+++ b/src/immutable/index.ts
@@ -7,10 +7,11 @@ export const immutable: Middleware = useSWRNext => (key, fetcher, config) => {
   config.revalidateOnFocus = false
   config.revalidateIfStale = false
   config.revalidateOnReconnect = false
-  config.refreshInterval = 0
   return useSWRNext(key, fetcher, config)
 }
 
-const useSWRImmutable = withMiddleware(useSWR, immutable)
+const useSWRImmutable = withMiddleware(useSWR, immutable, {
+  refreshInterval: 0
+})
 
 export default useSWRImmutable

--- a/test/use-swr-immutable.test.tsx
+++ b/test/use-swr-immutable.test.tsx
@@ -295,6 +295,29 @@ describe('useSWR - immutable', () => {
     await screen.findByText(`data: 1, isLoading: false, isValidating: false`)
     expect(onRender).toHaveBeenCalledTimes(4)
   })
+
+  it('should let a hook-level refreshInterval override a global one', async () => {
+    const key = createKey()
+    let fetchCount = 0
+    const fetcher = () => `data-${++fetchCount}`
+
+    function Page() {
+      const { data } = useSWRImmutable(key, fetcher, {
+        refreshInterval: 50,
+        dedupingInterval: 0
+      })
+      return <div>{data}</div>
+    }
+
+    renderWithConfig(<Page />, {
+      refreshInterval: 5000,
+      dedupingInterval: 0
+    })
+
+    await screen.findByText('data-1')
+    await act(() => sleep(180))
+    expect(fetchCount).toBeGreaterThan(1)
+  })
 })
 
 describe('issue #4207', () => {


### PR DESCRIPTION
Fixes #4322.

### Description

`useSWRImmutable` has ignored a `refreshInterval` passed directly to the hook since 2.4.0.

#4208 fixed a real bug — a global `refreshInterval` from a parent `<SWRConfig>` leaking into an immutable hook — by adding `config.refreshInterval = 0` to the `immutable` middleware. But middleware runs *after* `withArgs` has called `mergeConfigs(fallbackConfig, hookConfig)`, and by that point the context config and the hook options are a single flattened object. The middleware has no way to tell where `refreshInterval` came from, so it clears both.

The result is that polling silently stops on upgrade, with no error or warning:

```tsx
// 2.3.6: polls every second. 2.4.0+: fetches once.
useSWRImmutable('/api/status', fetcher, { refreshInterval: 1000 })
```

### The change

Rather than trying to recover the provenance of `refreshInterval` after the merge, this applies `refreshInterval: 0` as a *default* before it — at the hook-options layer, where the existing precedence rules already do the right thing.

`withMiddleware` takes an optional `defaultConfig`, spread beneath the user's own hook options:

```ts
return useSWR<Data, Error>(key, fn, {
  ...defaultConfig,
  ...config,
  use: uses
})
```

and `useSWRImmutable` passes `{ refreshInterval: 0 }` through it.

Because `mergeConfigs(fallbackConfig, hookConfig)` already gives hook options precedence over the context config, the default still beats a global `refreshInterval` — so #4207 stays fixed — while an explicit hook-level value now wins over the default, which is the behavior #4322 asks for.

### Additional Notes

This removes `config.refreshInterval = 0` from the exported `immutable` middleware itself, so any usages of `use: [immutable]` no longer forces the interval to 0. That keeps a single source of truth for the default instead of enforcing it in two places, but it is a behavior change for anyone applying the middleware directly. Happy to keep the middleware's override and scope the change to `useSWRImmutable` if you'd rather not touch that.
